### PR TITLE
Work towards JACOBIN-386

### DIFF
--- a/src/classloader/javaLangString.go
+++ b/src/classloader/javaLangString.go
@@ -39,14 +39,26 @@ func Load_Lang_String() map[string]GMeth {
 	// get the bytes from a string, given the Charset string name
 	MethodSignatures["java/lang/String.getBytes(Ljava/lang/String;)[B"] =
 		GMeth{
-			ParamSlots: 0,
+			ParamSlots: 1,
 			GFunction:  noSupportForUserCharsets,
 		}
 
 	// get the bytes from a string, given the specified Charset object
 	MethodSignatures["java/lang/String.getBytes(Ljava/nio/charset/Charset;)[B"] =
 		GMeth{
-			ParamSlots: 0,
+			ParamSlots: 1,
+			GFunction:  noSupportForUserCharsets,
+		}
+
+	MethodSignatures["java/lang/String.<init>([BLjava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  noSupportForUserCharsets,
+		}
+
+	MethodSignatures["java/lang/String.<init>([BLjava/nio/charset/Charset;)V"] =
+		GMeth{
+			ParamSlots: 2,
 			GFunction:  noSupportForUserCharsets,
 		}
 
@@ -66,7 +78,7 @@ func stringClinit([]interface{}) interface{} {
 }
 
 func noSupportForUserCharsets([]interface{}) interface{} {
-	errMsg := "No support yet for user-specified character sets"
+	errMsg := "No support yet for user-specified character sets and Unicode code point arrays"
 	exceptions.Throw(exceptions.UnsupportedEncodingException, errMsg)
 	return nil
 }

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -1959,6 +1959,7 @@ func runFrame(fs *list.List) error {
 			f.PC += 2
 			CP := f.CP.(*classloader.CPool)
 			className, methName, methSig := getMethInfoFromCPmethref(CP, CPslot)
+			//fmt.Printf("===========DEBUG INVOKESPECIAL className=%s, methName=%s, methSig=%s\n", className, methName, methSig)
 
 			// if it's a call to java/lang/Object."<init>":()V, which happens frequently,
 			// that function simply returns. So test for it here and if it is, skip the rest
@@ -1977,7 +1978,8 @@ func runFrame(fs *list.List) error {
 			}
 
 			if mtEntry.MType == 'G' { // it's a golang method
-				f, err = runGmethod(mtEntry, fs, className, className+"."+methName, methSig)
+				//f, err = runGmethod(mtEntry, fs, className, className+"."+methName, methSig)
+				f, err = runGmethod(mtEntry, fs, className, methName, methSig)
 				if err != nil {
 					glob := globals.GetGlobalRef()
 					glob.ErrorGoStack = string(debug.Stack())


### PR DESCRIPTION
* **classloader/javaLangString.go**
     - Fixed some entries that specified 0 arguments (lied) even though these entries result in an exception today (maybe not tomorrow).
     - Added entries for 
          - ```java/lang/String.<init>([BLjava/lang/String;)V```
          - ```java/lang/String.<init>([BLjava/nio/charset/Charset;)V```
* **jvm/run.go** - fixed INVOKESPECIAL to pass only the method name in the ```methName``` parameter in the call to ```runGmethod```. The former code broke ```java/lang/String.<init>([BLjava/lang/String;)V```. The fixed code looks like its counterpart in INVOKESTATIC and INVOKEVIRTUAL.