### PR TITLE
Throw exception when <clinit> diagnoses an unrecoverable error

### DIFF
--- a/src/classloader/javaLangMath.go
+++ b/src/classloader/javaLangMath.go
@@ -221,6 +221,7 @@ func mathClinit([]interface{}) interface{} {
 	if klass == nil {
 		errMsg := "In <clinit>, expected java/lang/Math to be in the MethodArea, but it was not"
 		_ = log.Log(errMsg, log.SEVERE)
+		exceptions.Throw(exceptions.VirtualMachineError, errMsg)
 	}
 	return nil
 }

--- a/src/classloader/javaLangString.go
+++ b/src/classloader/javaLangString.go
@@ -7,6 +7,7 @@
 package classloader
 
 import (
+	"jacobin/exceptions"
 	"jacobin/log"
 	"jacobin/types"
 )
@@ -32,6 +33,7 @@ func stringClinit([]interface{}) interface{} {
 	if klass == nil {
 		errMsg := "In <clinit>, expected java/lang/String to be in the MethodArea, but it was not"
 		_ = log.Log(errMsg, log.SEVERE)
+		exceptions.Throw(exceptions.VirtualMachineError, errMsg)
 	}
 	klass.Data.ClInit = types.ClInitRun // just mark that String.<clinit>() has been run
 	return nil

--- a/src/classloader/javaLangSystem.go
+++ b/src/classloader/javaLangSystem.go
@@ -8,6 +8,7 @@ package classloader
 
 import (
 	"fmt"
+	"jacobin/exceptions"
 	"jacobin/globals"
 	"jacobin/log"
 	"jacobin/object"
@@ -74,7 +75,6 @@ func Load_Lang_System() map[string]GMeth {
 			GFunction:  justReturn,
 		}
 
-
 	MethodSignatures["java/lang/Thread.registerNatives()V"] =
 		GMeth{
 			ParamSlots: 0,
@@ -108,6 +108,7 @@ func clinit([]interface{}) interface{} {
 	if klass == nil {
 		errMsg := "In <clinit>, expected java/lang/System to be in the MethodArea, but it was not"
 		_ = log.Log(errMsg, log.SEVERE)
+		exceptions.Throw(exceptions.VirtualMachineError, errMsg)
 	}
 	if klass.Data.ClInit != types.ClInitRun {
 		_ = AddStatic("java/lang/System.in", Static{Type: "L", Value: object.Null})


### PR DESCRIPTION
The ```<clinit>``` routine was expecting the class to be already loaded in the method area but it wasn't.
Source files affected in package classloader:
- javaLangMath.go
- javaLangString.go
- javaLangSystem.go