### PR TITLE
run.go fixes associated with signed numbers

### DIFF
--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -127,7 +127,6 @@ func runFrame(fs *list.List) error {
     for f.PC < len(f.Meth) {
         if MainThread.Trace {
             wstr2 := ""
-            // Not working yet!
             for j := -1; j < f.TOS; j++ {
                 wstr2 += fmt.Sprintf(" %v(%T)", f.OpStack[f.TOS], f.OpStack[f.TOS])
             }

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -128,10 +128,9 @@ func runFrame(fs *list.List) error {
         if MainThread.Trace {
             wstr2 := ""
             // Not working yet!
-            //for j := -1; j < f.TOS; j++ {
-            //	wuint64 := *((*uint64)(unsafe.Pointer(&f.OpStack[f.TOS])))
-            //    wstr2 += fmt.Sprintf(" %08x", wuint64)
-            //}
+            for j := -1; j < f.TOS; j++ {
+                wstr2 += fmt.Sprintf(" %v(%T)", f.OpStack[f.TOS], f.OpStack[f.TOS])
+            }
             wstr := "class: "+f.ClName+
                 ", meth: "+f.MethName+
                 ", pc: "+strconv.Itoa(f.PC)+

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -211,7 +211,8 @@ func runFrame(fs *list.List) error {
 				wint64 = int64(binary.BigEndian.Uint64(wbytes))
 				// debugging: fmt.Printf("SIPUSH DEBUG 1 wbyte1=%x, wbyte2=%x, wint64=%x\n", wbyte1, wbyte2, wint64)
 			} else {
-				// Not negative (left-most bit off) : just cast wbyte as an int64
+				// Not negative (left-most bit off) : just cast wbyte1 and wbyte2 as an int64
+				// and use the following linear formula for deriving the int64 value to push on the stack
 				wint64 = (int64(wbyte1) * 256) + int64(wbyte2)
 				// debugging: fmt.Printf("SIPUSH DEBUG 2 wbyte1=%x, wbyte2=%x, wint64=%x\n", wbyte1, wbyte2, wint64)
 			}


### PR DESCRIPTION
Newly passing test cases: 
* JACOBIN-0212-bit-shifting
* JACOBIN-0236-bitwise
* JACOBIN-0236-minus-signs.

Fixed BIPUSH and SIPUSH switch cases of ```func runFrame``` in ```jvm/run.go```.