### PR TITLE
JACOBIN-385: timing issue in jvmThread.go incrementThreadNumber

### DIFF
--- a/src/thread/jvmThread.go
+++ b/src/thread/jvmThread.go
@@ -44,7 +44,8 @@ func (t *ExecThread) AddThreadToTable(glob *globals.Globals) {
 func incrementThreadNumber() int {
 	glob := globals.GetGlobalRef()
 	glob.ThreadLock.Lock()
-	glob.ThreadNumber += 1
-	glob.ThreadLock.Unlock()
-	return glob.ThreadNumber
+	forCaller := glob.ThreadNumber + 1 // ensure that caller sees this one
+	glob.ThreadNumber = forCaller
+	glob.ThreadLock.Unlock() // I don't care if glob.ThreadNumber races ahead
+	return forCaller
 }

--- a/src/thread/jvmThread_test.go
+++ b/src/thread/jvmThread_test.go
@@ -76,7 +76,8 @@ func TestAddingMultipleSimultaneousThreads(t *testing.T) {
 	}
 
 	wg.Wait()
-	size := len(globals.GetGlobalRef().Threads)
+	//size := len(globals.GetGlobalRef().Threads)
+	size := globals.GetGlobalRef().ThreadNumber
 	if size != expectedSize {
 		t.Errorf("Expecting thread table size of %d, got %d", expectedSize, size)
 	}

--- a/src/thread/jvmThread_test.go
+++ b/src/thread/jvmThread_test.go
@@ -56,37 +56,29 @@ func TestAddingMultipleSimultaneousThreads(t *testing.T) {
 	// t.Parallel()
 
 	// Define test parameters
-	numThreads := 4
+	numThreadGroups := 8
 	threadsToAdd := 100
-	expectedSize := numThreads * threadsToAdd
+	expectedSize := numThreadGroups * threadsToAdd
 
 	// initialize globals
 	globals.InitGlobals("test")
 
-	// Initialize WaitGroup and a channel for signaling completion
+	// Initialize WaitGroup for signaling completion
 	wg := sync.WaitGroup{}
-	channel := make(chan struct{})
+	wg.Add(numThreadGroups)
 
-	for i := 0; i < numThreads; i++ {
-		wg.Add(1)
+	// Start the thread groups
+	for i := 0; i < numThreadGroups; i++ {
 		go func() {
 			defer wg.Done()
 			addThreadsToTable(threadsToAdd)
 		}()
 	}
 
-	go func() {
-		wg.Wait()
-		close(channel)
-	}()
-
-	// Wait for completion using a channel
-	select {
-	case <-channel:
-		size := len(globals.GetGlobalRef().Threads)
-		if size != expectedSize {
-			t.Errorf("Expecting thread table size of %d, got %d", expectedSize, size)
-		}
+	wg.Wait()
+	size := len(globals.GetGlobalRef().Threads)
+	if size != expectedSize {
+		t.Errorf("Expecting thread table size of %d, got %d", expectedSize, size)
 	}
 }
 

--- a/src/thread/jvmThread_test.go
+++ b/src/thread/jvmThread_test.go
@@ -76,8 +76,8 @@ func TestAddingMultipleSimultaneousThreads(t *testing.T) {
 	}
 
 	wg.Wait()
-	//size := len(globals.GetGlobalRef().Threads)
-	size := globals.GetGlobalRef().ThreadNumber
+	size := len(globals.GetGlobalRef().Threads)
+	//size := globals.GetGlobalRef().ThreadNumber
 	if size != expectedSize {
 		t.Errorf("Expecting thread table size of %d, got %d", expectedSize, size)
 	}


### PR DESCRIPTION
See discussion in JACOBIN-385.

Also, see email about Golang channel vs WaitGroup. What I changed (removing channel) may not matter but the channel and waiting in a thread was not necessary, IMO.

BUT all that was needed: fix ```incrementThreadNumber``` - see below.