### PR TITLE
contribution to JACOBIN-395

### DIFF
--- a/src/object/object_test.go
+++ b/src/object/object_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestObjectToString1(t *testing.T) {
+	t.Log("Test field table toString processing")
 	obj := MakeEmptyObject()
 	klassType := filepath.FromSlash("java/lang/madeUpClass")
 	obj.Klass = &klassType
@@ -84,7 +85,9 @@ func TestObjectToString1(t *testing.T) {
 	}
 }
 
+// Test field slice toString processing
 func TestObjectToString2(t *testing.T) {
+	t.Log("Test field slice toString processing")
 	literal := "This is a compact string from a Go string"
 	csObj := CreateCompactStringFromGoString(&literal)
 	retStr := csObj.ToString()

--- a/src/object/object_test.go
+++ b/src/object/object_test.go
@@ -7,19 +7,44 @@
 package object
 
 import (
-	"fmt"
+	"path/filepath"
 	"testing"
 )
 
 func TestObjectToString1(t *testing.T) {
 	obj := MakeEmptyObject()
-	klassType := "java\\lang\\madeUpClass"
+	klassType := filepath.FromSlash("java/lang/madeUpClass")
 	obj.Klass = &klassType
+
+	myFloatField := Field{
+		Ftype:  "F",
+		Fvalue: 1.0,
+	}
+	obj.FieldTable["myFloat"] = &myFloatField
+
+	myDoubleField := Field{
+		Ftype:  "D",
+		Fvalue: 2.0,
+	}
+	obj.FieldTable["myDouble"] = &myDoubleField
+
 	myIntField := Field{
 		Ftype:  "I",
 		Fvalue: 42,
 	}
 	obj.FieldTable["myInt"] = &myIntField
+
+	myLongField := Field{
+		Ftype:  "J",
+		Fvalue: 42,
+	}
+	obj.FieldTable["myLong"] = &myLongField
+
+	myShortField := Field{
+		Ftype:  "S",
+		Fvalue: 42,
+	}
+	obj.FieldTable["myShort"] = &myShortField
 
 	myByteField := Field{
 		Ftype:  "B",
@@ -27,9 +52,27 @@ func TestObjectToString1(t *testing.T) {
 	}
 	obj.FieldTable["myByte"] = &myByteField
 
+	myStaticTrueField := Field{
+		Ftype:  "XZ",
+		Fvalue: true,
+	}
+	obj.FieldTable["myStaticTrue"] = &myStaticTrueField
+
+	myFalseField := Field{
+		Ftype:  "Z",
+		Fvalue: false,
+	}
+	obj.FieldTable["myFalse"] = &myFalseField
+
+	myCharField := Field{
+		Ftype:  "C",
+		Fvalue: 'C',
+	}
+	obj.FieldTable["myChar"] = &myCharField
+
 	myStringField := Field{
 		Ftype:  "Ljava/lang/String;",
-		Fvalue: "Hello, Richard",
+		Fvalue: "Hello, Unka Andoo !",
 	}
 	obj.FieldTable["myString"] = &myStringField
 
@@ -37,18 +80,95 @@ func TestObjectToString1(t *testing.T) {
 	if len(str) == 0 {
 		t.Errorf("empty string for object.ToString()")
 	} else {
-		fmt.Println(str)
+		t.Log(str)
 	}
 }
 
 func TestObjectToString2(t *testing.T) {
-	literal := "Hello, Jacobin!"
-	str := CreateCompactStringFromGoString(&literal)
-
-	retStr := str.ToString()
+	literal := "This is a compact string from a Go string"
+	csObj := CreateCompactStringFromGoString(&literal)
+	retStr := csObj.ToString()
 	if len(retStr) == 0 {
 		t.Errorf("empty string for object.ToString()")
 	} else {
-		fmt.Println(retStr)
+		t.Log(retStr)
 	}
+
+	// Create a custom object.
+	obj := MakeEmptyObject()
+	klassType := filepath.FromSlash("java/lang/madeUpClass")
+	obj.Klass = &klassType
+
+	// Now, dump the same string as a byte array.
+	csObj.Klass = &klassType
+	retStr = csObj.ToString()
+	if len(retStr) == 0 {
+		t.Errorf("empty string for object.ToString()")
+	} else {
+		t.Log(retStr)
+	}
+
+	myFloatField := Field{
+		Ftype:  "F",
+		Fvalue: 1.0,
+	}
+	obj.Fields = append(obj.Fields, myFloatField)
+	t.Log(obj.ToString())
+
+	myDoubleField := Field{
+		Ftype:  "D",
+		Fvalue: 2.0,
+	}
+	obj.Fields[0] = myDoubleField
+	t.Log(obj.ToString())
+
+	myIntField := Field{
+		Ftype:  "I",
+		Fvalue: 42,
+	}
+	obj.Fields[0] = myIntField
+	t.Log(obj.ToString())
+
+	myLongField := Field{
+		Ftype:  "J",
+		Fvalue: 42,
+	}
+	obj.Fields[0] = myLongField
+	t.Log(obj.ToString())
+
+	myShortField := Field{
+		Ftype:  "S",
+		Fvalue: 42,
+	}
+	obj.Fields[0] = myShortField
+	t.Log(obj.ToString())
+
+	myByteField := Field{
+		Ftype:  "B",
+		Fvalue: 0x61,
+	}
+	obj.Fields[0] = myByteField
+	t.Log(obj.ToString())
+
+	myStaticTrueField := Field{
+		Ftype:  "XZ",
+		Fvalue: true,
+	}
+	obj.Fields[0] = myStaticTrueField
+	t.Log(obj.ToString())
+
+	myFalseField := Field{
+		Ftype:  "Z",
+		Fvalue: false,
+	}
+	obj.Fields[0] = myFalseField
+	t.Log(obj.ToString())
+
+	myCharField := Field{
+		Ftype:  "C",
+		Fvalue: 'C',
+	}
+	obj.Fields[0] = myCharField
+	t.Log(obj.ToString())
+
 }


### PR DESCRIPTION
Files affected:
- object/object.go
- object/object_test.go

Sample console output:
```
=== RUN   TestObjectToString1
    object_test.go:15: Test field table toString processing
    object_test.go:84: java/lang/madeUpClass
        	Fld: myString: (Ljava/lang/String;) Hello, Unka Andoo !
        	Fld: myFloat: (F) 1.000000
        	Fld: myStaticTrue: (XZ) true
        	Fld: myFalse: (Z) false
        	Fld: myChar: (C) 'C'
        	Fld: myByte: (B) 61
        	Fld: myDouble: (D) 2.000000
        	Fld: myInt: (I) 42
        	Fld: myLong: (J) 42
        	Fld: myShort: (S) 42
        
--- PASS: TestObjectToString1 (0.00s)

=== RUN   TestObjectToString2
    object_test.go:90: Test field slice toString processing
    object_test.go:97: java/lang/String
        	Fld:([B) This is a compact string from a Go string
    object_test.go:111: java/lang/madeUpClass
        	Fld:([B) 54 68 69 73 20 69 73 20 61 20 63 6f 6d 70 61 63 74 20 73 74 72 69 6e 67 20 66 72 6f 6d 20 61 20 47 6f 20 73 74 72 69 6e 67
    object_test.go:119: java/lang/madeUpClass
        	Fld:(F) 1.000000
    object_test.go:126: java/lang/madeUpClass
        	Fld:(D) 2.000000
    object_test.go:133: java/lang/madeUpClass
        	Fld:(I) 42
    object_test.go:140: java/lang/madeUpClass
        	Fld:(J) 42
    object_test.go:147: java/lang/madeUpClass
        	Fld:(S) 42
    object_test.go:154: java/lang/madeUpClass
        	Fld:(B) 61
    object_test.go:161: java/lang/madeUpClass
        	Fld:(XZ) true
    object_test.go:168: java/lang/madeUpClass
        	Fld:(Z) false
    object_test.go:175: java/lang/madeUpClass
        	Fld:(C) 'C'
--- PASS: TestObjectToString2 (0.00s)
```

If the FieldTable length > 0, then a single string containing one substring for each table entry is generated. Each substring is terminated by \n. The entire multi-line string is returned to caller.

Otherwise (Fields slice processing), only Fields[0] is processed. A single string output without a \n character is generated and returned to caller.

If the object klass string is "java/lang/String" (Ftype = "[B"), then the string format of output is used.
Note that individual bytes (Ftype = "B") and elements of non-string byte arrays (Ftype = "[B") are dumped in hex.
