### PR TITLE
Amended tracing to be after push/pop effects

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -19,4 +19,3 @@ All code files for Jacobin begin with the following header:
  Many people have contributed useful comments and suggestions, for
  which we are most grateful indeed!
 
-

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -1747,12 +1747,12 @@ func runFrame(fs *list.List) error {
 
 // pop from the operand stack. TODO: need to put in checks for invalid pops
 func pop(f *frames.Frame) interface{} {
+	value := f.OpStack[f.TOS]
+	f.TOS -= 1
 	if MainThread.Trace {
 		traceInfo := fmt.Sprintf("\tpop f.TOS=%d", f.TOS)
 		_ = log.Log(traceInfo, log.TRACE_INST)
 	}
-	value := f.OpStack[f.TOS]
-	f.TOS -= 1
 	return value
 }
 
@@ -1767,12 +1767,12 @@ func peek(f *frames.Frame) interface{} {
 
 // push onto the operand stack
 func push(f *frames.Frame, x interface{}) {
+	f.TOS += 1
+	f.OpStack[f.TOS] = x
 	if MainThread.Trace {
 		traceInfo := fmt.Sprintf("\tpush f.TOS=%d", f.TOS)
 		_ = log.Log(traceInfo, log.TRACE_INST)
 	}
-	f.TOS += 1
-	f.OpStack[f.TOS] = x
 }
 
 func add[N frames.Number](num1, num2 N) N {


### PR DESCRIPTION
Push and pop have been amended per the JACOBIN-247 discussion. As it turns out, peek was fine the way it was.

Sample trace from test case JACOBIN-0212-bit-shifting:
[trace.txt](https://github.com/platypusguy/jacobin/files/11442052/trace.txt)
