### PR TITLE
JACOBIN-396 Fix PrintS to support 2 input types

### DIFF
--- a/src/classloader/javaIoPrintStream.go
+++ b/src/classloader/javaIoPrintStream.go
@@ -223,11 +223,10 @@ func PrintDouble(l []interface{}) interface{} {
 
 // Print string
 func PrintS(i []interface{}) interface{} {
-	strAddr := i[1].(*object.Object)
+	str := i[1].(string)
 	// eventually will need to check wherther it's a compact string.
 	// Presently, we assume it is.
-	t := (strAddr.Fields[0].Fvalue).(*[]byte)
-	fmt.Print(string(*t))
+	fmt.Print(str)
 	return nil
 }
 

--- a/src/classloader/javaIoPrintStream.go
+++ b/src/classloader/javaIoPrintStream.go
@@ -223,10 +223,17 @@ func PrintDouble(l []interface{}) interface{} {
 
 // Print string
 func PrintS(i []interface{}) interface{} {
-	str := i[1].(string)
-	// eventually will need to check wherther it's a compact string.
-	// Presently, we assume it is.
-	fmt.Print(str)
+	// TODO: Eventually will need to check whether or not i[1] is a compact string.
+	//       Presently, we assume it is.
+	switch i[1].(type) {
+	case *object.Object:
+		strAddr := i[1].(*object.Object)
+		t := (strAddr.Fields[0].Fvalue).(*[]byte)
+		fmt.Print(string(*t))
+	case string:
+		str := i[1].(string)
+		fmt.Print(str)
+	}
 	return nil
 }
 


### PR DESCRIPTION
```
// Print string
func PrintS(i []interface{}) interface{} {
	// TODO: Eventually will need to check whether or not i[1] is a compact string.
	//       Presently, we assume it is.
	switch i[1].(type) {
	case *object.Object:
		strAddr := i[1].(*object.Object)
		t := (strAddr.Fields[0].Fvalue).(*[]byte)
		fmt.Print(string(*t))
	case string:
		str := i[1].(string)
		fmt.Print(str)
	}
	return nil
}

```