### PR TITLE
Solved StrictMath anomaly in FetchMethodAndCP

### DIFF
--- a/src/classloader/TestLoadClass_test.go
+++ b/src/classloader/TestLoadClass_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 )
 
-const MyLogLevel = log.TRACE_INST
-
 func checkClass(t *testing.T, className string, expectedJmod string) bool {
 
 	jmod := JmodMapFetch(className)
@@ -52,7 +50,6 @@ func TestJmodToClass(t *testing.T) {
 	// Initialise global and logging
 	globals.InitGlobals("test")
 	log.Init()
-	_ = log.SetLogLevel(MyLogLevel)
 	t.Logf("globals.InitGlobals(test) ok\n")
 
 	// Initialise JMODMAP

--- a/src/classloader/classes.go
+++ b/src/classloader/classes.go
@@ -195,11 +195,14 @@ type InvokeDynamicEntry struct { // type 18 (invokedynamic data)
 // If it finds it there, then it loads that class into the MTable and returns that
 // entry as the Method it's returning.
 func FetchMethodAndCP(class, meth string, methType string) (MTentry, error) {
-	err := LoadClassFromNameOnly(class)
-	if err != nil {
-		_ = log.Log("LoadBaseClasses: Loading "+class+" failed: "+err.Error(), log.WARNING)
-		_ = log.Log(err.Error(), log.SEVERE)
-		shutdown.Exit(shutdown.JVM_EXCEPTION)
+
+	if MethAreaFetch(class) == nil {
+		err := LoadClassFromNameOnly(class)
+		if err != nil {
+			_ = log.Log("LoadBaseClasses: Loading "+class+" failed: "+err.Error(), log.WARNING)
+			_ = log.Log(err.Error(), log.SEVERE)
+			shutdown.Exit(shutdown.JVM_EXCEPTION)
+		}
 	}
 
 	methFQN := class + "." + meth + methType // FQN = fully qualified name

--- a/src/classloader/classes.go
+++ b/src/classloader/classes.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"jacobin/log"
+	"jacobin/shutdown"
 )
 
 type Klass struct {
@@ -194,6 +195,13 @@ type InvokeDynamicEntry struct { // type 18 (invokedynamic data)
 // If it finds it there, then it loads that class into the MTable and returns that
 // entry as the Method it's returning.
 func FetchMethodAndCP(class, meth string, methType string) (MTentry, error) {
+	err := LoadClassFromNameOnly(class)
+	if err != nil {
+		_ = log.Log("LoadBaseClasses: Loading "+class+" failed: "+err.Error(), log.WARNING)
+		_ = log.Log(err.Error(), log.SEVERE)
+		shutdown.Exit(shutdown.JVM_EXCEPTION)
+	}
+
 	methFQN := class + "." + meth + methType // FQN = fully qualified name
 	methEntry := MTable[methFQN]
 	if methEntry.Meth == nil { // method is not in the MTable, so find it and put it there

--- a/src/classloader/classloader.go
+++ b/src/classloader/classloader.go
@@ -404,7 +404,7 @@ func loadClassFromBytes(cl Classloader, filename string, rawBytes []byte) (strin
 // if no errors occurred, posts/loads it to the method area.
 func ParseAndPostClass(cl *Classloader, filename string, rawBytes []byte) (string, error) {
 
-	_ = log.Log("ParseAndPostClass: File "+filename+" to be processed", log.TRACE_INST)
+	_ = log.Log("ParseAndPostClass: File "+filename+" to be processed", log.FINEST)
 	fullyParsedClass, err := parse(rawBytes)
 	if err != nil {
 		_ = log.Log("ParseAndPostClass: error parsing "+filename+". Exiting.", log.SEVERE)
@@ -430,7 +430,7 @@ func ParseAndPostClass(cl *Classloader, filename string, rawBytes []byte) (strin
 	ClassesLock.Lock()
 	cl.ClassCount += 1
 	ClassesLock.Unlock()
-	_ = log.Log("ParseAndPostClass: File "+filename+" fully processed", log.TRACE_INST)
+	_ = log.Log("ParseAndPostClass: File "+filename+" fully processed", log.FINEST)
 
 	return fullyParsedClass.className, nil
 }

--- a/src/classloader/jmodMap_test.go
+++ b/src/classloader/jmodMap_test.go
@@ -41,7 +41,7 @@ func TestJmodMapHomeTempdir(t *testing.T) {
 	t.Setenv("JACOBIN_HOME", tempDir)
 	globals.InitGlobals("test")
 	log.Init()
-	_ = log.SetLogLevel(log.FINEST)
+	_ = log.SetLogLevel(log.WARNING)
 
 	tStart := time.Now()
 	JmodMapInit()
@@ -88,7 +88,7 @@ func TestJmodMapHomeDefault(t *testing.T) {
 	globals.InitGlobals("test")
 	log.Init()
 	JmodMapInit() // Process a pre-existing gob file.
-	_ = log.SetLogLevel(log.FINEST)
+	_ = log.SetLogLevel(log.WARNING)
 
 	if !JmodMapFoundGob() {
 		t.Errorf("Expected gob found but one was not found")


### PR DESCRIPTION
JACOBIN-270
JACOBIN-271

It wasn't just StrictMath. It was any INVOKESTATIC situation that required loading a not previously loaded class.

FetchMethodAndCP now calls LoadClassFromNameOnly(classname) to make sure that the class is loaded if need be.

AND FetchMethodAndCP **ONLY** calls LoadClassFromNameOnly when MethAreaFetch says the class aint loaded!