### PR TITLE
JACOBIN-367 and JACOBIN-368 and JACOBIN-370

### DIFF
--- a/src/classloader/javaIoPrintStream.go
+++ b/src/classloader/javaIoPrintStream.go
@@ -55,6 +55,11 @@ func Load_Io_PrintStream() map[string]GMeth {
 			ParamSlots: 2,
 			GFunction:  PrintlnI,
 		}
+	MethodSignatures["java/io/PrintStream.println(Z)V"] = // println boolean
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  PrintlnBoolean,
+		}
 	MethodSignatures["java/io/PrintStream.println(J)V"] = // println long
 		GMeth{
 			ParamSlots: 3, // PrintStream.out object + 2 slots for the long
@@ -83,6 +88,11 @@ func Load_Io_PrintStream() map[string]GMeth {
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  PrintI,
+		}
+	MethodSignatures["java/io/PrintStream.print(Z)V"] = // print boolean
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  PrintBoolean,
 		}
 	MethodSignatures["java/io/PrintStream.print(J)V"] = // print long
 		GMeth{
@@ -139,6 +149,19 @@ func PrintlnI(i []interface{}) interface{} {
 	return nil
 }
 
+// PrintlnBoolean = java/io/Prinstream.println(boolean) TODO: equivalent (verify that this grabs the right param to print)
+func PrintlnBoolean(i []interface{}) interface{} {
+	var boolToPrint bool
+	boolAsInt64 := i[1].(int64) // contains an int64
+	if boolAsInt64 > 0 {
+		boolToPrint = true
+	} else {
+		boolToPrint = false
+	}
+	fmt.Println(boolToPrint)
+	return nil
+}
+
 // PrintlnLong = java/io/Prinstream.println(long)
 // Long in Java are 64-bit ints, so we just duplicated the logic for println(int)
 func PrintlnLong(l []interface{}) interface{} {
@@ -159,6 +182,19 @@ func PrintlnDouble(l []interface{}) interface{} {
 func PrintI(i []interface{}) interface{} {
 	intToPrint := i[1].(int64) // contains an int
 	fmt.Print(intToPrint)
+	return nil
+}
+
+// PrintBoolean = java/io/Prinstream.print(boolean) TODO: equivalent (verify that this grabs the right param to print)
+func PrintBoolean(i []interface{}) interface{} {
+	var boolToPrint bool
+	boolAsInt64 := i[1].(int64) // contains an int64
+	if boolAsInt64 > 0 {
+		boolToPrint = true
+	} else {
+		boolToPrint = false
+	}
+	fmt.Print(boolToPrint)
 	return nil
 }
 

--- a/src/classloader/javaLangMath.go
+++ b/src/classloader/javaLangMath.go
@@ -8,6 +8,7 @@ package classloader
 
 import (
 	"jacobin/exceptions"
+	"jacobin/log"
 	"math"
 	"math/big"
 	"math/rand"
@@ -206,7 +207,22 @@ func Load_Lang_Math() map[string]GMeth {
 	MethodSignatures["java/lang/StrictMath.ulp(D)D"] = GMeth{ParamSlots: 2, GFunction: ulpFloat64}
 	MethodSignatures["java/lang/StrictMath.ulp(F)F"] = GMeth{ParamSlots: 1, GFunction: ulpFloat64}
 
+	MethodSignatures["java/lang/Math.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  mathClinit,
+		}
+
 	return MethodSignatures
+}
+
+func mathClinit([]interface{}) interface{} {
+	klass := MethAreaFetch("java/lang/Math")
+	if klass == nil {
+		errMsg := "In <clinit>, expected java/lang/Math to be in the MethodArea, but it was not"
+		_ = log.Log(errMsg, log.SEVERE)
+	}
+	return nil
 }
 
 // Absolute value function for Java float and double

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -99,6 +99,9 @@ func runThread(t *thread.ExecThread) error {
 	defer func() int {
 		// only an untrapped panic gets us here
 		if r := recover(); r != nil {
+			stack := string(debug.Stack())
+			glob := globals.GetGlobalRef()
+			glob.ErrorGoStack = stack
 			showPanicCause(r)
 			showFrameStack(t)
 			showGoStackTrace(nil)


### PR DESCRIPTION
1. Ensure to capture the golang-stack immediately after entering the deferred recover function (JACOBIN-367).
2. Add a ```<clinit>``` function to java LangMath.go (JACOBIN-368).
3. Add boolean support to javaIoPrintStream.go (JACOBIN-370).