### PR TITLE
More progress on JACOBIN-386

### DIFF
--- a/src/classloader/javaLangString.go
+++ b/src/classloader/javaLangString.go
@@ -7,9 +7,10 @@
 package classloader
 
 import (
+	"fmt"
 	"jacobin/exceptions"
 	"jacobin/libs"
-	"jacobin/log"
+	"jacobin/object"
 	"jacobin/types"
 )
 
@@ -22,12 +23,101 @@ import (
 */
 
 func Load_Lang_String() map[string]GMeth {
-	// need to replace eventually by enbling the Java intializer to run
+
+	// === OBJECT INSTANTIATION ===
+
+	// String instantiation without parameters i.e. String string = new String();
+	// need to replace eventually by enabling the Java initializer to run
 	MethodSignatures["java/lang/String.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  stringClinit,
 		}
+
+	// String(byte[] bytes) - instantiate a String from a byte array
+	MethodSignatures["java/lang/String.<init>([B)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  newStringFromBytes,
+		}
+
+	// String(byte[] ascii, int hibyte) ***************************************** DEPRECATED
+	MethodSignatures["java/lang/String.<init>([BI)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  noSupportYetInString,
+		}
+
+	// String(byte[] bytes, int offset, int length)	- instantiate a String from a byte array SUBSET
+	MethodSignatures["java/lang/String.<init>([BII)V"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  newSubstringFromBytes,
+		}
+
+	// String(byte[] ascii, int hibyte, int offset, int count) *****************- DEPRECATED
+	MethodSignatures["java/lang/String.<init>([BIII)V"] =
+		GMeth{
+			ParamSlots: 4,
+			GFunction:  noSupportYetInString,
+		}
+
+	// String(byte[] bytes, int offset, int length, String charsetName) *********** CHARSET
+	MethodSignatures["java/lang/String.<init>([BIILjava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 4,
+			GFunction:  noSupportYetInString,
+		}
+
+	// String(byte[] bytes, int offset, int length, Charset charset) ************** CHARSET
+	MethodSignatures["java/lang/String.<init>([BIILjava/nio/charset/Charset;)V"] =
+		GMeth{
+			ParamSlots: 4,
+			GFunction:  noSupportYetInString,
+		}
+
+	// String(byte[] bytes, String charsetName) ******************************** CHARSET
+	MethodSignatures["java/lang/String.<init>([BLjava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  noSupportYetInString,
+		}
+
+	// String(byte[] bytes, Charset charset) ********************************** CHARSET
+	MethodSignatures["java/lang/String.<init>([BLjava/nio/charset/Charset;)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  noSupportYetInString,
+		}
+
+	// String(char[] value) *************************************************** works fine in Java
+
+	// String(char[] value, int offset, int count) ***************************- works fine in Java
+
+	// String(int[] codePoints, int offset, int count) ************************ CODEPOINTS
+	MethodSignatures["java/lang/String.<init>([III)V"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  noSupportYetInString,
+		}
+
+	// String(String original) - works fine in Java
+
+	// String(StringBuffer buffer) ********************************************* StringBuffer
+	MethodSignatures["java/lang/String.<init>(Ljava/lang/StringBuffer;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  noSupportYetInString,
+		}
+
+	// String(StringBuilder builder) ******************************************* StringBuilder
+	MethodSignatures["java/lang/String.<init>(Ljava/lang/StringBuilder;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  noSupportYetInString,
+		}
+
+	// === METHOD FUNCTIONS ===
 
 	// get the bytes from a string
 	MethodSignatures["java/lang/String.getBytes()[B"] =
@@ -36,30 +126,18 @@ func Load_Lang_String() map[string]GMeth {
 			GFunction:  libs.GetBytesVoid,
 		}
 
-	// get the bytes from a string, given the Charset string name
+	// get the bytes from a string, given the Charset string name ************************ CHARSET
 	MethodSignatures["java/lang/String.getBytes(Ljava/lang/String;)[B"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  noSupportForUserCharsets,
+			GFunction:  noSupportYetInString,
 		}
 
-	// get the bytes from a string, given the specified Charset object
+	// get the bytes from a string, given the specified Charset object *****************- CHARSET
 	MethodSignatures["java/lang/String.getBytes(Ljava/nio/charset/Charset;)[B"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  noSupportForUserCharsets,
-		}
-
-	MethodSignatures["java/lang/String.<init>([BLjava/lang/String;)V"] =
-		GMeth{
-			ParamSlots: 2,
-			GFunction:  noSupportForUserCharsets,
-		}
-
-	MethodSignatures["java/lang/String.<init>([BLjava/nio/charset/Charset;)V"] =
-		GMeth{
-			ParamSlots: 2,
-			GFunction:  noSupportForUserCharsets,
+			GFunction:  noSupportYetInString,
 		}
 
 	return MethodSignatures
@@ -69,27 +147,85 @@ func Load_Lang_String() map[string]GMeth {
 func stringClinit([]interface{}) interface{} {
 	klass := MethAreaFetch("java/lang/String")
 	if klass == nil {
-		errMsg := "In <clinit>, expected java/lang/String to be in the MethodArea, but it was not"
-		_ = log.Log(errMsg, log.SEVERE)
+		errMsg := "In stringClinit, expected java/lang/String to be in the MethodArea, but it was not"
 		exceptions.Throw(exceptions.VirtualMachineError, errMsg)
 	}
 	klass.Data.ClInit = types.ClInitRun // just mark that String.<clinit>() has been run
 	return nil
 }
 
-func noSupportForUserCharsets([]interface{}) interface{} {
+// No support YET for references to Charset objects nor for Unicode code point arrays
+func noSupportYetInString([]interface{}) interface{} {
 	errMsg := "No support yet for user-specified character sets and Unicode code point arrays"
 	exceptions.Throw(exceptions.UnsupportedEncodingException, errMsg)
 	return nil
 }
 
-// // get the bytes of a string. To find the string involved, we go to the TOS of the calling
-// // stack which has pushed a pointer to the string prior to this call.
-// func getBytesVoid(params []interface{}) interface{} {
-// 	threadPtr := params[0].(*jvmThread.ExecThread)
-// 	frameStack := threadPtr.Stack
-// 	prevFrame := frameStack.Front().Next().Value.(*frames.Frame)
-// 	str := prevFrame.OpStack[prevFrame.TOS].(*object.Object)
-// 	bytes := str.Fields[0].Fvalue.([]byte)
-// 	return bytes
-// }
+// Given a Go interface parameter from caller, compute the associated Go string.
+func getGoString(param0 interface{}) string {
+	var bptr *[]uint8
+	switch param0.(type) {
+	case *[]uint8:
+		bptr = param0.(*[]uint8)
+	case *object.Object:
+		parmObj := param0.(*object.Object)
+		bptr = parmObj.Fields[0].Fvalue.(*[]byte)
+	default:
+		errMsg := fmt.Sprintf("In getGoString, unexpected param[0] type = %T", param0)
+		exceptions.Throw(exceptions.VirtualMachineError, errMsg)
+		bptr = nil
+	}
+	return string(*bptr)
+}
+
+// Construct a compact string object (usable by Java) from a Go byte array.
+func newStringFromBytes(params []interface{}) interface{} {
+	klass := MethAreaFetch("java/lang/String")
+	if klass == nil {
+		errMsg := "In newStringFromBytes, expected java/lang/String to be in the MethodArea, but it was not"
+		exceptions.Throw(exceptions.VirtualMachineError, errMsg)
+	}
+	klass.Data.ClInit = types.ClInitRun // just mark that String.<clinit>() has been run
+
+	// Fetch a pointer to the raw slice of bytes from params[0].
+	// Convert the raw slice of bytes to a Go string.
+	wholeString := getGoString(params[0])
+
+	// Convert the Go string to a compact string object, usable by Java. Return to caller.
+	obj := object.CreateCompactStringFromGoString(&wholeString)
+	return obj
+
+}
+
+// Construct a compact string object (usable by Java) from a Go byte array.
+func newSubstringFromBytes(params []interface{}) interface{} {
+	klass := MethAreaFetch("java/lang/String")
+	if klass == nil {
+		errMsg := "In newStringFromBytes, expected java/lang/String to be in the MethodArea, but it was not"
+		exceptions.Throw(exceptions.VirtualMachineError, errMsg)
+	}
+	klass.Data.ClInit = types.ClInitRun // just mark that String.<clinit>() has been run
+
+	// Fetch a pointer to the raw slice of bytes from params[0].
+	// Convert the raw slice of bytes to a Go string.
+	wholeString := getGoString(params[0])
+
+	// Get substring offset and length
+	ssOffset := params[1].(int64)
+	ssLength := params[2].(int64)
+
+	// Validate boundaries.
+	wholeLength := int64(len(wholeString))
+	if wholeLength < 1 || ssOffset < 0 || ssLength < 1 || ssOffset > (wholeLength-1) || (ssOffset+ssLength) > wholeLength {
+		errMsg := "In newSubstringFromBytes, either: nil input byte array, invalid substring offset, or invalid substring length"
+		exceptions.Throw(exceptions.StringIndexOutOfBoundsException, errMsg)
+	}
+
+	// Compute substring.
+	ss := wholeString[ssOffset : ssOffset+ssLength]
+
+	// Convert the Go string (ss) to a compact string object, usable by Java. Return to caller.
+	obj := object.CreateCompactStringFromGoString(&ss)
+	return obj
+
+}

--- a/src/exceptions/exception.go
+++ b/src/exceptions/exception.go
@@ -163,6 +163,7 @@ const (
 	ServerNotActiveException
 	SQLException
 	StringConcatException
+	StringIndexOutOfBoundsException
 	TimeoutException
 	TooManyListenersException
 	TransformerException


### PR DESCRIPTION
* Added StringIndexOutOfBoundsException to the list of exceptions.

* Work on ```javaLangString.go```
     - Filled in the Load_Lang_String map with all of the documented constructors. Source: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html
     - Re-sorted the map entries to be in the same order as the Java String API documentation.
     - Noted as a comment when jacobin and the Java library functions are working well together so that is why jacobin need not implement a replacement.
     - Completed code for ```new String(bytes)``` and ```new String(bytes, offset, length)```.
     - The remaining constructors that we are postponing are directed to the String standard exception handler, ```noSupportYetInString```.
     - Regarding the  remaining member functions (gadzillions), one hopes that enough of them work. Those that don't will probably die in our favourite "lookup2" or maybe some other exciting character set type of function.
    
What did I leave FUBAR?
