### PR TITLE
JACOBIN-396, only 1 PrintS interface

### DIFF
--- a/src/classloader/javaIoPrintStream.go
+++ b/src/classloader/javaIoPrintStream.go
@@ -225,15 +225,10 @@ func PrintDouble(l []interface{}) interface{} {
 func PrintS(i []interface{}) interface{} {
 	// TODO: Eventually will need to check whether or not i[1] is a compact string.
 	//       Presently, we assume it is.
-	switch i[1].(type) {
-	case *object.Object:
-		strAddr := i[1].(*object.Object)
-		t := (strAddr.Fields[0].Fvalue).(*[]byte)
-		fmt.Print(string(*t))
-	case string:
-		str := i[1].(string)
-		fmt.Print(str)
-	}
+	// fmt.Printf("DEBUG PrintS got an Object\n")
+	strAddr := i[1].(*object.Object)
+	t := (strAddr.Fields[0].Fvalue).(*[]byte)
+	fmt.Print(string(*t))
 	return nil
 }
 
@@ -242,7 +237,8 @@ func Printf(params []interface{}) interface{} {
 	var intfSprintf = new([]interface{})
 	*intfSprintf = append(*intfSprintf, params[1])
 	*intfSprintf = append(*intfSprintf, params[2])
-	str := StringFormatter(*intfSprintf)
+	objPtr := StringFormatter(*intfSprintf)
+	str := object.GetGoStringFromJavaStringPtr(objPtr)
 	fmt.Print(str)
 	return params[0] // Return the PrintStream object
 

--- a/src/classloader/javaLangString.go
+++ b/src/classloader/javaLangString.go
@@ -275,7 +275,7 @@ func sprintf(params []interface{}) interface{} {
 	return StringFormatter(params)
 }
 
-func StringFormatter(params []interface{}) string {
+func StringFormatter(params []interface{}) *object.Object {
 	lenParams := len(params)
 	if lenParams < 1 || lenParams > 2 {
 		errMsg := fmt.Sprintf("StringFormatter: Invalid parameter count: %d", lenParams)
@@ -283,8 +283,7 @@ func StringFormatter(params []interface{}) string {
 	}
 	if lenParams == 1 { // No parameters beyond the format string
 		formatStringObj := params[1].(*object.Object) // the format string is passed as a pointer to a string object
-		formatString := object.GetGoStringFromJavaStringPtr(formatStringObj)
-		return formatString
+		return formatStringObj
 	}
 	formatStringObj := params[0].(*object.Object) // the format string is passed as a pointer to a string object
 	formatString := object.GetGoStringFromJavaStringPtr(formatStringObj)
@@ -316,6 +315,9 @@ func StringFormatter(params []interface{}) string {
 
 	}
 
-	return fmt.Sprintf(formatString, valuesOut...)
+	// Use golang fmt.Sprintf to do the heavy lifting.
+	str := fmt.Sprintf(formatString, valuesOut...)
 
+	// Return a pointer to an object.Object that wraps the string byte array.
+	return object.CreateCompactStringFromGoString(&str)
 }


### PR DESCRIPTION
After playing wack-a-mole this morning, I finally came down to the conclusion that there is only 1 type of interface that PrintS need entertain: *object.Object.

The issues overcome:
* StringFormatter in javaLangString.go was returning a Go string. This contradicts other String variables which are initialized or receive their value in some other way. The correct type to return from StringFormatter is *object.Object. 
* PrintS has been corrected to only look for an *object.Object interface.
* My Java language test driver previously did not have enough individual cases. Now, it has more!