### PR TITLE
Classloader cleanup +getting ready for the Big Bang

### DIFF
--- a/src/classloader/classloader.go
+++ b/src/classloader/classloader.go
@@ -184,9 +184,8 @@ func CFE(msg string) error { return cfe(msg) }
 
 // LoadBaseClasses loads a basic set of classes that are found in
 // the JAVA_HOME/jmods/java.base.jmod zip file.
-// In Java 1.7, there are currently a total of 6401 embedded classes, of which,
-// 1402 are actually bootstrap-loaded.
-// File JAVA_HOME/lib/classlist has the bootstrap selection list.
+// In Java 17.0.7, there are currently a total of 6401 embedded classes in java.base.jmod.
+// Based on the lib/classlist member in java.base.jmod, only 1402 class files are actually loaded by this function.
 func LoadBaseClasses(global *globals.Globals) {
 	if len(global.JavaHome) > 0 {
 		fname := global.JavaHome + string(os.PathSeparator) + "jmods" + string(os.PathSeparator) + "java.base.jmod"

--- a/src/classloader/classloader.go
+++ b/src/classloader/classloader.go
@@ -7,21 +7,21 @@
 package classloader
 
 import (
-    "bytes"
-    "encoding/gob"
-    "errors"
-    "fmt"
-    "io/fs"
-    "jacobin/globals"
-    "jacobin/log"
-    "jacobin/util"
+	"bytes"
+	"encoding/gob"
+	"errors"
+	"fmt"
+	"io/fs"
+	"jacobin/globals"
+	"jacobin/log"
 	"jacobin/shutdown"
-    "os"
-    "path/filepath"
-    "runtime"
-    "strconv"
-    "strings"
-    "sync"
+	"jacobin/util"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
 )
 
 // Classloader holds the parsed bytecode in classes, where they can be retrieved
@@ -29,10 +29,10 @@ import (
 // familiarity with the role of classloaders. More information can be found at:
 // https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-5.html#jvms-5.3
 type Classloader struct {
-    Name       string
-    Parent     string
-    ClassCount int
-    Archives   map[string]*Archive // TODO: I think this should be moved to classpath when we make it a thing
+	Name       string
+	Parent     string
+	ClassCount int
+	Archives   map[string]*Archive // TODO: I think this should be moved to classpath when we make it a thing
 }
 
 // AppCL is the application classloader, which loads most of the app's classes
@@ -46,114 +46,114 @@ var ExtensionCL Classloader
 
 // ParsedClass contains all the parsed fields
 type ParsedClass struct {
-    javaVersion    int
-    className      string // name of class without path and without .class
-    superClass     string // name of superclass for this class
-    moduleName     string
-    packageName    string
-    interfaceCount int   // number of interfaces this class implements
-    interfaces     []int // the interfaces this class implements, as indices into utf8Refs
-    fieldCount     int   // number of fields in this class
-    fields         []field
-    methodCount    int
-    methods        []method
-    attribCount    int
-    attributes     []attr
-    sourceFile     string
-    bootstrapCount int // the number of bootstrap methods
-    bootstraps     []bootstrapMethod
+	javaVersion    int
+	className      string // name of class without path and without .class
+	superClass     string // name of superclass for this class
+	moduleName     string
+	packageName    string
+	interfaceCount int   // number of interfaces this class implements
+	interfaces     []int // the interfaces this class implements, as indices into utf8Refs
+	fieldCount     int   // number of fields in this class
+	fields         []field
+	methodCount    int
+	methods        []method
+	attribCount    int
+	attributes     []attr
+	sourceFile     string
+	bootstrapCount int // the number of bootstrap methods
+	bootstraps     []bootstrapMethod
 
-    deprecated bool
+	deprecated bool
 
-    // ---- constant pool data items ----
-    cpCount        int       // count of constant pool entries
-    cpIndex        []cpEntry // the constant pool index to entries
-    classRefs      []int     // points to a UTF-8 entry in the CP
-    doubles        []float64
-    dynamics       []dynamic
-    fieldRefs      []fieldRefEntry
-    floats         []float32
-    intConsts      []int // 32-bit int containing the actual int value
-    interfaceRefs  []interfaceRefEntry
-    invokeDynamics []invokeDynamic
-    longConsts     []int64
-    methodHandles  []methodHandleEntry
-    methodRefs     []methodRefEntry
-    methodTypes    []int
-    nameAndTypes   []nameAndTypeEntry
-    stringRefs     []stringConstantEntry // integer index into utf8Refs
-    utf8Refs       []utf8Entry
+	// ---- constant pool data items ----
+	cpCount        int       // count of constant pool entries
+	cpIndex        []cpEntry // the constant pool index to entries
+	classRefs      []int     // points to a UTF-8 entry in the CP
+	doubles        []float64
+	dynamics       []dynamic
+	fieldRefs      []fieldRefEntry
+	floats         []float32
+	intConsts      []int // 32-bit int containing the actual int value
+	interfaceRefs  []interfaceRefEntry
+	invokeDynamics []invokeDynamic
+	longConsts     []int64
+	methodHandles  []methodHandleEntry
+	methodRefs     []methodRefEntry
+	methodTypes    []int
+	nameAndTypes   []nameAndTypeEntry
+	stringRefs     []stringConstantEntry // integer index into utf8Refs
+	utf8Refs       []utf8Entry
 
-    // ---- access flags items ----
-    accessFlags       int // the following booleans interpret the access flags
-    classIsPublic     bool
-    classIsFinal      bool
-    classIsSuper      bool
-    classIsInterface  bool
-    classIsAbstract   bool
-    classIsSynthetic  bool
-    classIsAnnotation bool
-    classIsEnum       bool
-    classIsModule     bool
+	// ---- access flags items ----
+	accessFlags       int // the following booleans interpret the access flags
+	classIsPublic     bool
+	classIsFinal      bool
+	classIsSuper      bool
+	classIsInterface  bool
+	classIsAbstract   bool
+	classIsSynthetic  bool
+	classIsAnnotation bool
+	classIsEnum       bool
+	classIsModule     bool
 
-    // ---- field attributes ----
+	// ---- field attributes ----
 }
 
 // the fields defined in the class
 type field struct {
-    accessFlags int
-    isStatic    bool
-    name        int         // index of the UTF-8 entry in the CP
-    description int         // index of the UTF-8 entry in the CP
-    constValue  interface{} // the constant value if any was defined
-    attributes  []attr
+	accessFlags int
+	isStatic    bool
+	name        int         // index of the UTF-8 entry in the CP
+	description int         // index of the UTF-8 entry in the CP
+	constValue  interface{} // the constant value if any was defined
+	attributes  []attr
 }
 
 // the methods of the class, including the constructors
 type method struct {
-    accessFlags int
-    name        int // index of the UTF-8 entry in the CP
-    description int // index of the UTF-8 entry in the CP
-    codeAttr    codeAttrib
-    attributes  []attr
-    exceptions  []int // indexes into Utf8Refs in the CP
-    parameters  []paramAttrib
-    deprecated  bool // is the method deprecated?
+	accessFlags int
+	name        int // index of the UTF-8 entry in the CP
+	description int // index of the UTF-8 entry in the CP
+	codeAttr    codeAttrib
+	attributes  []attr
+	exceptions  []int // indexes into Utf8Refs in the CP
+	parameters  []paramAttrib
+	deprecated  bool // is the method deprecated?
 }
 
 type codeAttrib struct {
-    maxStack   int
-    maxLocals  int
-    code       []byte
-    exceptions []exception // exception entries for this method
-    attributes []attr      // the code attributes has its own sub-attributes(!)
+	maxStack   int
+	maxLocals  int
+	code       []byte
+	exceptions []exception // exception entries for this method
+	attributes []attr      // the code attributes has its own sub-attributes(!)
 }
 
 // the MethodParameters method attribute
 type paramAttrib struct {
-    name        string // string, rather than index into utf8Refs b/c the name could be ""
-    accessFlags int
+	name        string // string, rather than index into utf8Refs b/c the name could be ""
+	accessFlags int
 }
 
 // the structure of many attributes (field, class, etc.) The content is just the raw bytes.
 type attr struct {
-    attrName    int    // index of the UTF-8 entry in the CP
-    attrSize    int    // length of the following array of raw bytes
-    attrContent []byte // the raw data of the attribute
+	attrName    int    // index of the UTF-8 entry in the CP
+	attrSize    int    // length of the following array of raw bytes
+	attrContent []byte // the raw data of the attribute
 }
 
 // the exception-related data for each exception in the Code attribute of a given method
 type exception struct {
-    startPc   int // first instruction covered by this exception (pc = program counter)
-    endPc     int // the last instruction covered by this exception
-    handlerPc int // the place in the method code that has the exception instructions
-    catchType int // the type of exception, index to CP, which must point a ClassFref entry
+	startPc   int // first instruction covered by this exception (pc = program counter)
+	endPc     int // the last instruction covered by this exception
+	handlerPc int // the place in the method code that has the exception instructions
+	catchType int // the type of exception, index to CP, which must point a ClassFref entry
 }
 
 // the boostrap methods, specified in the bootstrap class attribute
 type bootstrapMethod struct {
-    methodRef int   // index pointing to a MethodHandle
-    args      []int // arguments: indexes to loadable arguments from the CP
+	methodRef int   // index pointing to a MethodHandle
+	args      []int // arguments: indexes to loadable arguments from the CP
 }
 
 var ClassesLock = sync.RWMutex{}
@@ -162,22 +162,22 @@ var ClassesLock = sync.RWMutex{}
 // of the errors arising from malformed bytecode. Prints out file and line# where
 // the call to cfe() occurred.
 func cfe(msg string) error {
-    errMsg := "Class Format Error: " + msg
+	errMsg := "Class Format Error: " + msg
 
-    // get the filename and line# of the function where the error occurred
-    // implementation note: Caller(0) would be this function. (1) is the
-    // previous function on the stack (so, the one calling this error routine)
-    // To traverse all the way back to the start of the program, set up a loop
-    // and exit when ok is no longer true.
-    pc, _, _, ok := runtime.Caller(1)
-    if ok {
-        fn := runtime.FuncForPC(pc)
-        fileName, fileLine := fn.FileLine(pc)
-        errMsg = errMsg + "\n  detected by file: " + filepath.Base(fileName) +
-            ", line: " + strconv.Itoa(fileLine)
-    }
-    _ = log.Log(errMsg, log.SEVERE)
-    return errors.New(errMsg)
+	// get the filename and line# of the function where the error occurred
+	// implementation note: Caller(0) would be this function. (1) is the
+	// previous function on the stack (so, the one calling this error routine)
+	// To traverse all the way back to the start of the program, set up a loop
+	// and exit when ok is no longer true.
+	pc, _, _, ok := runtime.Caller(1)
+	if ok {
+		fn := runtime.FuncForPC(pc)
+		fileName, fileLine := fn.FileLine(pc)
+		errMsg = errMsg + "\n  detected by file: " + filepath.Base(fileName) +
+			", line: " + strconv.Itoa(fileLine)
+	}
+	_ = log.Log(errMsg, log.SEVERE)
+	return errors.New(errMsg)
 }
 
 func CFE(msg string) error { return cfe(msg) }
@@ -188,42 +188,42 @@ func CFE(msg string) error { return cfe(msg) }
 // 1402 are actually bootstrap-loaded.
 // File JAVA_HOME/lib/classlist has the bootstrap selection list.
 func LoadBaseClasses(global *globals.Globals) {
-    if len(global.JavaHome) > 0 {
-        fname := global.JavaHome + string(os.PathSeparator) + "jmods" + string(os.PathSeparator) + "java.base.jmod"
+	if len(global.JavaHome) > 0 {
+		fname := global.JavaHome + string(os.PathSeparator) + "jmods" + string(os.PathSeparator) + "java.base.jmod"
 
-        jmodFile, err := os.Open(fname)
-        if err != nil {
-            _ = log.Log("Couldn't load JMOD file from "+fname, log.WARNING)
+		jmodFile, err := os.Open(fname)
+		if err != nil {
+			_ = log.Log("Couldn't load JMOD file from "+fname, log.WARNING)
 			_ = log.Log(err.Error(), log.SEVERE)
 			shutdown.Exit(shutdown.APP_EXCEPTION)
-        } else {
-            defer jmodFile.Close()
-            jmod := Jmod{File: *jmodFile}
-            err = jmod.Walk(func(bytes []byte, filename string) error {
-                _, err := loadClassFromBytes(BootstrapCL, filename, bytes)
-                return err
-            })
+		} else {
+			defer jmodFile.Close()
+			jmod := Jmod{File: *jmodFile}
+			err = jmod.Walk(func(bytes []byte, filename string) error {
+				_, err := loadClassFromBytes(BootstrapCL, filename, bytes)
+				return err
+			})
 
-            if err != nil {
-                _ = log.Log("Error loading jmod file "+fname, log.SEVERE)
-                _ = log.Log(err.Error(), log.SEVERE)
+			if err != nil {
+				_ = log.Log("Error loading jmod file "+fname, log.SEVERE)
+				_ = log.Log(err.Error(), log.SEVERE)
 				shutdown.Exit(shutdown.APP_EXCEPTION)
-            }
-        }
-    }
+			}
+		}
+	}
 
 }
 
 // walk the directory and load every file (which is known to be a class)
 func walk(s string, d fs.DirEntry, err error) error {
-    if err != nil {
-        return err
-    }
-    if !d.IsDir() && strings.HasSuffix(s, ".class") {
-        // Error is discarded b/c it's not clear yet a given class is needed.
-        _, _ = LoadClassFromFile(BootstrapCL, s)
-    }
-    return nil
+	if err != nil {
+		return err
+	}
+	if !d.IsDir() && strings.HasSuffix(s, ".class") {
+		// Error is discarded b/c it's not clear yet a given class is needed.
+		_, _ = LoadClassFromFile(BootstrapCL, s)
+	}
+	return nil
 }
 
 // LoadReferencedClasses loads the classes referenced in the class named clName.
@@ -235,179 +235,179 @@ func walk(s string, d fs.DirEntry, err error) error {
 // Note that The class being loaded has records in the CP that indicate all the other classes it interacts with.
 // Thus, classes are preloaded prior to need.
 func LoadReferencedClasses(clName string) {
-    currClass := MethAreaFetch(clName)
-    if currClass == nil {
-        return
-    }
-    cpClassCP := currClass.Data.CP
-    classRefs := cpClassCP.ClassRefs
+	currClass := MethAreaFetch(clName)
+	if currClass == nil {
+		return
+	}
+	cpClassCP := currClass.Data.CP
+	classRefs := cpClassCP.ClassRefs
 
-    loaderChannel := make(chan string, len(classRefs))
-    for _, v := range classRefs {
-        refClassName := FetchUTF8stringFromCPEntryNumber(&cpClassCP, v)
-        name := normalizeClassReference(refClassName)
-        if name == "" {
-            continue
-        }
-        loaderChannel <- name
-    }
-    globals.LoaderWg.Add(1)
-    go LoadFromLoaderChannel(loaderChannel)
-    close(loaderChannel)
+	loaderChannel := make(chan string, len(classRefs))
+	for _, v := range classRefs {
+		refClassName := FetchUTF8stringFromCPEntryNumber(&cpClassCP, v)
+		name := normalizeClassReference(refClassName)
+		if name == "" {
+			continue
+		}
+		loaderChannel <- name
+	}
+	globals.LoaderWg.Add(1)
+	go LoadFromLoaderChannel(loaderChannel)
+	close(loaderChannel)
 }
 
 // LoadFromLoaderChannel receives a name of a class to load in /java/lang/String format,
 // determines the classloader, checks if the class is already loaded, and loads it if not.
 func LoadFromLoaderChannel(LoaderChannel <-chan string) {
-    for name := range LoaderChannel {
-        present := MethAreaFetch(name)
-        if present != nil { // if the class is already loaded, skip rest of this loop
-            continue
-        }
+	for name := range LoaderChannel {
+		present := MethAreaFetch(name)
+		if present != nil { // if the class is already loaded, skip rest of this loop
+			continue
+		}
 
-        // add entry to the method area, indicating initialization of the load of this class
-        eKI := Klass{
-            Status: 'I', // I = initializing the load
-            Loader: "",
-            Data:   nil,
-        }
-        MethAreaInsert(name, &eKI)
-        _ = LoadClassFromNameOnly(util.ConvertToPlatformPathSeparators(name))
-    }
-    globals.LoaderWg.Done()
+		// add entry to the method area, indicating initialization of the load of this class
+		eKI := Klass{
+			Status: 'I', // I = initializing the load
+			Loader: "",
+			Data:   nil,
+		}
+		MethAreaInsert(name, &eKI)
+		_ = LoadClassFromNameOnly(util.ConvertToPlatformPathSeparators(name))
+	}
+	globals.LoaderWg.Done()
 }
 
 func LoadClassFromNameOnly(name string) error {
-    var err error
-    k := MethAreaFetch(name)
-    if k != nil && k.Data != nil { // if the class is already loaded, skip rest of this
-        return nil
-    }
+	var err error
+	k := MethAreaFetch(name)
+	if k != nil && k.Data != nil { // if the class is already loaded, skip rest of this
+		return nil
+	}
 
-    // add entry to the method area, indicating initialization of the load of this class
-    eKI := Klass{
-        Status: 'I', // I = initializing the load
-        Loader: "",
-        Data:   nil,
-    }
-    MethAreaInsert(name, &eKI)
+	// add entry to the method area, indicating initialization of the load of this class
+	eKI := Klass{
+		Status: 'I', // I = initializing the load
+		Loader: "",
+		Data:   nil,
+	}
+	MethAreaInsert(name, &eKI)
 
-    validName := util.ConvertToPlatformPathSeparators(name)
-    if strings.HasPrefix(name, "java/") || strings.HasPrefix(name, "jdk/") ||
-        strings.HasPrefix(name, "javax/") || strings.HasPrefix(name, "sun/") {
-        name = util.ConvertInternalClassNameToFilename(name)
-        name = globals.JacobinHome() + "classes" + string(os.PathSeparator) + name
-        validName = util.ConvertToPlatformPathSeparators(name)
-        _, err = LoadClassFromFile(BootstrapCL, validName)
-    } else if len(globals.GetGlobalRef().StartingJar) > 0 {
-        _, err = LoadClassFromJar(AppCL, validName, globals.GetGlobalRef().StartingJar)
-    } else {
-        _, err = LoadClassFromFile(AppCL, validName)
-    }
-    return err
+	validName := util.ConvertToPlatformPathSeparators(name)
+	if strings.HasPrefix(name, "java/") || strings.HasPrefix(name, "jdk/") ||
+		strings.HasPrefix(name, "javax/") || strings.HasPrefix(name, "sun/") {
+		name = util.ConvertInternalClassNameToFilename(name)
+		name = globals.JavaHome() + "classes" + string(os.PathSeparator) + name
+		validName = util.ConvertToPlatformPathSeparators(name)
+		_, err = LoadClassFromFile(BootstrapCL, validName)
+	} else if len(globals.GetGlobalRef().StartingJar) > 0 {
+		_, err = LoadClassFromJar(AppCL, validName, globals.GetGlobalRef().StartingJar)
+	} else {
+		_, err = LoadClassFromFile(AppCL, validName)
+	}
+	return err
 }
 
 // LoadClassFromFile first canonicalizes the filename, and reads
 // the indicated file, and runs it through the classloader.
 func LoadClassFromFile(cl Classloader, fname string) (string, error) {
-    var filename string
-    if !strings.HasSuffix(fname, ".class") {
-        filename = fname + ".class"
-    } else {
-        filename = fname
-    }
-    rawBytes, err := os.ReadFile(filename)
-    if err != nil {
-        _ = log.Log("Error: could not find or load class "+filename+".", log.SEVERE)
-        return "", fmt.Errorf("java.lang.classNotFoundException")
-    }
+	var filename string
+	if !strings.HasSuffix(fname, ".class") {
+		filename = fname + ".class"
+	} else {
+		filename = fname
+	}
+	rawBytes, err := os.ReadFile(filename)
+	if err != nil {
+		_ = log.Log("Error: could not find or load class "+filename+".", log.SEVERE)
+		return "", fmt.Errorf("java.lang.classNotFoundException")
+	}
 
-    // _ = log.Log(filename+" read", log.FINE)
+	// _ = log.Log(filename+" read", log.FINE)
 
-    return loadClassFromBytes(cl, filename, rawBytes)
+	return loadClassFromBytes(cl, filename, rawBytes)
 }
 
 func getJarFile(cl Classloader, jarFileName string) (*Archive, error) {
-    archive, exists := cl.Archives[jarFileName]
+	archive, exists := cl.Archives[jarFileName]
 
-    if exists {
-        return archive, nil
-    }
+	if exists {
+		return archive, nil
+	}
 
-    jar, err := NewJarFile(jarFileName)
+	jar, err := NewJarFile(jarFileName)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    cl.Archives[jarFileName] = jar
+	cl.Archives[jarFileName] = jar
 
-    return jar, nil
+	return jar, nil
 }
 
 func GetMainClassFromJar(cl Classloader, jarFileName string) (string, error) {
-    jar, err := getJarFile(cl, jarFileName)
+	jar, err := getJarFile(cl, jarFileName)
 
-    if err != nil {
-        return "", err
-    }
+	if err != nil {
+		return "", err
+	}
 
-    return jar.getMainClass(), nil
+	return jar.getMainClass(), nil
 }
 
 func LoadClassFromJar(cl Classloader, filename string, jarFileName string) (string, error) {
-    jar, err := getJarFile(cl, jarFileName)
+	jar, err := getJarFile(cl, jarFileName)
 
-    if err != nil {
-        return "", err
-    }
+	if err != nil {
+		return "", err
+	}
 
-    result, err := jar.loadClass(filename)
+	result, err := jar.loadClass(filename)
 
-    if err != nil {
-        return "", err
-    }
+	if err != nil {
+		return "", err
+	}
 
-    if !result.Success {
-        return "", fmt.Errorf("unable to find file %s in JAR file %s", filename, jarFileName)
-    }
+	if !result.Success {
+		return "", fmt.Errorf("unable to find file %s in JAR file %s", filename, jarFileName)
+	}
 
-    return ParseAndPostClass(&cl, filename, *result.Data)
+	return ParseAndPostClass(&cl, filename, *result.Data)
 }
 
 func loadClassFromBytes(cl Classloader, filename string, rawBytes []byte) (string, error) {
-    return ParseAndPostClass(&cl, filename, rawBytes)
+	return ParseAndPostClass(&cl, filename, rawBytes)
 }
 
 // ParseAndPostClass parses a class, presented as a slice of bytes, and
 // if no errors occurred, posts/loads it to the method area.
 func ParseAndPostClass(cl *Classloader, filename string, rawBytes []byte) (string, error) {
-    fullyParsedClass, err := parse(rawBytes)
-    if err != nil {
-        _ = log.Log("error parsing "+filename+". Exiting.", log.SEVERE)
-        return "", fmt.Errorf("parsing error")
-    }
+	fullyParsedClass, err := parse(rawBytes)
+	if err != nil {
+		_ = log.Log("error parsing "+filename+". Exiting.", log.SEVERE)
+		return "", fmt.Errorf("parsing error")
+	}
 
-    // format check the class
-    if formatCheckClass(&fullyParsedClass) != nil {
-        _ = log.Log("error format-checking "+filename+". Exiting.", log.SEVERE)
-        return "", fmt.Errorf("format-checking error")
-    }
-    _ = log.Log("Class "+fullyParsedClass.className+" has been format-checked.", log.FINEST)
+	// format check the class
+	if formatCheckClass(&fullyParsedClass) != nil {
+		_ = log.Log("error format-checking "+filename+". Exiting.", log.SEVERE)
+		return "", fmt.Errorf("format-checking error")
+	}
+	_ = log.Log("Class "+fullyParsedClass.className+" has been format-checked.", log.FINEST)
 
-    classToPost := convertToPostableClass(&fullyParsedClass)
-    eKF := Klass{
-        Status: 'F', // F = format-checked
-        Loader: cl.Name,
-        Data:   &classToPost,
-    }
-    MethAreaInsert(fullyParsedClass.className, &eKF)
+	classToPost := convertToPostableClass(&fullyParsedClass)
+	eKF := Klass{
+		Status: 'F', // F = format-checked
+		Loader: cl.Name,
+		Data:   &classToPost,
+	}
+	MethAreaInsert(fullyParsedClass.className, &eKF)
 
-    // // record the class in the classloader
-    ClassesLock.Lock()
-    cl.ClassCount += 1
-    ClassesLock.Unlock()
-    return fullyParsedClass.className, nil
+	// // record the class in the classloader
+	ClassesLock.Lock()
+	cl.ClassCount += 1
+	ClassesLock.Unlock()
+	return fullyParsedClass.className, nil
 }
 
 // =====  replaced by MethArea.MethAreaInsert
@@ -426,310 +426,310 @@ func ParseAndPostClass(cl *Classloader, filename string, rawBytes []byte) (strin
 // and removing some fields we needed in parsing, but which are no longer required.
 func convertToPostableClass(fullyParsedClass *ParsedClass) ClData {
 
-    kd := ClData{}
-    kd.Name = fullyParsedClass.className
-    kd.Superclass = fullyParsedClass.superClass
-    kd.Module = fullyParsedClass.moduleName
-    kd.Pkg = fullyParsedClass.packageName
-    for i := 0; i < len(fullyParsedClass.interfaces); i++ {
-        kd.Interfaces = append(kd.Interfaces, uint16(fullyParsedClass.interfaces[i]))
-    }
-    if len(fullyParsedClass.fields) > 0 {
-        for i := 0; i < len(fullyParsedClass.fields); i++ {
-            kdf := Field{}
-            kdf.Name = uint16(fullyParsedClass.fields[i].name)
-            kdf.Desc = uint16(fullyParsedClass.fields[i].description)
-            kdf.IsStatic = fullyParsedClass.fields[i].isStatic
-            if len(fullyParsedClass.fields[i].attributes) > 0 {
-                for j := 0; j < len(fullyParsedClass.fields[i].attributes); j++ {
-                    kdfa := Attr{}
-                    kdfa.AttrName = uint16(fullyParsedClass.fields[i].attributes[j].attrName)
-                    kdfa.AttrSize = fullyParsedClass.fields[i].attributes[j].attrSize
-                    kdfa.AttrContent = fullyParsedClass.fields[i].attributes[j].attrContent
-                    kdf.Attributes = append(kdf.Attributes, kdfa)
-                }
-            }
-            kd.Fields = append(kd.Fields, kdf)
-        }
-    }
+	kd := ClData{}
+	kd.Name = fullyParsedClass.className
+	kd.Superclass = fullyParsedClass.superClass
+	kd.Module = fullyParsedClass.moduleName
+	kd.Pkg = fullyParsedClass.packageName
+	for i := 0; i < len(fullyParsedClass.interfaces); i++ {
+		kd.Interfaces = append(kd.Interfaces, uint16(fullyParsedClass.interfaces[i]))
+	}
+	if len(fullyParsedClass.fields) > 0 {
+		for i := 0; i < len(fullyParsedClass.fields); i++ {
+			kdf := Field{}
+			kdf.Name = uint16(fullyParsedClass.fields[i].name)
+			kdf.Desc = uint16(fullyParsedClass.fields[i].description)
+			kdf.IsStatic = fullyParsedClass.fields[i].isStatic
+			if len(fullyParsedClass.fields[i].attributes) > 0 {
+				for j := 0; j < len(fullyParsedClass.fields[i].attributes); j++ {
+					kdfa := Attr{}
+					kdfa.AttrName = uint16(fullyParsedClass.fields[i].attributes[j].attrName)
+					kdfa.AttrSize = fullyParsedClass.fields[i].attributes[j].attrSize
+					kdfa.AttrContent = fullyParsedClass.fields[i].attributes[j].attrContent
+					kdf.Attributes = append(kdf.Attributes, kdfa)
+				}
+			}
+			kd.Fields = append(kd.Fields, kdf)
+		}
+	}
 
-    if len(fullyParsedClass.methods) > 0 {
-        for i := 0; i < len(fullyParsedClass.methods); i++ {
-            kdm := Method{}
-            kdm.Name = uint16(fullyParsedClass.methods[i].name)
-            kdm.Desc = uint16(fullyParsedClass.methods[i].description)
-            kdm.AccessFlags = fullyParsedClass.methods[i].accessFlags
-            kdm.CodeAttr.MaxStack = fullyParsedClass.methods[i].codeAttr.maxStack
-            kdm.CodeAttr.MaxLocals = fullyParsedClass.methods[i].codeAttr.maxLocals
-            kdm.CodeAttr.Code = fullyParsedClass.methods[i].codeAttr.code
-            if len(fullyParsedClass.methods[i].codeAttr.exceptions) > 0 {
-                for j := 0; j < len(fullyParsedClass.methods[i].codeAttr.exceptions); j++ {
-                    kdmce := CodeException{}
-                    kdmce.StartPc = fullyParsedClass.methods[i].codeAttr.exceptions[j].startPc
-                    kdmce.EndPc = fullyParsedClass.methods[i].codeAttr.exceptions[j].endPc
-                    kdmce.HandlerPc = fullyParsedClass.methods[i].codeAttr.exceptions[j].handlerPc
-                    kdmce.CatchType = uint16(fullyParsedClass.methods[i].codeAttr.exceptions[j].catchType)
-                    kdm.CodeAttr.Exceptions = append(kdm.CodeAttr.Exceptions, kdmce)
-                }
-            }
-            if len(fullyParsedClass.methods[i].codeAttr.attributes) > 0 {
-                for m := 0; m < len(fullyParsedClass.methods[i].codeAttr.attributes); m++ {
-                    kdmca := Attr{}
-                    kdmca.AttrName = uint16(fullyParsedClass.methods[i].codeAttr.attributes[m].attrName)
-                    kdmca.AttrSize = fullyParsedClass.methods[i].codeAttr.attributes[m].attrSize
-                    kdmca.AttrContent = fullyParsedClass.methods[i].codeAttr.attributes[m].attrContent
-                    kdm.CodeAttr.Attributes = append(kdm.CodeAttr.Attributes, kdmca)
-                }
-            }
-            if len(fullyParsedClass.methods[i].attributes) > 0 {
-                for n := 0; n < len(fullyParsedClass.methods[i].attributes); n++ {
-                    kdma := Attr{
-                        AttrName:    uint16(fullyParsedClass.methods[i].attributes[n].attrName),
-                        AttrSize:    fullyParsedClass.methods[i].attributes[n].attrSize,
-                        AttrContent: fullyParsedClass.methods[i].attributes[n].attrContent,
-                    }
-                    kdm.Attributes = append(kdm.Attributes, kdma)
-                }
-            }
-            if len(fullyParsedClass.methods[i].exceptions) > 0 {
-                for p := 0; p < len(fullyParsedClass.methods[i].exceptions); p++ {
-                    kdm.Exceptions = append(kdm.Exceptions, uint16(fullyParsedClass.methods[i].exceptions[p]))
-                }
-            }
-            if len(fullyParsedClass.methods[i].parameters) > 0 {
-                for q := 0; q < len(fullyParsedClass.methods[i].parameters); q++ {
-                    kdmp := ParamAttrib{
-                        Name:        fullyParsedClass.methods[i].parameters[q].name,
-                        AccessFlags: fullyParsedClass.methods[i].parameters[q].accessFlags,
-                    }
-                    kdm.Parameters = append(kdm.Parameters, kdmp)
-                }
-            }
-            kdm.Deprecated = fullyParsedClass.methods[i].deprecated
-            kd.Methods = append(kd.Methods, kdm)
-        }
-    }
-    if len(fullyParsedClass.attributes) > 0 {
-        for i := 0; i < len(fullyParsedClass.attributes); i++ {
-            kda := Attr{
-                AttrName:    uint16(fullyParsedClass.attributes[i].attrName),
-                AttrSize:    fullyParsedClass.attributes[i].attrSize,
-                AttrContent: fullyParsedClass.attributes[i].attrContent,
-            }
-            kd.Attributes = append(kd.Attributes, kda)
-        }
-    }
-    kd.SourceFile = fullyParsedClass.sourceFile
-    if len(fullyParsedClass.bootstraps) > 0 {
-        for j := 0; j < len(fullyParsedClass.bootstraps); j++ {
-            kdbs := BootstrapMethod{
-                MethodRef: uint16(fullyParsedClass.bootstraps[j].methodRef),
-                Args:      nil,
-            }
-            if len(fullyParsedClass.bootstraps[j].args) > 0 {
-                for l := 0; l < len(fullyParsedClass.bootstraps[j].args); l++ {
-                    kdbs.Args = append(kdbs.Args, uint16(fullyParsedClass.bootstraps[j].args[l]))
-                }
-            }
-            kd.Bootstraps = append(kd.Bootstraps, kdbs)
-        }
-    }
-    kd.Access.ClassIsPublic = fullyParsedClass.classIsPublic
-    kd.Access.ClassIsFinal = fullyParsedClass.classIsFinal
-    kd.Access.ClassIsSuper = fullyParsedClass.classIsSuper
-    kd.Access.ClassIsInterface = fullyParsedClass.classIsInterface
-    kd.Access.ClassIsAbstract = fullyParsedClass.classIsAbstract
-    kd.Access.ClassIsSynthetic = fullyParsedClass.classIsSynthetic
-    kd.Access.ClassIsAnnotation = fullyParsedClass.classIsAnnotation
-    kd.Access.ClassIsEnum = fullyParsedClass.classIsEnum
-    kd.Access.ClassIsModule = fullyParsedClass.classIsModule
+	if len(fullyParsedClass.methods) > 0 {
+		for i := 0; i < len(fullyParsedClass.methods); i++ {
+			kdm := Method{}
+			kdm.Name = uint16(fullyParsedClass.methods[i].name)
+			kdm.Desc = uint16(fullyParsedClass.methods[i].description)
+			kdm.AccessFlags = fullyParsedClass.methods[i].accessFlags
+			kdm.CodeAttr.MaxStack = fullyParsedClass.methods[i].codeAttr.maxStack
+			kdm.CodeAttr.MaxLocals = fullyParsedClass.methods[i].codeAttr.maxLocals
+			kdm.CodeAttr.Code = fullyParsedClass.methods[i].codeAttr.code
+			if len(fullyParsedClass.methods[i].codeAttr.exceptions) > 0 {
+				for j := 0; j < len(fullyParsedClass.methods[i].codeAttr.exceptions); j++ {
+					kdmce := CodeException{}
+					kdmce.StartPc = fullyParsedClass.methods[i].codeAttr.exceptions[j].startPc
+					kdmce.EndPc = fullyParsedClass.methods[i].codeAttr.exceptions[j].endPc
+					kdmce.HandlerPc = fullyParsedClass.methods[i].codeAttr.exceptions[j].handlerPc
+					kdmce.CatchType = uint16(fullyParsedClass.methods[i].codeAttr.exceptions[j].catchType)
+					kdm.CodeAttr.Exceptions = append(kdm.CodeAttr.Exceptions, kdmce)
+				}
+			}
+			if len(fullyParsedClass.methods[i].codeAttr.attributes) > 0 {
+				for m := 0; m < len(fullyParsedClass.methods[i].codeAttr.attributes); m++ {
+					kdmca := Attr{}
+					kdmca.AttrName = uint16(fullyParsedClass.methods[i].codeAttr.attributes[m].attrName)
+					kdmca.AttrSize = fullyParsedClass.methods[i].codeAttr.attributes[m].attrSize
+					kdmca.AttrContent = fullyParsedClass.methods[i].codeAttr.attributes[m].attrContent
+					kdm.CodeAttr.Attributes = append(kdm.CodeAttr.Attributes, kdmca)
+				}
+			}
+			if len(fullyParsedClass.methods[i].attributes) > 0 {
+				for n := 0; n < len(fullyParsedClass.methods[i].attributes); n++ {
+					kdma := Attr{
+						AttrName:    uint16(fullyParsedClass.methods[i].attributes[n].attrName),
+						AttrSize:    fullyParsedClass.methods[i].attributes[n].attrSize,
+						AttrContent: fullyParsedClass.methods[i].attributes[n].attrContent,
+					}
+					kdm.Attributes = append(kdm.Attributes, kdma)
+				}
+			}
+			if len(fullyParsedClass.methods[i].exceptions) > 0 {
+				for p := 0; p < len(fullyParsedClass.methods[i].exceptions); p++ {
+					kdm.Exceptions = append(kdm.Exceptions, uint16(fullyParsedClass.methods[i].exceptions[p]))
+				}
+			}
+			if len(fullyParsedClass.methods[i].parameters) > 0 {
+				for q := 0; q < len(fullyParsedClass.methods[i].parameters); q++ {
+					kdmp := ParamAttrib{
+						Name:        fullyParsedClass.methods[i].parameters[q].name,
+						AccessFlags: fullyParsedClass.methods[i].parameters[q].accessFlags,
+					}
+					kdm.Parameters = append(kdm.Parameters, kdmp)
+				}
+			}
+			kdm.Deprecated = fullyParsedClass.methods[i].deprecated
+			kd.Methods = append(kd.Methods, kdm)
+		}
+	}
+	if len(fullyParsedClass.attributes) > 0 {
+		for i := 0; i < len(fullyParsedClass.attributes); i++ {
+			kda := Attr{
+				AttrName:    uint16(fullyParsedClass.attributes[i].attrName),
+				AttrSize:    fullyParsedClass.attributes[i].attrSize,
+				AttrContent: fullyParsedClass.attributes[i].attrContent,
+			}
+			kd.Attributes = append(kd.Attributes, kda)
+		}
+	}
+	kd.SourceFile = fullyParsedClass.sourceFile
+	if len(fullyParsedClass.bootstraps) > 0 {
+		for j := 0; j < len(fullyParsedClass.bootstraps); j++ {
+			kdbs := BootstrapMethod{
+				MethodRef: uint16(fullyParsedClass.bootstraps[j].methodRef),
+				Args:      nil,
+			}
+			if len(fullyParsedClass.bootstraps[j].args) > 0 {
+				for l := 0; l < len(fullyParsedClass.bootstraps[j].args); l++ {
+					kdbs.Args = append(kdbs.Args, uint16(fullyParsedClass.bootstraps[j].args[l]))
+				}
+			}
+			kd.Bootstraps = append(kd.Bootstraps, kdbs)
+		}
+	}
+	kd.Access.ClassIsPublic = fullyParsedClass.classIsPublic
+	kd.Access.ClassIsFinal = fullyParsedClass.classIsFinal
+	kd.Access.ClassIsSuper = fullyParsedClass.classIsSuper
+	kd.Access.ClassIsInterface = fullyParsedClass.classIsInterface
+	kd.Access.ClassIsAbstract = fullyParsedClass.classIsAbstract
+	kd.Access.ClassIsSynthetic = fullyParsedClass.classIsSynthetic
+	kd.Access.ClassIsAnnotation = fullyParsedClass.classIsAnnotation
+	kd.Access.ClassIsEnum = fullyParsedClass.classIsEnum
+	kd.Access.ClassIsModule = fullyParsedClass.classIsModule
 
-    // ---- loading the CP ----
-    for i := 0; i < fullyParsedClass.cpCount; i++ {
+	// ---- loading the CP ----
+	for i := 0; i < fullyParsedClass.cpCount; i++ {
 
-        // most CP entries are brought over with minor changes (indexes are shortened to uint16, etc.);
-        // however, stringRefs are converted to UTF-8 references here before being brought over.
-        if fullyParsedClass.cpIndex[i].entryType == StringConst {
-            whichStringConst := fullyParsedClass.cpIndex[i].slot
-            cpIndexForUTF8 := fullyParsedClass.stringRefs[whichStringConst]
-            cpE := CpEntry{
-                Type: UTF8,
-                Slot: uint16(fullyParsedClass.cpIndex[cpIndexForUTF8.index].slot),
-            }
-            kd.CP.CpIndex = append(kd.CP.CpIndex, cpE)
-        } else {
-            cpE := CpEntry{
-                Type: uint16(fullyParsedClass.cpIndex[i].entryType),
-                Slot: uint16(fullyParsedClass.cpIndex[i].slot),
-            }
-            kd.CP.CpIndex = append(kd.CP.CpIndex, cpE)
-        }
-    }
+		// most CP entries are brought over with minor changes (indexes are shortened to uint16, etc.);
+		// however, stringRefs are converted to UTF-8 references here before being brought over.
+		if fullyParsedClass.cpIndex[i].entryType == StringConst {
+			whichStringConst := fullyParsedClass.cpIndex[i].slot
+			cpIndexForUTF8 := fullyParsedClass.stringRefs[whichStringConst]
+			cpE := CpEntry{
+				Type: UTF8,
+				Slot: uint16(fullyParsedClass.cpIndex[cpIndexForUTF8.index].slot),
+			}
+			kd.CP.CpIndex = append(kd.CP.CpIndex, cpE)
+		} else {
+			cpE := CpEntry{
+				Type: uint16(fullyParsedClass.cpIndex[i].entryType),
+				Slot: uint16(fullyParsedClass.cpIndex[i].slot),
+			}
+			kd.CP.CpIndex = append(kd.CP.CpIndex, cpE)
+		}
+	}
 
-    if len(fullyParsedClass.classRefs) > 0 {
-        for i := 0; i < len(fullyParsedClass.classRefs); i++ {
-            kd.CP.ClassRefs = append(kd.CP.ClassRefs, uint16(fullyParsedClass.classRefs[i]))
-        }
-    }
+	if len(fullyParsedClass.classRefs) > 0 {
+		for i := 0; i < len(fullyParsedClass.classRefs); i++ {
+			kd.CP.ClassRefs = append(kd.CP.ClassRefs, uint16(fullyParsedClass.classRefs[i]))
+		}
+	}
 
-    if len(fullyParsedClass.doubles) > 0 {
-        for i := 0; i < len(fullyParsedClass.doubles); i++ {
-            kd.CP.Doubles = append(kd.CP.Doubles, fullyParsedClass.doubles[i])
-        }
-    }
+	if len(fullyParsedClass.doubles) > 0 {
+		for i := 0; i < len(fullyParsedClass.doubles); i++ {
+			kd.CP.Doubles = append(kd.CP.Doubles, fullyParsedClass.doubles[i])
+		}
+	}
 
-    if len(fullyParsedClass.dynamics) > 0 {
-        for i := 0; i < len(fullyParsedClass.dynamics); i++ {
-            dyn := DynamicEntry{
-                BootstrapIndex: uint16(fullyParsedClass.dynamics[i].bootstrapIndex),
-                NameAndType:    uint16(fullyParsedClass.dynamics[i].nameAndType),
-            }
-            kd.CP.Dynamics = append(kd.CP.Dynamics, dyn)
-        }
-    }
+	if len(fullyParsedClass.dynamics) > 0 {
+		for i := 0; i < len(fullyParsedClass.dynamics); i++ {
+			dyn := DynamicEntry{
+				BootstrapIndex: uint16(fullyParsedClass.dynamics[i].bootstrapIndex),
+				NameAndType:    uint16(fullyParsedClass.dynamics[i].nameAndType),
+			}
+			kd.CP.Dynamics = append(kd.CP.Dynamics, dyn)
+		}
+	}
 
-    if len(fullyParsedClass.fieldRefs) > 0 {
-        for i := 0; i < len(fullyParsedClass.fieldRefs); i++ {
-            fr := FieldRefEntry{
-                ClassIndex:  uint16(fullyParsedClass.fieldRefs[i].classIndex),
-                NameAndType: uint16(fullyParsedClass.fieldRefs[i].nameAndTypeIndex),
-            }
-            kd.CP.FieldRefs = append(kd.CP.FieldRefs, fr)
-        }
-    }
+	if len(fullyParsedClass.fieldRefs) > 0 {
+		for i := 0; i < len(fullyParsedClass.fieldRefs); i++ {
+			fr := FieldRefEntry{
+				ClassIndex:  uint16(fullyParsedClass.fieldRefs[i].classIndex),
+				NameAndType: uint16(fullyParsedClass.fieldRefs[i].nameAndTypeIndex),
+			}
+			kd.CP.FieldRefs = append(kd.CP.FieldRefs, fr)
+		}
+	}
 
-    if len(fullyParsedClass.floats) > 0 {
-        for i := 0; i < len(fullyParsedClass.floats); i++ {
-            kd.CP.Floats = append(kd.CP.Floats, fullyParsedClass.floats[i])
-        }
-    }
+	if len(fullyParsedClass.floats) > 0 {
+		for i := 0; i < len(fullyParsedClass.floats); i++ {
+			kd.CP.Floats = append(kd.CP.Floats, fullyParsedClass.floats[i])
+		}
+	}
 
-    if len(fullyParsedClass.intConsts) > 0 {
-        for i := 0; i < len(fullyParsedClass.intConsts); i++ {
-            kd.CP.IntConsts = append(kd.CP.IntConsts, int32(fullyParsedClass.intConsts[i]))
-        }
-    }
+	if len(fullyParsedClass.intConsts) > 0 {
+		for i := 0; i < len(fullyParsedClass.intConsts); i++ {
+			kd.CP.IntConsts = append(kd.CP.IntConsts, int32(fullyParsedClass.intConsts[i]))
+		}
+	}
 
-    if len(fullyParsedClass.interfaceRefs) > 0 {
-        for i := 0; i < len(fullyParsedClass.interfaceRefs); i++ {
-            ir := InterfaceRefEntry{
-                ClassIndex:  uint16(fullyParsedClass.interfaceRefs[i].classIndex),
-                NameAndType: uint16(fullyParsedClass.interfaceRefs[i].nameAndTypeIndex),
-            }
-            kd.CP.InterfaceRefs = append(kd.CP.InterfaceRefs, ir)
-        }
-    }
+	if len(fullyParsedClass.interfaceRefs) > 0 {
+		for i := 0; i < len(fullyParsedClass.interfaceRefs); i++ {
+			ir := InterfaceRefEntry{
+				ClassIndex:  uint16(fullyParsedClass.interfaceRefs[i].classIndex),
+				NameAndType: uint16(fullyParsedClass.interfaceRefs[i].nameAndTypeIndex),
+			}
+			kd.CP.InterfaceRefs = append(kd.CP.InterfaceRefs, ir)
+		}
+	}
 
-    if len(fullyParsedClass.invokeDynamics) > 0 {
-        for i := 0; i < len(fullyParsedClass.invokeDynamics); i++ {
-            id := InvokeDynamicEntry{
-                BootstrapIndex: uint16(fullyParsedClass.invokeDynamics[i].bootstrapIndex),
-                NameAndType:    uint16(fullyParsedClass.invokeDynamics[i].nameAndType),
-            }
-            kd.CP.InvokeDynamics = append(kd.CP.InvokeDynamics, id)
-        }
-    }
+	if len(fullyParsedClass.invokeDynamics) > 0 {
+		for i := 0; i < len(fullyParsedClass.invokeDynamics); i++ {
+			id := InvokeDynamicEntry{
+				BootstrapIndex: uint16(fullyParsedClass.invokeDynamics[i].bootstrapIndex),
+				NameAndType:    uint16(fullyParsedClass.invokeDynamics[i].nameAndType),
+			}
+			kd.CP.InvokeDynamics = append(kd.CP.InvokeDynamics, id)
+		}
+	}
 
-    if len(fullyParsedClass.longConsts) > 0 {
-        for i := 0; i < len(fullyParsedClass.longConsts); i++ {
-            kd.CP.LongConsts = append(kd.CP.LongConsts, fullyParsedClass.longConsts[i])
-        }
-    }
+	if len(fullyParsedClass.longConsts) > 0 {
+		for i := 0; i < len(fullyParsedClass.longConsts); i++ {
+			kd.CP.LongConsts = append(kd.CP.LongConsts, fullyParsedClass.longConsts[i])
+		}
+	}
 
-    if len(fullyParsedClass.methodHandles) > 0 {
-        for i := 0; i < len(fullyParsedClass.methodHandles); i++ {
-            mh := MethodHandleEntry{
-                RefKind:  uint16(fullyParsedClass.methodHandles[i].referenceKind),
-                RefIndex: uint16(fullyParsedClass.methodHandles[i].referenceIndex),
-            }
-            kd.CP.MethodHandles = append(kd.CP.MethodHandles, mh)
-        }
-    }
+	if len(fullyParsedClass.methodHandles) > 0 {
+		for i := 0; i < len(fullyParsedClass.methodHandles); i++ {
+			mh := MethodHandleEntry{
+				RefKind:  uint16(fullyParsedClass.methodHandles[i].referenceKind),
+				RefIndex: uint16(fullyParsedClass.methodHandles[i].referenceIndex),
+			}
+			kd.CP.MethodHandles = append(kd.CP.MethodHandles, mh)
+		}
+	}
 
-    if len(fullyParsedClass.methodRefs) > 0 {
-        for i := 0; i < len(fullyParsedClass.methodRefs); i++ {
-            mr := MethodRefEntry{
-                ClassIndex:  uint16(fullyParsedClass.methodRefs[i].classIndex),
-                NameAndType: uint16(fullyParsedClass.methodRefs[i].nameAndTypeIndex),
-            }
-            kd.CP.MethodRefs = append(kd.CP.MethodRefs, mr)
-        }
-    }
+	if len(fullyParsedClass.methodRefs) > 0 {
+		for i := 0; i < len(fullyParsedClass.methodRefs); i++ {
+			mr := MethodRefEntry{
+				ClassIndex:  uint16(fullyParsedClass.methodRefs[i].classIndex),
+				NameAndType: uint16(fullyParsedClass.methodRefs[i].nameAndTypeIndex),
+			}
+			kd.CP.MethodRefs = append(kd.CP.MethodRefs, mr)
+		}
+	}
 
-    if len(fullyParsedClass.methodTypes) > 0 {
-        for i := 0; i < len(fullyParsedClass.methodTypes); i++ {
-            kd.CP.MethodTypes = append(kd.CP.MethodTypes, uint16(fullyParsedClass.methodTypes[i]))
-        }
-    }
+	if len(fullyParsedClass.methodTypes) > 0 {
+		for i := 0; i < len(fullyParsedClass.methodTypes); i++ {
+			kd.CP.MethodTypes = append(kd.CP.MethodTypes, uint16(fullyParsedClass.methodTypes[i]))
+		}
+	}
 
-    if len(fullyParsedClass.nameAndTypes) > 0 {
-        for i := 0; i < len(fullyParsedClass.nameAndTypes); i++ {
-            nat := NameAndTypeEntry{
-                NameIndex: uint16(fullyParsedClass.nameAndTypes[i].nameIndex),
-                DescIndex: uint16(fullyParsedClass.nameAndTypes[i].descriptorIndex),
-            }
-            kd.CP.NameAndTypes = append(kd.CP.NameAndTypes, nat)
-        }
-    }
+	if len(fullyParsedClass.nameAndTypes) > 0 {
+		for i := 0; i < len(fullyParsedClass.nameAndTypes); i++ {
+			nat := NameAndTypeEntry{
+				NameIndex: uint16(fullyParsedClass.nameAndTypes[i].nameIndex),
+				DescIndex: uint16(fullyParsedClass.nameAndTypes[i].descriptorIndex),
+			}
+			kd.CP.NameAndTypes = append(kd.CP.NameAndTypes, nat)
+		}
+	}
 
-    if len(fullyParsedClass.utf8Refs) > 0 {
-        for i := 0; i < len(fullyParsedClass.utf8Refs); i++ {
-            kd.CP.Utf8Refs = append(kd.CP.Utf8Refs, fullyParsedClass.utf8Refs[i].content)
-        }
-    }
+	if len(fullyParsedClass.utf8Refs) > 0 {
+		for i := 0; i < len(fullyParsedClass.utf8Refs); i++ {
+			kd.CP.Utf8Refs = append(kd.CP.Utf8Refs, fullyParsedClass.utf8Refs[i].content)
+		}
+	}
 
-    if log.Level == log.FINEST {
-        b := new(bytes.Buffer)
-        if gob.NewEncoder(b).Encode(kd) == nil {
-            _ = log.Log("Size of loaded class: "+strconv.Itoa(b.Len()), log.FINEST)
-        }
-    }
-    return kd
+	if log.Level == log.FINEST {
+		b := new(bytes.Buffer)
+		if gob.NewEncoder(b).Encode(kd) == nil {
+			_ = log.Log("Size of loaded class: "+strconv.Itoa(b.Len()), log.FINEST)
+		}
+	}
+	return kd
 }
 
 // GetCountOfLoadedClasses returns the number of classes loaded
 // by the classloader
 func (cl *Classloader) GetCountOfLoadedClasses() int {
-    return cl.ClassCount
+	return cl.ClassCount
 }
 
 // accepts a string containing a class reference from a class file and converts
 // it into a normalized z/y/x format. It converts references that start with [L
 // and skips all array classes. For these latter cases or any errors, it returns ""
 func normalizeClassReference(ref string) string {
-    refClassName := ref
-    if strings.HasPrefix(refClassName, "[L") {
-        refClassName = strings.TrimPrefix(refClassName, "[L")
-        if strings.HasSuffix(refClassName, ";") {
-            refClassName = strings.TrimSuffix(refClassName, ";")
-        }
-    } else if strings.HasPrefix(refClassName, "[") {
-        refClassName = ""
-    }
-    return refClassName
+	refClassName := ref
+	if strings.HasPrefix(refClassName, "[L") {
+		refClassName = strings.TrimPrefix(refClassName, "[L")
+		if strings.HasSuffix(refClassName, ";") {
+			refClassName = strings.TrimSuffix(refClassName, ";")
+		}
+	} else if strings.HasPrefix(refClassName, "[") {
+		refClassName = ""
+	}
+	return refClassName
 }
 
 // Init simply initializes the three classloaders and the class area
 // and points the classloaders to each other in the proper order.
 // This function might be substantially revised later.
 func Init() error {
-    BootstrapCL.Name = "bootstrap"
-    BootstrapCL.Parent = ""
-    BootstrapCL.ClassCount = 0
-    BootstrapCL.Archives = make(map[string]*Archive)
+	BootstrapCL.Name = "bootstrap"
+	BootstrapCL.Parent = ""
+	BootstrapCL.ClassCount = 0
+	BootstrapCL.Archives = make(map[string]*Archive)
 
-    ExtensionCL.Name = "extension"
-    ExtensionCL.Parent = "bootstrap"
-    ExtensionCL.ClassCount = 0
-    ExtensionCL.Archives = make(map[string]*Archive)
+	ExtensionCL.Name = "extension"
+	ExtensionCL.Parent = "bootstrap"
+	ExtensionCL.ClassCount = 0
+	ExtensionCL.Archives = make(map[string]*Archive)
 
-    AppCL.Name = "app"
-    AppCL.Parent = "extension"
-    AppCL.ClassCount = 0
-    AppCL.Archives = make(map[string]*Archive)
+	AppCL.Name = "app"
+	AppCL.Parent = "extension"
+	AppCL.ClassCount = 0
+	AppCL.Archives = make(map[string]*Archive)
 
-    // initialize the method area
-    initMethodArea()
+	// initialize the method area
+	initMethodArea()
 
-    return nil
+	return nil
 }

--- a/src/classloader/classloader.go
+++ b/src/classloader/classloader.go
@@ -193,7 +193,7 @@ func LoadBaseClasses(global *globals.Globals) {
 
 		jmodFile, err := os.Open(fname)
 		if err != nil {
-			_ = log.Log("Couldn't load JMOD file from "+fname, log.WARNING)
+			_ = log.Log("LoadBaseClasses: Couldn't load JMOD file from "+fname, log.WARNING)
 			_ = log.Log(err.Error(), log.SEVERE)
 			shutdown.Exit(shutdown.APP_EXCEPTION)
 		} else {
@@ -205,7 +205,7 @@ func LoadBaseClasses(global *globals.Globals) {
 			})
 
 			if err != nil {
-				_ = log.Log("Error loading jmod file "+fname, log.SEVERE)
+				_ = log.Log("LoadBaseClasses: Error loading jmod file "+fname, log.SEVERE)
 				_ = log.Log(err.Error(), log.SEVERE)
 				shutdown.Exit(shutdown.APP_EXCEPTION)
 			}
@@ -272,7 +272,7 @@ func LoadFromLoaderChannel(LoaderChannel <-chan string) {
 			Data:   nil,
 		}
 		MethAreaInsert(name, &eKI)
-		_ = LoadClassFromNameOnly(util.ConvertToPlatformPathSeparators(name))
+		LoadClassFromNameOnly(util.ConvertToPlatformPathSeparators(name))
 	}
 	globals.LoaderWg.Done()
 }
@@ -299,10 +299,22 @@ func LoadClassFromNameOnly(name string) error {
 		name = globals.JavaHome() + "classes" + string(os.PathSeparator) + name
 		validName = util.ConvertToPlatformPathSeparators(name)
 		_, err = LoadClassFromFile(BootstrapCL, validName)
+		if err != nil {
+			_ = log.Log("LoadClassFromNameOnly: LoadClassFromFile "+validName+" failed", log.SEVERE)
+			_ = log.Log(err.Error(), log.SEVERE)
+		}
 	} else if len(globals.GetGlobalRef().StartingJar) > 0 {
 		_, err = LoadClassFromJar(AppCL, validName, globals.GetGlobalRef().StartingJar)
+		if err != nil {
+			_ = log.Log("LoadClassFromNameOnly: LoadClassFromJar "+validName+" failed", log.SEVERE)
+			_ = log.Log(err.Error(), log.SEVERE)
+		}
 	} else {
 		_, err = LoadClassFromFile(AppCL, validName)
+		if err != nil {
+			_ = log.Log("LoadClassFromNameOnly: LoadClassFromFile "+validName+" failed", log.SEVERE)
+			_ = log.Log(err.Error(), log.SEVERE)
+		}
 	}
 	return err
 }

--- a/src/classloader/jmod.go
+++ b/src/classloader/jmod.go
@@ -35,7 +35,8 @@ type Jmod struct {
 
 // Walk a Jmod file and invoke the indicated WalkEntryFunc for each class found in the classlist
 // Only called in one place: LoadBaseClasses.
-// TODO: For clearity of reading, it might be better to not pass a sub-function reference. Instead, move the sub-function into Walk itself.
+// Passing the sub-function loadClassFromBytes from LoadBaseClasses makes this code challenging to read
+// but it might be the lesser of evils.
 func (jmodFile *Jmod) Walk(walk WalkEntryFunc) error {
 	b, err := os.ReadFile(jmodFile.File.Name())
 	if err != nil {

--- a/src/classloader/methArea.go
+++ b/src/classloader/methArea.go
@@ -21,7 +21,9 @@ var MethAreaMutex sync.RWMutex // All additions or updates to MethArea map come 
 // method area. In the event the class is not present there, the
 // function returns nil.
 func MethAreaFetch(key string) *Klass {
+    MethAreaMutex.RLock()
     v, _ := MethArea.Load(key)
+    MethAreaMutex.RUnlock()
     if v == nil {
         return nil
     }
@@ -31,8 +33,8 @@ func MethAreaFetch(key string) *Klass {
 // MethAreaInsert adds a class to the method area, using a pointer
 // to the parsed class.
 func MethAreaInsert(name string, klass *Klass) {
-    MethArea.Store(name, klass)
     MethAreaMutex.Lock()
+    MethArea.Store(name, klass)
     methAreaSize++
     MethAreaMutex.Unlock()
 
@@ -55,7 +57,9 @@ func MethAreaSize() int {
 // initMethodArea simply initializes MethArea (the method area
 // table of loaded classes) and initializes the counter of classes.
 func initMethodArea() {
+    MethAreaMutex.Lock()
     ma := sync.Map{}
     MethArea = &ma
     methAreaSize = 0
+    MethAreaMutex.Unlock()
 }

--- a/src/globals/globals_test.go
+++ b/src/globals/globals_test.go
@@ -7,6 +7,7 @@
 package globals
 
 import (
+	"fmt"
 	"os"
 	"testing"
 )
@@ -35,6 +36,20 @@ func TestJavaHomeFormat(t *testing.T) {
 		t.Errorf("Expecting a JAVA_HOME of '%s', got: %s", expectedPath, ret)
 	}
 	_ = os.Setenv("JAVA_HOME", origJavaHome)
+}
+
+// test original java home + version
+func TestJavaHomeAndVersion(t *testing.T) {
+	InitJavaHome()
+	home := JavaHome()
+	version := JavaVersion()
+	if home == "" {
+		t.Errorf("JAVA_HOME is nil")
+	}
+	if version == "" {
+		t.Errorf("JAVA_VERSION is nil")
+	}
+	fmt.Printf("TestJavaHomeAndVersion: JAVA_HOME=%s, JAVA_VERSION=%s\n", home, version)
 }
 
 // verify that a trailing slash in JAVA_HOME is removed

--- a/src/jvm/cli.go
+++ b/src/jvm/cli.go
@@ -12,6 +12,7 @@ import (
 	"jacobin/execdata"
 	"jacobin/globals"
 	"jacobin/log"
+	"jacobin/shutdown"
 	"os"
 	"strings"
 )
@@ -29,7 +30,6 @@ func HandleCli(osArgs []string, Global *globals.Globals) (err error) {
 	// add command-line args to those extracted from the environment (if any)
 	cliArgs := javaEnvOptions + " "
 	for _, v := range osArgs[1:] {
-		//		fmt.Printf("\t%q\n", v)
 		cliArgs += v + " "
 	}
 	Global.CommandLine = strings.TrimSpace(cliArgs)
@@ -39,7 +39,6 @@ func HandleCli(osArgs []string, Global *globals.Globals) (err error) {
 	// within quotes is treated as a single arg
 	args := strings.Fields(javaEnvOptions)
 	for _, v := range osArgs[1:] {
-		//		fmt.Printf("\t%q\n", v)
 		args = append(args, v)
 	}
 	Global.Args = args
@@ -73,16 +72,14 @@ func HandleCli(osArgs []string, Global *globals.Globals) (err error) {
 		if ok {
 			i, _ = opt.Action(i, arg, Global)
 		} else {
-			_, _ = fmt.Fprintf(os.Stderr, "%s is not a recognized option. Ignored.\n", args[i])
+			_, _ = fmt.Fprintf(os.Stderr, "%s is not a recognized option. Exiting.\n", args[i])
+			shutdown.Exit(shutdown.JVM_EXCEPTION)
 		}
 
 		// TODO: check for JAR specified and process the JAR. At present, it will
 		// recognize the JAR file and insert it into Global, and copy all succeeding args
 		// to app args. However, it does not recognize the JAR file as an executable.
 
-		// if len(arg) > 0 {
-		// 	fmt.Printf("Option %s has argument value: %s\n", option, arg)
-		// }
 	}
 	return nil
 }

--- a/src/jvm/instantiate.go
+++ b/src/jvm/instantiate.go
@@ -41,9 +41,7 @@ func instantiateClass(classname string) (*object.Object, error) {
 	}
 
 	// at this point the class has been loaded into the method area (MethArea).
-	classloader.ClassesLock.RLock()
 	k = classloader.MethAreaFetch(classname)
-	classloader.ClassesLock.RUnlock()
 
 	obj := object.Object{
 		Klass: k,

--- a/src/jvm/instantiate.go
+++ b/src/jvm/instantiate.go
@@ -7,13 +7,13 @@
 package jvm
 
 import (
-    "errors"
-    "fmt"
-    "jacobin/classloader"
-    "jacobin/log"
-    "jacobin/object"
-    "os"
-    "unsafe"
+	"fmt"
+	"jacobin/classloader"
+	"jacobin/log"
+	"jacobin/object"
+	"jacobin/shutdown"
+	"os"
+	"unsafe"
 )
 
 // instantiating a class is a two-part process:
@@ -25,126 +25,104 @@ import (
 // var mutex = sync.Mutex{}
 
 func instantiateClass(classname string) (*object.Object, error) {
-    _ = log.Log("instantiateClass: Instantiating class: "+classname, log.FINE)
-    k := classloader.MethAreaFetch(classname)
-    if k == nil || k.Data == nil {
+	_ = log.Log("instantiateClass: Instantiating class: "+classname, log.FINE)
+	k := classloader.MethAreaFetch(classname)
+	if k == nil || k.Data == nil {
 
-        // }
-        // countDown := 4 // 2 seconds maximum time to load a class
-        // for true {
-        // 	// mutex.Lock()
-        // 	k, present := classloader.MethArea[classname]
-        // mutex.Unlock()
-        // if k.Status == 'I' { // the class is being loaded
-        // 	if countDown < 1 { // I've waited too long!
-        // 		msg := "instantiateClass: Status is still 'I' waiting for class: " + classname + ". Overdue!"
-        // 		err := errors.New(msg)
-        // 		_ = log.Log(msg, log.SEVERE)
-        // 		return nil, err
-        // 	}
-        // 	countDown -= 1
-        // 	time.Sleep(500 * time.Millisecond)
-        // 	continue // recheck the status until it changes (i.e., until the class is loaded)
-        // }
-        //
-        // if present {
-        // 	break
-        // }
+		// Not present - try to load from name
+		if classloader.LoadClassFromNameOnly(classname) != nil {
+			msg := "instantiateClass: Failed to load class " + classname
+			_ = log.Log(msg, log.SEVERE)
+			shutdown.Exit(shutdown.APP_EXCEPTION)
+		}
 
-        // Not present - try to load from name
-        if classloader.LoadClassFromNameOnly(classname) != nil {
-            msg := "instantiateClass: LoadClassFromNameOnly(" +
-                classname + ") failed. Exiting."
-            err := errors.New(msg)
-            _ = log.Log(msg, log.SEVERE)
-            return nil, err
-        }
-        // break // loaded by name
-    }
+		// Success in loaded by name
 
-    // at this point the class has been loaded into the method area (MethArea).
-    classloader.ClassesLock.RLock()
-    k = classloader.MethAreaFetch(classname)
-    classloader.ClassesLock.RUnlock()
+	}
 
-    obj := object.Object{
-        Klass: k,
-    }
+	// at this point the class has been loaded into the method area (MethArea).
+	classloader.ClassesLock.RLock()
+	k = classloader.MethAreaFetch(classname)
+	classloader.ClassesLock.RUnlock()
 
-    // the object's mark field contains the lower 32-bits of the object's
-    // address, which serves as the hash code for the object
-    uintp := uintptr(unsafe.Pointer(&obj))
-    obj.Mark.Hash = uint32(uintp)
+	obj := object.Object{
+		Klass: k,
+	}
 
-    if len(k.Data.Fields) > 0 {
-        for i := 0; i < len(k.Data.Fields); i++ {
-            f := k.Data.Fields[i]
-            if (f.AccessFlags & 0b00001000) != 0 {
-                fmt.Fprintf(os.Stdout, "%s is static",
-                    classloader.FetchUTF8stringFromCPEntryNumber(&k.Data.CP, f.Name))
-            }
-            // name := k.Data.CP.CpIndex[f.Name]
-            desc := k.Data.CP.Utf8Refs[f.Desc]
-            // if desc.Type != classloader.NameAndType {
-            // 	_ = log.Log("error creating field in: "+classname, log.SEVERE)
-            // 	return nil, classloader.CFE("invalid field type")
-            // }
-            // nameAndType := k.Data.CP.NameAndTypes[desc.Slot]
-            // ftype := classloader.FetchUTF8stringFromCPEntryNumber(
-            // 	&k.Data.CP, nameAndType.DescIndex)
+	// the object's mark field contains the lower 32-bits of the object's
+	// address, which serves as the hash code for the object
+	uintp := uintptr(unsafe.Pointer(&obj))
+	obj.Mark.Hash = uint32(uintp)
 
-            fieldToAdd := new(object.Field)
-            fieldToAdd.Ftype = desc
-            switch string(fieldToAdd.Ftype[0]) {
-            case "L", "[": // it's a reference
-                fieldToAdd.Fvalue = nil
-            case "B", "C", "I", "J", "S", "Z":
-                fieldToAdd.Fvalue = 0
-            case "D", "F":
-                fieldToAdd.Fvalue = 0.0
-            default:
-                _ = log.Log("error creating field in: "+classname+
-                    " Invalid type: "+fieldToAdd.Ftype, log.SEVERE)
-                return nil, classloader.CFE("invalid field type")
-            }
-            obj.Fields = append(obj.Fields, *fieldToAdd)
-            // CURR: resume here
-        }
-    }
-    return &obj, nil
+	if len(k.Data.Fields) > 0 {
+		for i := 0; i < len(k.Data.Fields); i++ {
+			f := k.Data.Fields[i]
+			if (f.AccessFlags & 0b00001000) != 0 {
+				fmt.Fprintf(os.Stdout, "%s is static",
+					classloader.FetchUTF8stringFromCPEntryNumber(&k.Data.CP, f.Name))
+			}
+			// name := k.Data.CP.CpIndex[f.Name]
+			desc := k.Data.CP.Utf8Refs[f.Desc]
+			// if desc.Type != classloader.NameAndType {
+			// 	_ = log.Log("error creating field in: "+classname, log.SEVERE)
+			// 	return nil, classloader.CFE("invalid field type")
+			// }
+			// nameAndType := k.Data.CP.NameAndTypes[desc.Slot]
+			// ftype := classloader.FetchUTF8stringFromCPEntryNumber(
+			// 	&k.Data.CP, nameAndType.DescIndex)
+
+			fieldToAdd := new(object.Field)
+			fieldToAdd.Ftype = desc
+			switch string(fieldToAdd.Ftype[0]) {
+			case "L", "[": // it's a reference
+				fieldToAdd.Fvalue = nil
+			case "B", "C", "I", "J", "S", "Z":
+				fieldToAdd.Fvalue = 0
+			case "D", "F":
+				fieldToAdd.Fvalue = 0.0
+			default:
+				_ = log.Log("error creating field in: "+classname+
+					" Invalid type: "+fieldToAdd.Ftype, log.SEVERE)
+				return nil, classloader.CFE("invalid field type")
+			}
+			obj.Fields = append(obj.Fields, *fieldToAdd)
+			// CURR: resume here
+		}
+	}
+	return &obj, nil
 }
 
 // the only fields allocated during class instantiation are instance fields--
 // method-local fields are created on the stack during method execution.
 // The allocated fields are in a structure that is defined in object.go
 func initializeField(f classloader.Field, cp *classloader.CPool, cn string, obj *object.Object) {
-    name := cp.Utf8Refs[int(f.Name)]
-    desc := cp.Utf8Refs[int(f.Desc)]
-    var attr = ""
-    // var value int64
-    if len(f.Attributes) > 0 {
-        for i := 0; i < len(f.Attributes); i++ {
-            attr = cp.Utf8Refs[int(f.Attributes[i].AttrName)]
-            if attr == "ConstantValue" {
-                // valueIndex := int(f.Attributes[i].AttrContent[0])*256 +
-                //     int(f.Attributes[i].AttrContent[1])
-                // // valueType := cp.CpIndex[valueIndex].Type
-                // // valueSlot := cp.CpIndex[valueIndex].Slot
-            }
-            // } else {
-            // 	value = 0
-            // }
+	name := cp.Utf8Refs[int(f.Name)]
+	desc := cp.Utf8Refs[int(f.Desc)]
+	var attr = ""
+	// var value int64
+	if len(f.Attributes) > 0 {
+		for i := 0; i < len(f.Attributes); i++ {
+			attr = cp.Utf8Refs[int(f.Attributes[i].AttrName)]
+			if attr == "ConstantValue" {
+				// valueIndex := int(f.Attributes[i].AttrContent[0])*256 +
+				//     int(f.Attributes[i].AttrContent[1])
+				// // valueType := cp.CpIndex[valueIndex].Type
+				// // valueSlot := cp.CpIndex[valueIndex].Slot
+			}
+			// } else {
+			// 	value = 0
+			// }
 
-        }
-    }
-    // append field to the object.fields slice TODO: check that this is a good solution.
-    // obj.fields = append(obj.fields, Field{
-    // 	metadata: classloader.Field{},
-    // 	value:    value,
-    // })
-    // CURR: Resume here, entering the new field into obj.
-    _, _ = fmt.Fprintf(os.Stdout, "Class: %s, Field to initialize: %s, type: %s\n", cn, name, desc)
-    if attr != "" {
-        _, _ = fmt.Fprintf(os.Stdout, "Attribute name: %s\n", attr)
-    }
+		}
+	}
+	// append field to the object.fields slice TODO: check that this is a good solution.
+	// obj.fields = append(obj.fields, Field{
+	// 	metadata: classloader.Field{},
+	// 	value:    value,
+	// })
+	// CURR: Resume here, entering the new field into obj.
+	_, _ = fmt.Fprintf(os.Stdout, "Class: %s, Field to initialize: %s, type: %s\n", cn, name, desc)
+	if attr != "" {
+		_, _ = fmt.Fprintf(os.Stdout, "Attribute name: %s\n", attr)
+	}
 }

--- a/src/jvm/jvmStart.go
+++ b/src/jvm/jvmStart.go
@@ -22,68 +22,71 @@ var Global globals.Globals
 // it is here returned is because in testing mode, the actual exit() call is side-stepped and
 // instead an int is returned (because calling exit() during testing exits the testing run as well).
 func JVMrun() int {
-    // if globals.JacobinName == "test", then we're in test mode and globals and log have been set
-    // in the testing function. So, don't reset them here.
-    if globals.GetGlobalRef().JacobinName != "test" {
-        Global = globals.InitGlobals(os.Args[0])
-        log.Init()
-    } else {
-        Global = *globals.GetGlobalRef()
-    }
+	// if globals.JacobinName == "test", then we're in test mode and globals and log have been set
+	// in the testing function. So, don't reset them here.
+	if globals.GetGlobalRef().JacobinName != "test" {
+		Global = globals.InitGlobals(os.Args[0])
+		log.Init()
+	} else {
+		Global = *globals.GetGlobalRef()
+	}
 
-    _ = log.Log("running program: "+Global.JacobinName, log.FINE)
+	_ = log.Log("running program: "+Global.JacobinName, log.FINE)
 
-    // handle the command-line interface (cli) -- i.e., process the args
-    LoadOptionsTable(Global)
-    err := HandleCli(os.Args, &Global)
-    if err != nil {
-        return shutdown.Exit(shutdown.APP_EXCEPTION)
-    }
-    // some CLI options, like -version, show data and immediately exit. This tests for that.
-    if Global.ExitNow == true {
-        return shutdown.Exit(shutdown.OK)
-    }
+	// handle the command-line interface (cli) -- i.e., process the args
+	LoadOptionsTable(Global)
+	err := HandleCli(os.Args, &Global)
+	if err != nil {
+		return shutdown.Exit(shutdown.JVM_EXCEPTION)
+	}
+	// some CLI options, like -version, show data and immediately exit. This tests for that.
+	if Global.ExitNow == true {
+		return shutdown.Exit(shutdown.OK)
+	}
 
-    // Init classloader and load base classes
-    _ = classloader.Init()
-    classloader.LoadBaseClasses(&Global)
+	// Init classloader and load base classes
+	err = classloader.Init()
+	if err != nil {
+		return shutdown.Exit(shutdown.JVM_EXCEPTION)
+	}
+	classloader.LoadBaseClasses(&Global)
 
-    var mainClass string
+	var mainClass string
 
-    if Global.StartingJar != "" {
-        manifestClass, err := classloader.GetMainClassFromJar(classloader.BootstrapCL, Global.StartingJar)
+	if Global.StartingJar != "" {
+		manifestClass, err := classloader.GetMainClassFromJar(classloader.BootstrapCL, Global.StartingJar)
 
-        if err != nil {
-            _ = log.Log(err.Error(), log.INFO)
-            return shutdown.Exit(shutdown.JVM_EXCEPTION)
-        }
+		if err != nil {
+			_ = log.Log(err.Error(), log.INFO)
+			return shutdown.Exit(shutdown.JVM_EXCEPTION)
+		}
 
-        if manifestClass == "" {
-            _ = log.Log(fmt.Sprintf("no main manifest attribute, in %s", Global.StartingJar), log.INFO)
-            return shutdown.Exit(shutdown.APP_EXCEPTION)
-        }
-        mainClass, err = classloader.LoadClassFromJar(classloader.BootstrapCL, manifestClass, Global.StartingJar)
-        if err != nil { // the exceptions message will already have been shown to user
-            return shutdown.Exit(shutdown.JVM_EXCEPTION)
-        }
-    } else if Global.StartingClass != "" {
-        mainClass, err = classloader.LoadClassFromFile(classloader.BootstrapCL, Global.StartingClass)
-        if err != nil { // the exceptions message will already have been shown to user
-            return shutdown.Exit(shutdown.JVM_EXCEPTION)
-        }
-    } else {
-        _ = log.Log("Error: No executable program specified. Exiting.", log.INFO)
-        ShowUsage(os.Stdout)
-        return shutdown.Exit(shutdown.APP_EXCEPTION)
-    }
+		if manifestClass == "" {
+			_ = log.Log(fmt.Sprintf("no main manifest attribute, in %s", Global.StartingJar), log.INFO)
+			return shutdown.Exit(shutdown.APP_EXCEPTION)
+		}
+		mainClass, err = classloader.LoadClassFromJar(classloader.BootstrapCL, manifestClass, Global.StartingJar)
+		if err != nil { // the exceptions message will already have been shown to user
+			return shutdown.Exit(shutdown.JVM_EXCEPTION)
+		}
+	} else if Global.StartingClass != "" {
+		mainClass, err = classloader.LoadClassFromFile(classloader.BootstrapCL, Global.StartingClass)
+		if err != nil { // the exceptions message will already have been shown to user
+			return shutdown.Exit(shutdown.JVM_EXCEPTION)
+		}
+	} else {
+		_ = log.Log("Error: No executable program specified. Exiting.", log.INFO)
+		ShowUsage(os.Stdout)
+		return shutdown.Exit(shutdown.APP_EXCEPTION)
+	}
 
-    classloader.LoadReferencedClasses(mainClass)
+	classloader.LoadReferencedClasses(mainClass)
 
-    // begin execution
-    _ = log.Log("Starting execution with: "+mainClass, log.INFO)
-    if StartExec(mainClass, &Global) != nil {
-        return shutdown.Exit(shutdown.APP_EXCEPTION)
-    }
+	// begin execution
+	_ = log.Log("Starting execution with: "+mainClass, log.INFO)
+	if StartExec(mainClass, &Global) != nil {
+		return shutdown.Exit(shutdown.APP_EXCEPTION)
+	}
 
-    return shutdown.Exit(shutdown.OK)
+	return shutdown.Exit(shutdown.OK)
 }


### PR DESCRIPTION
@platypusguy 
This is an initial PR. You can merge it any time. If still open, I will add to it. Otherwise, I'll open a new PR.

This list will continue to be updated.
* Added shutdowns in classloader.go LoadBaseClasses error situations.
* Added and amended commentary in a few places classloader.go - some based on discussion in JACOBIN-268.
* Updated some URLs to point to the Java/JVM version 17 documentation.
* Removed reference to JacobinHome from LoadClassByNameOnly (to be extensively revamped). As it turns out, this change was not necessary at this time. Jacobin home directory concept is still under discussion.
* In LoadClassByNameOnly, logging with accompanying context was added at the points of error recognition.
* Add the name of the function in several error messages so to see explicitly which function was reporting.
* In jvm/instantiate.go instantiateClass, when a class cannot be loaded, a shutdown is called.
* Confine MethArea locking to the methArea.go source file (take it out of instantiate.go).
* JACOBIN_HOME set up in globals.go.
* Make jvmStart.go JVMRun field the potential err from classloader.Init.
* Added context to some of jmod.go comments.
* Added JAVA_HOME installation version from the release file in globals.go and globals_test.go.