### PR TITLE
jacobin v0.3.1 started

### DIFF
--- a/src/classloader/getClassBytes.go
+++ b/src/classloader/getClassBytes.go
@@ -1,0 +1,55 @@
+package classloader
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/binary"
+	"io"
+	"jacobin/globals"
+	"log"
+	"os"
+)
+
+const ExpectedMagicNumber = 0x4A4D
+
+func getClassBytes(jmodFileName string, classFileName string) []byte {
+
+	global := globals.GetGlobalRef()
+	jmodPath := global.JavaHome + string(os.PathSeparator) + "jmods" + string(os.PathSeparator) + jmodFileName
+
+	// Read entire jmod file contents
+	jmodBytes, err := os.ReadFile(jmodPath)
+	if err != nil {
+		log.Fatalf("getClassBytes: os.ReadFile(%s) failed:\n%s\n", jmodPath, err.Error())
+	}
+
+	// Validate the file's magic number
+	fileMagicNumber := binary.BigEndian.Uint16(jmodBytes[:2])
+	if fileMagicNumber != ExpectedMagicNumber {
+		log.Fatalf("getClassBytes: fileMagicNumber != ExpectedMagicNumber in jmod file %s\n", jmodPath)
+	}
+
+	// Skip over the jmod header so that it is recognized as a ZIP file
+	ioReader := bytes.NewReader(jmodBytes[4:])
+
+	// Prepare the reader for the zip archive
+	zipReader, err := zip.NewReader(ioReader, int64(len(jmodBytes)-4))
+	if err != nil {
+		log.Fatalf("getClassBytes: zip.NewReader(%s) failed:\n%s\n", jmodPath, err.Error())
+	}
+
+	// Open the file within the zip archive
+	fileHandle, err := zipReader.Open(classFileName)
+	if err != nil {
+		log.Fatalf("getClassBytes: zipReader.Open(%s in %s) failed:\n%s\n", classFileName, jmodPath, err.Error())
+	}
+
+	// Read entire class file contents
+	bytes, err := io.ReadAll(fileHandle)
+	if err != nil {
+		log.Fatalf("getClassBytes: os.ReadAll(%s in %s) failed:\n%s\n", classFileName, jmodPath, err.Error())
+	}
+
+	return bytes
+
+}

--- a/src/classloader/jmodMap_test.go
+++ b/src/classloader/jmodMap_test.go
@@ -37,9 +37,8 @@ func TestJmodMapHomeTempdir(t *testing.T) {
 		return
 	}
 	tempDir := homeDir + string(os.PathSeparator) + "temp"
-	defer os.RemoveAll(tempDir)
+	_ = os.RemoveAll(tempDir) // in case that it pre-exists
 	t.Setenv("JACOBIN_HOME", tempDir)
-	_ = os.RemoveAll(tempDir) // Make sure that JACOBIN_HOME does not yet exist
 	globals.InitGlobals("test")
 	log.Init()
 	_ = log.SetLogLevel(log.FINEST)
@@ -63,8 +62,14 @@ func TestJmodMapHomeTempdir(t *testing.T) {
 		t.Logf("Gob not found as expected")
 	}
 
-	checkMap(t, "java/lang/String.class", "java.base.jmod")
-	checkMap(t, "com/sun/accessibility/internal/resources/accessibility.class", "java.desktop.jmod")
+	checkMap(t, "java/lang/String", "java.base.jmod")
+	checkMap(t, "com/sun/accessibility/internal/resources/accessibility", "java.desktop.jmod")
+
+	err = os.RemoveAll(tempDir)
+	if err != nil {
+		t.Errorf("os.RemoveAll(%s) failed: %s", tempDir, err.Error())
+		return
+	}
 
 }
 
@@ -77,6 +82,7 @@ func TestJmodMapHomeDefault(t *testing.T) {
 	}
 	globals.InitGlobals("test")
 	log.Init()
+	global := globals.GetGlobalRef()
 	JmodMapInit() // Create gob file if it does not yet exist.
 
 	globals.InitGlobals("test")
