### PR TITLE
JACOBIN-305 createAndInitNewFrame must pop objectref BEFORE the parameters

### DIFF
--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -2143,7 +2143,11 @@ func createAndInitNewFrame(
 		objectRef = pop(f).(*object.Object)
 	}
 	
-	fram := frames.CreateFrame(m.MaxStack)
+	stackSize := m.MaxStack
+	if stackSize < 1 {
+		stackSize = 1
+	}
+	fram := frames.CreateFrame(stackSize)
 	fram.ClName = className
 	fram.MethName = methodName
 	fram.CP = m.Cp                     // add its pointer to the class CP

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -2143,7 +2143,7 @@ func createAndInitNewFrame(
 		objectRef = pop(f).(*object.Object)
 	}
 	
-	fram := frames.CreateFrame(m.MaxStack+8)
+	fram := frames.CreateFrame(m.MaxStack)
 	fram.ClName = className
 	fram.MethName = methodName
 	fram.CP = m.Cp                     // add its pointer to the class CP

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -1538,6 +1538,7 @@ func runFrame(fs *list.List) error {
 
 			if mtEntry.MType == 'J' { // it's a Java function (that is, non-native)
 				m := mtEntry.Meth.(classloader.JmEntry)
+				push(f, CPentry)
 				fram, err := createAndInitNewFrame(
 					className, methodName, methodType, &m, true, f)
 				if err != nil {
@@ -2129,7 +2130,8 @@ func createAndInitNewFrame(
 	currFrame *frames.Frame) (*frames.Frame, error) {
 
 	if MainThread.Trace {
-		traceInfo := fmt.Sprintf("\tcreateAndInitNewFrame: includeObjectRef=%v, m.MaxStack=%d, m.MaxLocals=%d", includeObjectRef, m.MaxStack, m.MaxLocals)
+		traceInfo := fmt.Sprintf("\tcreateAndInitNewFrame: class=%s, method=%s, methodType=%s, includeObjectRef=%v, m.MaxStack=%d, m.MaxLocals=%d", 
+		                         className, methodName, methodType, includeObjectRef, m.MaxStack, m.MaxLocals)
 		_ = log.Log(traceInfo, log.TRACE_INST)
 	}
 	
@@ -2141,7 +2143,7 @@ func createAndInitNewFrame(
 		objectRef = pop(f).(*object.Object)
 	}
 	
-	fram := frames.CreateFrame(m.MaxStack)
+	fram := frames.CreateFrame(m.MaxStack+8)
 	fram.ClName = className
 	fram.MethName = methodName
 	fram.CP = m.Cp                     // add its pointer to the class CP

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -2117,7 +2117,7 @@ func convertInterfaceToUint64(val interface{}) uint64 {
 
 // create a new frame and load up the local variables with the passed
 // arguments, set up the stack, and all the remaining items to begin execution
-// Note: the includeOjectRef parameter is a boolean. When true, it indicates
+// Note: the includeObjectRef parameter is a boolean. When true, it indicates
 // that in addition to the method parameter, an object reference is also on
 // the stack and needs to be popped off the caller's opStack and passed in.
 // (This would be the case for invokevirtual, among others.) When false, no
@@ -2125,16 +2125,22 @@ func convertInterfaceToUint64(val interface{}) uint64 {
 func createAndInitNewFrame(
 	className string, methodName string, methodType string,
 	m *classloader.JmEntry,
-	includeOjectRef bool,
+	includeObjectRef bool,
 	currFrame *frames.Frame) (*frames.Frame, error) {
 
 	if MainThread.Trace {
-		traceInfo := fmt.Sprintf("\tcreateAndInitNewFrame: includeOjectRef=%v, m.MaxStack=%d, m.MaxLocals=%d", includeOjectRef, m.MaxStack, m.MaxLocals)
+		traceInfo := fmt.Sprintf("\tcreateAndInitNewFrame: includeObjectRef=%v, m.MaxStack=%d, m.MaxLocals=%d", includeObjectRef, m.MaxStack, m.MaxLocals)
 		_ = log.Log(traceInfo, log.TRACE_INST)
 	}
 	
 	f := currFrame
 
+	// If there is an object reference, I have to pop it first and save it for later.
+	var objectRef *object.Object
+	if includeObjectRef {
+		objectRef = pop(f).(*object.Object)
+	}
+	
 	fram := frames.CreateFrame(m.MaxStack)
 	fram.ClName = className
 	fram.MethName = methodName
@@ -2245,12 +2251,12 @@ func createAndInitNewFrame(
 		fram.Locals = append(fram.Locals, int64(0))
 	}
 
-	// if includeOjectRef is true then objectRef != nil.
+	// if includeObjectRef is true then objectRef != nil.
 	// Insert it in the local[0]
 	// This is used in invokevirtual, invokespecial, and invokeinterface.
 	destLocal := 0
-	if includeOjectRef {
-		fram.Locals[0] = pop(f)
+	if includeObjectRef {
+		fram.Locals[0] = objectRef
 		fram.Locals = append(fram.Locals, int64(0)) // add some space for objectRef
 		destLocal = 1
 		lenLocals++ // There is one more needed

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -1538,7 +1538,6 @@ func runFrame(fs *list.List) error {
 
 			if mtEntry.MType == 'J' { // it's a Java function (that is, non-native)
 				m := mtEntry.Meth.(classloader.JmEntry)
-				push(f, CPentry)
 				fram, err := createAndInitNewFrame(
 					className, methodName, methodType, &m, true, f)
 				if err != nil {

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -2136,12 +2136,6 @@ func createAndInitNewFrame(
 	
 	f := currFrame
 
-	// If there is an object reference, I have to pop it first and save it for later.
-	var objectRef *object.Object
-	if includeObjectRef {
-		objectRef = pop(f).(*object.Object)
-	}
-	
 	stackSize := m.MaxStack
 	if stackSize < 1 {
 		stackSize = 1
@@ -2261,10 +2255,10 @@ func createAndInitNewFrame(
 	// This is used in invokevirtual, invokespecial, and invokeinterface.
 	destLocal := 0
 	if includeObjectRef {
-		fram.Locals[0] = objectRef
-		fram.Locals = append(fram.Locals, int64(0)) // add some space for objectRef
-		destLocal = 1
-		lenLocals++ // There is one more needed
+		fram.Locals[0] = pop(f)
+		fram.Locals = append(fram.Locals, int64(0)) // add the slot taken up by objectRef
+		destLocal = 1 // The first parameter starts at index 1
+		lenLocals++ // There is 1 more local needed
 	}
 
 	if MainThread.Trace {


### PR DESCRIPTION
I changed createAndInitNewFrame:
* Pop off the objectref LAST per original version. Add supporting code to make room for the objectref in the frame Locals array.
* For more information in tracing, added the string values of the class name, method name, and method type.
* When m.MaxStack = 0, what do we do instead of this:
```fram := frames.CreateFrame(m.MaxStack)```
Included in this PR:
```
	stackSize := m.MaxStack
	if stackSize < 1 {
		stackSize = 1
	}
	fram := frames.CreateFrame(stackSize)
```

Need to know: Are INVOKEVIRTUAL and INVOKESPECIAL supposed to push the object reference or was a prior opcode step supposed to push the object reference?

Answer: A prior opcode is supposed to do it. No additional pushes should be required from INVOKEVIRTUAL and INVOKESPECIAL.

This still remains The Case of the Missing Push.
Suspect: JNI situation.


