### PR TITLE
JACOBIN-354

### DIFF
--- a/src/classloader/classes.go
+++ b/src/classloader/classes.go
@@ -305,8 +305,6 @@ func FetchMethodAndCP(className, methName, methType string) (MTentry, error) {
 	// if we got this far, something went wrong with locating the method
 	msg := "FetchMethodAndCP: Found class " + className + ", but it did not contain method: " + methName
 	return MTentry{}, errors.New(msg)
-	//shutdown.Exit(shutdown.JVM_EXCEPTION)
-	//return MTentry{}, errors.New("method not found") // dummy return needed for tests
 }
 
 // error message when main() can't be found

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -1806,8 +1806,11 @@ func runFrame(fs *list.List) error {
 			}
 
 			mtEntry, err := classloader.FetchMethodAndCP(className, methName, methSig)
-			if err != nil {
-				return errors.New("INVOKESPECIAL: Class not found: " + className + "." + methName)
+			if err != nil || mtEntry.Meth == nil {
+				// TODO: search the classpath and retry
+				errMsg := "INVOKESPECIAL: Class method not found: " + className + "." + methName
+				_ = log.Log(errMsg, log.SEVERE)
+				return errors.New(errMsg)
 			}
 
 			if mtEntry.MType == 'G' { // it's a golang method
@@ -1872,8 +1875,11 @@ func runFrame(fs *list.List) error {
 			methodType := classloader.FetchUTF8stringFromCPEntryNumber(f.CP, methodSigIndex)
 
 			mtEntry, err := classloader.FetchMethodAndCP(className, methodName, methodType)
-			if err != nil {
-				return errors.New("INVOKESTATIC: Class not found: " + className + methodName)
+			if err != nil || mtEntry.Meth == nil {
+				// TODO: search the classpath and retry
+				errMsg := "INVOKESTATIC: Class method not found: " + className + "." + methodName
+				_ = log.Log(errMsg, log.SEVERE)
+				return errors.New(errMsg)
 			}
 
 			// before we can run the method, we need to either instantiate the class and/or

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -1744,7 +1744,9 @@ func runFrame(fs *list.List) error {
 				mtEntry, err = classloader.FetchMethodAndCP(className, methodName, methodType)
 				if err != nil || mtEntry.Meth == nil {
 					// TODO: search the classpath and retry
-					return errors.New("INVOKEVIRTUAL: Class not found: " + className + "." + methodName)
+					errMsg := "INVOKEVIRTUAL: Class method not found: " + className + "." + methodName
+					_ = log.Log(errMsg, log.SEVERE)
+					return errors.New(errMsg)
 				}
 			}
 


### PR DESCRIPTION
INVOKEVIRTUAL must emit the error message when a class method is not found because classloader.FetchMethodAndCP does not log when a method is not found; it simply returns error text to be used by caller.