@@ -97,7 +103,13 @@ func TestJmodMapHomeDefault(t *testing.T) {
 	}
 	t.Logf("Map size is %d\n", mapSize)
 
-	checkMap(t, "java/lang/String.class", "java.base.jmod")
-	checkMap(t, "com/sun/accessibility/internal/resources/accessibility.class", "java.desktop.jmod")
+	checkMap(t, "java/lang/String", "java.base.jmod")
+	checkMap(t, "com/sun/accessibility/internal/resources/accessibility", "java.desktop.jmod")
+
+	err := os.RemoveAll(global.JacobinHome)
+	if err != nil {
+		t.Errorf("os.RemoveAll(%s) failed: %s", global.JacobinHome, err.Error())
+		return
+	}
 
 }

--- a/src/globals/globals.go
+++ b/src/globals/globals.go
@@ -72,7 +72,7 @@ var global Globals
 // InitGlobals initializes the global values that are known at start-up
 func InitGlobals(progName string) Globals {
 	global = Globals{
-		Version:           "0.2.1",
+		Version:           "0.3.1",
 		VmModel:           "server",
 		ExitNow:           false,
 		JacobinName:       progName,

--- a/src/globals/globals_test.go
+++ b/src/globals/globals_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 var foobar string
+var foo string
 
 func nameFooBar(t *testing.T) bool {
 	userHomeDir, err := os.UserHomeDir()
@@ -20,7 +21,8 @@ func nameFooBar(t *testing.T) bool {
 		t.Errorf("nameFooBar: os.UserHomeDir failed: %s", err.Error())
 		return false
 	}
-	foobar = userHomeDir + string(os.PathSeparator) + "foo" + string(os.PathSeparator) + "bar"
+	foo = userHomeDir + string(os.PathSeparator) + "foo"
+	foobar = foo + string(os.PathSeparator) + "bar"
 	return true
 }
 
@@ -42,7 +44,7 @@ func TestJavaHomeFormat(t *testing.T) {
 	if !nameFooBar(t) {
 		return
 	}
-	defer os.RemoveAll(foobar)
+	defer os.RemoveAll(foo)
 
 	origJavaHome := os.Getenv("JAVA_HOME")
 	_ = os.Setenv("JAVA_HOME", foobar)
@@ -93,7 +95,7 @@ func TestJacobinHomeFormat(t *testing.T) {
 	if !nameFooBar(t) {
 		return
 	}
-	defer os.RemoveAll(foobar)
+	defer os.RemoveAll(foo)
 
 	origJavaHome := os.Getenv("JACOBIN_HOME")
 	_ = os.Setenv("JACOBIN_HOME", foobar)
@@ -111,7 +113,7 @@ func TestJacobinHomeRemovalOfTrailingSlash(t *testing.T) {
 	if !nameFooBar(t) {
 		return
 	}
-	defer os.RemoveAll(foobar)
+	defer os.RemoveAll(foo)
 
 	origJavaHome := os.Getenv("JACOBIN_HOME")
 	_ = os.Setenv("JACOBIN_HOME", foobar)

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -247,6 +247,11 @@ func runFrame(fs *list.List) error {
 					stringAddr :=
 						object.CreateJavaStringFromGoString(CPe.stringVal)
 					stringAddr.Klass = classloader.MethAreaFetch("java/lang/String")
+					if stringAddr.Klass == nil {
+						msg := fmt.Sprintf("FetchMethodAndCP: MethAreaFetch could not find class java/lang/String")
+						_ = log.Log(msg, log.SEVERE)
+						shutdown.Exit(shutdown.JVM_EXCEPTION)
+					}
 					// push(f, unsafe.Pointer(CPe.addrVal))
 					push(f, stringAddr)
 				}

--- a/test_one/jmodMap.sh
+++ b/test_one/jmodMap.sh
@@ -1,5 +1,4 @@
 set -e
-set batdir=`pwd`
 cd ../src
 
 echo


### PR DESCRIPTION
This PR addresses JACOBIN-266 and JACOBIN-270.

**Source changes**

	new file:   src/classloader/getClassBytes.go

	modified:   src/classloader/classes.go
	modified:   src/classloader/classloader.go
	modified:   src/classloader/jmodMap.go
	modified:   src/classloader/jmodMap_test.go
	modified:   src/classloader/methArea.go
	modified:   src/globals/globals.go
	modified:   src/globals/globals_test.go
	modified:   src/jvm/instantiate.go
	modified:   src/jvm/run.go
	modified:   test_one/jmodMap.sh

**Last jacotest session failure report**

```
Failed Test Case Summary - 2023-06-10 17:34:51 CDT
 
===========================
panic: interface conversion
===========================
FAILED.JACOBIN-0211-pbcrypto.jacobin.log: panic: interface conversion: interface {} is *[]int8, not *object.Object
FAILED.JACOBIN-0234-0240-0241-array-length.jacobin.log: panic: interface conversion: interface {} is int64, not *object.Object
FAILED.JACOBIN-0234-string-length.jacobin.log: panic: interface conversion: interface {} is *[]int8, not *object.Object
FAILED.array-list-iterator.jacobin.log: panic: interface conversion: interface {} is nil, not int64
FAILED.casting.jacobin.log: panic: interface conversion: interface {} is int64, not *object.Object
FAILED.catch-exception.jacobin.log: panic: interface conversion: interface {} is *object.Object, not int64
FAILED.dedupe-hacked.jacobin.log: panic: interface conversion: interface {} is int, not *object.Object
FAILED.emission-line-spectra.jacobin.log: panic: interface conversion: interface {} is *object.Object, not int64
FAILED.fits.jacobin.log: panic: interface conversion: interface {} is *object.Object, not int64
FAILED.hashed-map.jacobin.log: panic: interface conversion: interface {} is *object.Object, not int64
FAILED.hashed-set.jacobin.log: panic: interface conversion: interface {} is int64, not *object.Object
FAILED.java17-enhancements.jacobin.log: panic: interface conversion: interface {} is int64, not *object.Object
FAILED.kalman-filtering.jacobin.log: panic: interface conversion: interface {} is int64, not *object.Object
FAILED.linked-list.jacobin.log: panic: interface conversion: interface {} is int64, not *object.Object
FAILED.scimark2.jacobin.log: panic: interface conversion: interface {} is int, not *object.Object
FAILED.sha3.jacobin.log: panic: interface conversion: interface {} is int, not *object.Object
FAILED.solitairgraphy.jacobin.log: panic: interface conversion: interface {} is int, not *object.Object
FAILED.stringer.jacobin.log: panic: interface conversion: interface {} is int64, not *object.Object
FAILED.taylor-series.jacobin.log: panic: interface conversion: interface {} is int64, not *object.Object
FAILED.two-fish.jacobin.log: panic: interface conversion: interface {} is *[]int8, not *object.Object
FAILED.vectors.jacobin.log: panic: interface conversion: interface {} is int64, not *object.Object
FAILED.zippy.jacobin.log: panic: interface conversion: interface {} is *object.Object, not int64
--- Total: 22
 
=================================
runtime error: index out of range
=================================
FAILED.blockchain.jacobin.log: panic: runtime error: index out of range [-1]
FAILED.negtest-runner-timeout.jacobin.log: panic: runtime error: index out of range [0] with length 0
FAILED.user-defined-exception.jacobin.log: panic: runtime error: index out of range [2] with length 1
--- Total: 3
 
============================
could not find or load class
============================
 
=====================================
runtime error: invalid memory address
=====================================
 
=====================================
MethAreaFetch
=====================================
 
================
runtime.sigpanic
================
 
================
invalid bytecode
================
FAILED.lambdas-maps.jacobin.log: Invalid bytecode found: 186 (0xBA)(INVOKEDYNAMIC) at location 10 in method main() of class main
--- Total: 1
```