### PR TITLE
Progress on JACOBIN386 & JACOBIN-387

### DIFF
--- a/src/classloader/javaIoPrintStream.go
+++ b/src/classloader/javaIoPrintStream.go
@@ -31,13 +31,6 @@ import (
 
 var MethodSignatures = make(map[string]GMeth)
 
-type GMeth struct {
-	ParamSlots int
-	GFunction  function
-}
-
-type function func([]interface{}) interface{}
-
 func Load_Io_PrintStream() map[string]GMeth {
 	MethodSignatures["java/io/PrintStream.println()V"] = // println string
 		GMeth{

--- a/src/classloader/javaLangString.go
+++ b/src/classloader/javaLangString.go
@@ -73,6 +73,7 @@ func Load_Lang_String() map[string]GMeth {
 	MethodSignatures["java/lang/String.<init>([BIILjava/nio/charset/Charset;)V"] =
 		GMeth{
 			ParamSlots: 4,
+			ParamExtra: true,
 			GFunction:  noSupportYetInString,
 		}
 
@@ -123,6 +124,7 @@ func Load_Lang_String() map[string]GMeth {
 	MethodSignatures["java/lang/String.getBytes()[B"] =
 		GMeth{
 			ParamSlots: 0,
+			ParamExtra: true,
 			GFunction:  libs.GetBytesVoid,
 		}
 
@@ -130,6 +132,7 @@ func Load_Lang_String() map[string]GMeth {
 	MethodSignatures["java/lang/String.getBytes(Ljava/lang/String;)[B"] =
 		GMeth{
 			ParamSlots: 1,
+			ParamExtra: true,
 			GFunction:  noSupportYetInString,
 		}
 
@@ -137,6 +140,7 @@ func Load_Lang_String() map[string]GMeth {
 	MethodSignatures["java/lang/String.getBytes(Ljava/nio/charset/Charset;)[B"] =
 		GMeth{
 			ParamSlots: 1,
+			ParamExtra: true,
 			GFunction:  noSupportYetInString,
 		}
 
@@ -162,20 +166,26 @@ func noSupportYetInString([]interface{}) interface{} {
 }
 
 // Given a Go interface parameter from caller, compute the associated Go string.
-func getGoString(param0 interface{}) string {
+func getGoString(myParm interface{}) string {
 	var bptr *[]uint8
-	switch param0.(type) {
+	var str string
+	//fmt.Printf("::::::::::::::::::::::::::: javaLangString/getGoString: myParm is %T\n", myParm)
+	switch myParm.(type) {
 	case *[]uint8:
-		bptr = param0.(*[]uint8)
+		bptr = myParm.(*[]uint8)
+		str = string(*bptr)
+		//fmt.Printf("::::::::::::::::::::::::::: javaLangString/getGoString: extra is *[]uint8, str: %s\n", str)
 	case *object.Object:
-		parmObj := param0.(*object.Object)
+		parmObj := myParm.(*object.Object)
 		bptr = parmObj.Fields[0].Fvalue.(*[]byte)
+		str = string(*bptr)
+		//fmt.Printf("::::::::::::::::::::::::::: javaLangString/getGoString: extra is *object.Object, str:[%s]\n", str)
 	default:
-		errMsg := fmt.Sprintf("In getGoString, unexpected param[0] type = %T", param0)
+		errMsg := fmt.Sprintf("In getGoString, unexpected myParm type=%T, value=%v", myParm, myParm)
 		exceptions.Throw(exceptions.VirtualMachineError, errMsg)
-		bptr = nil
+		str = "RUBBISH!"
 	}
-	return string(*bptr)
+	return str
 }
 
 // Construct a compact string object (usable by Java) from a Go byte array.

--- a/src/classloader/mTable.go
+++ b/src/classloader/mTable.go
@@ -39,12 +39,16 @@ type MTentry struct {
 // MData can be a GmEntry or a JmEntry (method in Go or Java, respectively)
 type MData interface{}
 
-// GmEntry is the entry in the MTable for Go functions. See MTable comments for details.
-// Fu is a go function. All go functions accept a possibly empty slice of interface{} and
-// return a possibly nil interface{}
-type GmEntry struct {
+// GMeth is the entry in the MTable for Go functions. See MTable comments for more details.
+// GFunction is a go function. All go functions accept a possibly empty slice of interface{} and
+// return a possibly nil interface{}.
+// If ParamExtra is true, there is an extra parameter on the stack at entry to runGmethod.
+// By default, ParamExtra is false.
+// deleted: type gfunction func([]interface{}) interface{}
+type GMeth struct {
 	ParamSlots int
-	Fu         func([]interface{}) interface{}
+	ParamExtra bool
+	GFunction  func([]interface{}) interface{}
 }
 
 // JmEntry is the entry in the Mtable for Java methods.
@@ -87,9 +91,10 @@ func MTableLoadNatives() {
 
 func loadlib(tbl *MT, libMeths map[string]GMeth) {
 	for key, val := range libMeths {
-		gme := GmEntry{}
+		gme := GMeth{}
 		gme.ParamSlots = val.ParamSlots
-		gme.Fu = val.GFunction
+		gme.ParamExtra = val.ParamExtra
+		gme.GFunction = val.GFunction
 
 		tableEntry := MTentry{
 			MType: 'G',

--- a/src/jvm/goFunctionExec.go
+++ b/src/jvm/goFunctionExec.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Similar to global tracing but just for this source file.
-var localDebugging bool = true
+var localDebugging bool = false
 
 // This function is called from run(). It executes a frame whose
 // method is a golang method. It copies the parameters from the

--- a/src/jvm/goFunctionExec.go
+++ b/src/jvm/goFunctionExec.go
@@ -12,11 +12,12 @@ import (
 	"fmt"
 	"jacobin/classloader"
 	"jacobin/frames"
-	"jacobin/globals"
 	"jacobin/log"
-	jvmThread "jacobin/thread"
 	"strings"
 )
+
+// Similar to global tracing but just for this source file.
+var localDebugging bool = true
 
 // This function is called from run(). It executes a frame whose
 // method is a golang method. It copies the parameters from the
@@ -26,10 +27,11 @@ import (
 // (which is nil in the case of a void function), where it is placed
 // by run() on the operand stack of the calling function.
 func runGframe(fr *frames.Frame) (interface{}, int, error) {
-	if MainThread.Trace {
-		traceInfo := fmt.Sprintf("runGframe class: %s, methodName: %s",
-			fr.ClName, fr.MethName)
-		_ = log.Log(traceInfo, log.TRACE_INST)
+	if localDebugging || MainThread.Trace {
+		traceInfo := fmt.Sprintf("runGframe class: %s, methodName: %s", fr.ClName, fr.MethName)
+		_ = log.Log(traceInfo, log.WARNING)
+		_ = log.Log("runGframe go frame stack:", log.WARNING)
+		logTraceStack(fr)
 	}
 
 	// get the go method from the MTable
@@ -44,18 +46,19 @@ func runGframe(fr *frames.Frame) (interface{}, int, error) {
 	for _, v := range fr.OpStack {
 		*params = append(*params, v)
 	}
+	//fmt.Printf("runGframe class: %s, methodName: %s, params: %v\n", fr.ClName, fr.MethName, params)
 
 	// pass a pointer to the thread as the last parameter to the function;
 	// from the thread, the frame stack (and the individual frame) become accessible
-	glob := globals.GetGlobalRef()
-	thread := glob.Threads[fr.Thread]
-	if thread != nil { // will be nil only in unit tests
-		threadPtr := thread.(*jvmThread.ExecThread)
-		*params = append(*params, threadPtr)
-	}
+	//glob := globals.GetGlobalRef()
+	//thread := glob.Threads[fr.Thread]
+	//if thread != nil { // will be nil only in unit tests
+	//	threadPtr := thread.(*jvmThread.ExecThread)
+	//	*params = append(*params, threadPtr)
+	//}
 
 	// call the function passing a pointer to the slice of arguments
-	ret := me.Meth.(classloader.GmEntry).Fu(*params)
+	ret := me.Meth.(classloader.GMeth).GFunction(*params)
 
 	// how many slots does the return value consume on the op stack?
 	// the last char in the method name indicates the data type of the return
@@ -81,19 +84,30 @@ func runGframe(fr *frames.Frame) (interface{}, int, error) {
 // the function is run, this method pops the frame off the frame stack and returns.
 func runGmethod(mt classloader.MTentry, fs *list.List, className, methodName, methodType string) (*frames.Frame, error) {
 
-	if MainThread.Trace {
-		traceInfo := fmt.Sprintf("runGmethod class: %s, methodName: %s, methodType: %s",
-			className, methodName, methodType)
-		_ = log.Log(traceInfo, log.TRACE_INST)
-	}
-
 	f := fs.Front().Value.(*frames.Frame)
 
-	// create a frame (gf for 'go frame') for this function
-	paramSlots := mt.Meth.(classloader.GmEntry).ParamSlots
-	gf := frames.CreateFrame(paramSlots)
-	gf.Thread = f.Thread
+	// Extra parameter?
+	paramExtra := mt.Meth.(classloader.GMeth).ParamExtra
 
+	// Get the GMeth paramSlots value.
+	paramSlots := mt.Meth.(classloader.GMeth).ParamSlots
+	if localDebugging || MainThread.Trace {
+		traceInfo := fmt.Sprintf("runGmethod class: %s, methodName: %s, paramExtra: %v, methodType: %s, paramSlots: %d, len(f.OpStack): %d, f.TOS: %d",
+			className, methodName, paramExtra, methodType, paramSlots, len(f.OpStack), f.TOS)
+		_ = log.Log(traceInfo, log.WARNING)
+		logTraceStack(f)
+	}
+
+	// create a frame (gf for 'go frame') for this function
+	var gf *frames.Frame
+	var npops int
+	if paramExtra {
+		npops = paramSlots + 1
+	} else {
+		npops = paramSlots
+	}
+	gf = frames.CreateFrame(npops)
+	gf.Thread = f.Thread
 	gf.MethName = methodName + methodType
 	gf.ClName = className
 	gf.Meth = nil
@@ -103,16 +117,42 @@ func runGmethod(mt classloader.MTentry, fs *list.List, className, methodName, me
 
 	// get the args (if any) from the operand stack of the current frame(f)
 	// then push them onto the stack of the go function
+
 	var argList []interface{}
 
-	for i := 0; i < paramSlots; i++ {
+	// Current frame stack is one of 2 forms:
+	// (1) { pn | ... | p2 | p1 } where TOS --> p1                Note: vast majority of cases
+	// (2) { pn | ... | p2 | p1 | extra } where TOS --> extra     Note: out of the ordinary, like getBytes()
+
+	// For each paramSlot, pop from the current frame and append it to argList.
+	for i := 0; i < npops; i++ {
 		arg := pop(f)
+		if localDebugging || MainThread.Trace {
+			traceInfo := fmt.Sprintf("runGmethod popped arg type=%T, value=%v", arg, arg)
+			_ = log.Log(traceInfo, log.WARNING)
+		}
 		argList = append(argList, arg)
 	}
+
+	// argList now has 2 possible forms:
+	// (1) p1 | p2 | ... | pn
+	// (2) extra | p1 | p2 | ... | pn
+
+	// Push the arguments in reverse order onto the Go frame stack.
+	// If there was an extra parameter, it's at the Go frame stack index 0.
 	for j := len(argList) - 1; j >= 0; j-- {
 		push(gf, argList[j])
 	}
+
+	// Set the Go frame TOS = parent frame TOS.
 	gf.TOS = len(gf.OpStack) - 1
+	if localDebugging || MainThread.Trace {
+		_ = log.Log("runGmethod go frame stack:", log.WARNING)
+		logTraceStack(gf)
+	}
+
+	//**** At this point, the Go frame stack is identical to
+	//*** the parent stack frame at entry to runGmethod (before popping f).
 
 	// push this new frame onto the frame stack for this thread
 	fs.PushFront(gf)                     // push the new frame

--- a/src/libs/javaLangStringMethods.go
+++ b/src/libs/javaLangStringMethods.go
@@ -7,9 +7,9 @@
 package libs
 
 import (
-	"jacobin/frames"
+	"fmt"
+	"jacobin/exceptions"
 	"jacobin/object"
-	"jacobin/thread"
 )
 
 // These are java/lang/String native functions that need to be segregated in libs
@@ -20,11 +20,18 @@ import (
 // get the bytes of a string. To find the string involved, we go to the TOS of the calling
 // stack which has pushed a pointer to the string prior to this call. Returns a pointer to
 // a raw slice of bytes.
+
+// NOTE:
+// * params[0] = extra parameter, the String object
 func GetBytesVoid(params []interface{}) interface{} {
-	threadPtr := params[0].(*thread.ExecThread)
-	frameStack := threadPtr.Stack
-	prevFrame := frameStack.Front().Next().Value.(*frames.Frame)
-	str := prevFrame.OpStack[prevFrame.TOS].(*object.Object)
-	bytes := str.Fields[0].Fvalue.(*[]byte)
-	return bytes
+	switch params[0].(type) {
+	case *object.Object:
+		parmObj := params[0].(*object.Object)
+		bytes := parmObj.Fields[0].Fvalue.(*[]byte)
+		return bytes
+	default:
+		errMsg := fmt.Sprintf("In libs.GetBytesVoid, unexpected params[0] type=%T, value=%v", params[0], params[0])
+		exceptions.Throw(exceptions.VirtualMachineError, errMsg)
+		return nil
+	}
 }


### PR DESCRIPTION
* Implemented local tracing in runGframe and runGmethod to avoid tracing the whole world. So, tracing there will occur with either the local boolean set true (false by default) or through the normal jacobin command line.
* Simplified libs.GetBytesVoid by ensuring that the "extra" parameter (input string) is params[0]. 
* Added checking in libs.GetBytesVoid for a *object.Object type parameter.
* Implemented a new GMeth boolean field "ParamExtra". When set true, this indicates to runGmethod that there is an extra parameter on the stack at entry. Note that by default, ParamExtra is false.
* In the interest of centralisation, I moved the GMeth type definition from javaIoPrintStream.go to mTable.go.
* Note that GMeth and GmEntry are duplicate type definitions. I replaced GmEntry with GMeth in mTable.go and goFunctionExec.go. I favoured GMeth because there are multitudes of GMeth references in classloader files. I also replaced "Fu" by "GFunction".
* Removed the extra thread pointer passed as the last parameter since libs.GetBytesVoid no longer needs it. If I erred in doing so, it can be put back.

The following works a few times but eventually crashes with stack overflow:
```String ss = new String(bytes);```
This needs more work. Why is there stack creep??!!

WARNING: If localDebugging is set true, then some of the unit tests will fail. Yes, I need to look into that too.

Happy Halloween!