### PR TITLE
JACOBIN-365 INVOKEVIRTUAL trap native methods

### DIFF
--- a/src/classloader/classes.go
+++ b/src/classloader/classes.go
@@ -270,7 +270,7 @@ func FetchMethodAndCP(className, methName, methType string) (MTentry, error) {
 		// lookup in the MTable (as all native methods are loaded there before
 		// program execution begins.
 		jme := JmEntry{
-			accessFlags: m.AccessFlags,
+			AccessFlags: m.AccessFlags,
 			MaxStack:    m.CodeAttr.MaxStack,
 			MaxLocals:   m.CodeAttr.MaxLocals,
 			Code:        m.CodeAttr.Code,

--- a/src/classloader/mTable.go
+++ b/src/classloader/mTable.go
@@ -49,7 +49,7 @@ type GmEntry struct {
 
 // JmEntry is the entry in the Mtable for Java methods.
 type JmEntry struct {
-	accessFlags int
+	AccessFlags int
 	MaxStack    int
 	MaxLocals   int
 	Code        []byte

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -1799,8 +1799,14 @@ func runFrame(fs *list.List) error {
 				break
 			}
 
-			if mtEntry.MType == 'J' { // it's a Java function (that is, non-native)
+			if mtEntry.MType == 'J' { // it's a Java or Native function
 				m := mtEntry.Meth.(classloader.JmEntry)
+				if m.AccessFlags&0x0100 > 0 {
+					// Native code
+					errMsg := "INVOKEVIRTUAL: Native method requested: " + className + "." + methodName
+					_ = log.Log(errMsg, log.SEVERE)
+					return errors.New(errMsg)
+				}
 				fram, err := createAndInitNewFrame(
 					className, methodName, methodType, &m, true, f)
 				if err != nil {


### PR DESCRIPTION
Files affected:
* run.go INVOKEVIRTUAL
* classes.go JmEntry accessFlags -> AccessFlags
* mTable.go ditto
