### PR TITLE
Centralise GMeth + goFunctionExec.go local tracing

### DIFF
--- a/src/classloader/javaIoPrintStream.go
+++ b/src/classloader/javaIoPrintStream.go
@@ -31,13 +31,6 @@ import (
 
 var MethodSignatures = make(map[string]GMeth)
 
-type GMeth struct {
-	ParamSlots int
-	GFunction  function
-}
-
-type function func([]interface{}) interface{}
-
 func Load_Io_PrintStream() map[string]GMeth {
 	MethodSignatures["java/io/PrintStream.println()V"] = // println string
 		GMeth{

--- a/src/classloader/mTable.go
+++ b/src/classloader/mTable.go
@@ -36,15 +36,15 @@ type MTentry struct {
 	MType byte  // method type, G = Go method, J = Java method
 }
 
-// MData can be a GmEntry or a JmEntry (method in Go or Java, respectively)
+// MData can be a GMeth or a JmEntry (method in Go or Java, respectively)
 type MData interface{}
 
-// GmEntry is the entry in the MTable for Go functions. See MTable comments for details.
+// GMeth is the entry in the MTable for Go functions. See MTable comments for details.
 // Fu is a go function. All go functions accept a possibly empty slice of interface{} and
 // return a possibly nil interface{}
-type GmEntry struct {
+type GMeth struct {
 	ParamSlots int
-	Fu         func([]interface{}) interface{}
+	GFunction  func([]interface{}) interface{}
 }
 
 // JmEntry is the entry in the Mtable for Java methods.
@@ -87,9 +87,9 @@ func MTableLoadNatives() {
 
 func loadlib(tbl *MT, libMeths map[string]GMeth) {
 	for key, val := range libMeths {
-		gme := GmEntry{}
+		gme := GMeth{}
 		gme.ParamSlots = val.ParamSlots
-		gme.Fu = val.GFunction
+		gme.GFunction = val.GFunction
 
 		tableEntry := MTentry{
 			MType: 'G',

--- a/src/jvm/goFunctionExec.go
+++ b/src/jvm/goFunctionExec.go
@@ -18,6 +18,9 @@ import (
 	"strings"
 )
 
+// Similar to global tracing but just for this source file.
+var localDebugging bool = false
+
 // This function is called from run(). It executes a frame whose
 // method is a golang method. It copies the parameters from the
 // operand stack and passes them to the go function, here called Fu,
@@ -26,10 +29,12 @@ import (
 // (which is nil in the case of a void function), where it is placed
 // by run() on the operand stack of the calling function.
 func runGframe(fr *frames.Frame) (interface{}, int, error) {
-	if MainThread.Trace {
-		traceInfo := fmt.Sprintf("runGframe class: %s, methodName: %s",
-			fr.ClName, fr.MethName)
-		_ = log.Log(traceInfo, log.TRACE_INST)
+
+	if localDebugging || MainThread.Trace {
+		traceInfo := fmt.Sprintf("runGframe class: %s, methodName: %s", fr.ClName, fr.MethName)
+		_ = log.Log(traceInfo, log.WARNING)
+		_ = log.Log("runGframe go frame stack:", log.WARNING)
+		logTraceStack(fr)
 	}
 
 	// get the go method from the MTable
@@ -81,16 +86,17 @@ func runGframe(fr *frames.Frame) (interface{}, int, error) {
 // the function is run, this method pops the frame off the frame stack and returns.
 func runGmethod(mt classloader.MTentry, fs *list.List, className, methodName, methodType string) (*frames.Frame, error) {
 
-	if MainThread.Trace {
-		traceInfo := fmt.Sprintf("runGmethod class: %s, methodName: %s, methodType: %s",
-			className, methodName, methodType)
-		_ = log.Log(traceInfo, log.TRACE_INST)
-	}
-
+	paramSlots := mt.Meth.(classloader.GMeth).ParamSlots
 	f := fs.Front().Value.(*frames.Frame)
 
+	if localDebugging || MainThread.Trace {
+		traceInfo := fmt.Sprintf("runGmethod class: %s, methodName: %s, methodType: %s, paramSlots: %d, len(f.OpStack): %d, f.TOS: %d",
+			className, methodName, methodType, paramSlots, len(f.OpStack), f.TOS)
+		_ = log.Log(traceInfo, log.WARNING)
+		logTraceStack(f)
+	}
+
 	// create a frame (gf for 'go frame') for this function
-	paramSlots := mt.Meth.(classloader.GMeth).ParamSlots
 	gf := frames.CreateFrame(paramSlots)
 	gf.Thread = f.Thread
 
@@ -107,12 +113,20 @@ func runGmethod(mt classloader.MTentry, fs *list.List, className, methodName, me
 
 	for i := 0; i < paramSlots; i++ {
 		arg := pop(f)
+		if localDebugging || MainThread.Trace {
+			traceInfo := fmt.Sprintf("runGmethod popped arg type=%T, value=%v", arg, arg)
+			_ = log.Log(traceInfo, log.WARNING)
+		}
 		argList = append(argList, arg)
 	}
 	for j := len(argList) - 1; j >= 0; j-- {
 		push(gf, argList[j])
 	}
 	gf.TOS = len(gf.OpStack) - 1
+	if localDebugging || MainThread.Trace {
+		_ = log.Log("runGmethod go frame stack:", log.WARNING)
+		logTraceStack(gf)
+	}
 
 	// push this new frame onto the frame stack for this thread
 	fs.PushFront(gf)                     // push the new frame

--- a/src/jvm/goFunctionExec.go
+++ b/src/jvm/goFunctionExec.go
@@ -55,7 +55,7 @@ func runGframe(fr *frames.Frame) (interface{}, int, error) {
 	}
 
 	// call the function passing a pointer to the slice of arguments
-	ret := me.Meth.(classloader.GmEntry).Fu(*params)
+	ret := me.Meth.(classloader.GMeth).GFunction(*params)
 
 	// how many slots does the return value consume on the op stack?
 	// the last char in the method name indicates the data type of the return
@@ -90,7 +90,7 @@ func runGmethod(mt classloader.MTentry, fs *list.List, className, methodName, me
 	f := fs.Front().Value.(*frames.Frame)
 
 	// create a frame (gf for 'go frame') for this function
-	paramSlots := mt.Meth.(classloader.GmEntry).ParamSlots
+	paramSlots := mt.Meth.(classloader.GMeth).ParamSlots
 	gf := frames.CreateFrame(paramSlots)
 	gf.Thread = f.Thread
 


### PR DESCRIPTION
Re: JACOBIN-387

**classloader/javaIoPrintStream.go and mTable.go**

- GMeth is used in several classloader source files.
-  So, I moved the GMeth type definition from javaIoPrintStream.go (one of the users) to mTable.go which I perceive as a central-ish definition file for classloader.

**classloader/mTable.go, jvm/goFunctionExec.go**

- After I did the move, I saw that GMeth and GmEntry are duplicate type definitions.
- I replaced GmEntry with GMeth in mTable.go and goFunctionExec.go. I favored GMeth because there are many GMeth references in classloader files.
-  I also replaced "Fu" references by "GFunction".

**jvm/goFunctionExec.go**

Implemented a local tracing boolean (localDebugging) in runGframe and runGmethod to avoid tracing the whole world. So, tracing in both functions will occur when either the local boolean set true (false by default) or through the normal jacobin command line. Note that currently, some of the unit tests fail when localDebugging is true. Hmmmm.
