### PR TITLE
JACOBIN-393 StringFormatter: handle primitives (int, short, etc.)

### DIFF
--- a/src/classloader/javaLangString.go
+++ b/src/classloader/javaLangString.go
@@ -316,7 +316,12 @@ func StringFormatter(params []interface{}) *object.Object {
 			case types.Byte:
 				valuesOut = append(valuesOut, fvalue.(int64))
 			case types.Bool:
-				valuesOut = append(valuesOut, fvalue.(bool))
+				fmt.Printf("DEBUG %T %v\n", fvalue, fvalue)
+				if fvalue.(int64) == 0 {
+					valuesOut = append(valuesOut, false)
+				} else {
+					valuesOut = append(valuesOut, true)
+				}
 			case types.Char:
 				valuesOut = append(valuesOut, fvalue.(int64))
 			case types.Double:

--- a/src/classloader/javaLangString.go
+++ b/src/classloader/javaLangString.go
@@ -297,20 +297,43 @@ func StringFormatter(params []interface{}) *object.Object {
 			valuesOut = append(valuesOut, object.GetGoStringFromJavaStringPtr(valuesIn[i]))
 			//fmt.Printf("DEBUG got a string: %s\n", object.GetGoStringFromJavaStringPtr(valuesIn[i]))
 		} else {
-			switch valuesIn[i].Fields[0].Ftype {
+			//str := valuesIn[i].ToString(10)
+			//fmt.Printf("DEBUG StringFormatter valuesIn[%d] ToString:\n%s", i, str)
+
+			// Establish a pointer to the field.
+			var fldPtr *object.Field
+			if len(valuesIn[i].FieldTable) > 0 { // using FieldTable
+				fldPtr = valuesIn[i].FieldTable["value"]
+			} else { // using Fields slice
+				fldPtr = &valuesIn[i].Fields[0]
+			}
+
+			// Get the field value.
+			fvalue := (*fldPtr).Fvalue
+
+			// Process depending on field type
+			switch (*fldPtr).Ftype {
 			case types.Byte:
+				valuesOut = append(valuesOut, fvalue.(int64))
 			case types.Bool:
+				valuesOut = append(valuesOut, fvalue.(bool))
 			case types.Char:
+				valuesOut = append(valuesOut, fvalue.(int64))
 			case types.Double:
+				valuesOut = append(valuesOut, fvalue.(float64))
 			case types.Float:
+				valuesOut = append(valuesOut, fvalue.(float64))
 			case types.Int:
+				valuesOut = append(valuesOut, fvalue.(int64))
 			case types.Long:
+				valuesOut = append(valuesOut, fvalue.(int64))
 			case types.Short:
+				valuesOut = append(valuesOut, fvalue.(int64))
 			default:
 				errMsg := fmt.Sprintf("StringFormatter: Invalid parameter %d type %s", i+1, valuesIn[i].Fields[0].Ftype)
 				exceptions.Throw(exceptions.IllegalClassFormatException, errMsg)
 			}
-			valuesOut = append(valuesOut, valuesIn[i].Fields[0].Fvalue.(int64))
+
 		}
 
 	}

--- a/src/classloader/javaPrimitives.go
+++ b/src/classloader/javaPrimitives.go
@@ -1,0 +1,108 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2023 by the Jacobin authors. All rights reserved.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)
+ */
+
+package classloader
+
+import (
+	"jacobin/object"
+	"jacobin/types"
+)
+
+// Implementation of some of the functions in in Java/lang/Class.
+
+func Load_Primitives() map[string]GMeth {
+
+	MethodSignatures["java/lang/Byte.valueOf(B)Ljava/lang/Byte;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  byteValueOf,
+		}
+
+	MethodSignatures["java/lang/Character.valueOf(C)Ljava/lang/Character;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  characterValueOf,
+		}
+
+	MethodSignatures["java/lang/Integer.valueOf(I)Ljava/lang/Integer;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  integerValueOf,
+		}
+
+	MethodSignatures["java/lang/Long.valueOf(J)Ljava/lang/Long;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  longValueOf,
+		}
+
+	MethodSignatures["java/lang/Short.valueOf(S)Ljava/lang/Short;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  shortValueOf,
+		}
+
+	MethodSignatures["java/lang/Boolean.valueOf(Z)Ljava/lang/Boolean;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  booleanValueOf,
+		}
+
+	MethodSignatures["java/lang/Boolean.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  booleanJustReturn,
+		}
+
+	return MethodSignatures
+}
+
+func makePrimitiveObject(klass string, ftype string, arg any) *object.Object {
+	objPtr := object.MakeEmptyObject()
+	(*objPtr).Klass = &klass
+	(*objPtr).Fields = append((*objPtr).Fields, object.Field{Ftype: ftype, Fvalue: arg})
+	return objPtr
+}
+
+func byteValueOf(params []interface{}) interface{} {
+	bb := params[0].(int64)
+	objPtr := makePrimitiveObject("java/lang/Byte", types.Byte, bb)
+	return objPtr
+}
+
+func characterValueOf(params []interface{}) interface{} {
+	cc := params[0].(int64)
+	objPtr := makePrimitiveObject("java/lang/Character", types.Char, cc)
+	return objPtr
+}
+
+func integerValueOf(params []interface{}) interface{} {
+	ii := params[0].(int64)
+	objPtr := makePrimitiveObject("java/lang/Integer", types.Int, ii)
+	return objPtr
+}
+
+func longValueOf(params []interface{}) interface{} {
+	jj := params[0].(int64)
+	objPtr := makePrimitiveObject("java/lang/Long", types.Long, jj)
+	return objPtr
+}
+
+func shortValueOf(params []interface{}) interface{} {
+	ss := params[0].(int64)
+	objPtr := makePrimitiveObject("java/lang/Short", types.Short, ss)
+	return objPtr
+}
+
+func booleanValueOf(params []interface{}) interface{} {
+	zz := params[0].(int64)
+	objPtr := makePrimitiveObject("java/lang/Boolean", types.Bool, zz)
+	return objPtr
+}
+
+func booleanJustReturn(params []interface{}) interface{} {
+	return nil
+}

--- a/src/classloader/mTable.go
+++ b/src/classloader/mTable.go
@@ -84,6 +84,7 @@ func MTableLoadNatives() {
 	loadlib(&MTable, Load_Lang_Throwable()) // load the java.lang.Throwable golang functions (errors & exceptions)
 	loadlib(&MTable, Load_Lang_UTF16())     // load the java.lang.UTF16 golang functions
 	loadlib(&MTable, Load_Util_HashMap())   // load the java.util.HashMap golang functions
+	loadlib(&MTable, Load_Primitives())     // load the Java primitives golang functions
 }
 
 func loadlib(tbl *MT, libMeths map[string]GMeth) {

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -2637,6 +2637,9 @@ func emitTraceData(f *frames.Frame) string {
 			if f.OpStack[f.TOS].(*object.Object) == object.Null {
 				stackTop = fmt.Sprintf("null")
 			} else {
+				objPtr := f.OpStack[f.TOS].(*object.Object)
+				stackTop = objPtr.ToString(50)
+				/***
 				obj := *(f.OpStack[f.TOS].(*object.Object))
 				if obj.Fields != nil && len(obj.Fields) > 0 {
 					if obj.Fields != nil && obj.Fields[0].Ftype == types.ByteArray { // if it's a string, just show the string
@@ -2653,6 +2656,7 @@ func emitTraceData(f *frames.Frame) string {
 				} else {
 					stackTop = "obj.Field[]"
 				}
+				***/
 			}
 		case *[]uint8:
 			value := f.OpStack[f.TOS]

--- a/src/object/object.go
+++ b/src/object/object.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"jacobin/types"
 	"path/filepath"
+	"strings"
 	"unsafe"
 )
 
@@ -87,7 +88,7 @@ func toStringHelper(klassString string, field Field) string {
 }
 
 // ToString dumps the contents of an object to a formatted multi-line string
-func (objPtr *Object) ToString() string {
+func (objPtr *Object) ToString(indent int) string {
 	var str string
 	obj := *objPtr
 	klassString := *obj.Klass
@@ -99,12 +100,18 @@ func (objPtr *Object) ToString() string {
 
 	if len(obj.FieldTable) > 0 {
 		for key := range obj.FieldTable {
+			if indent > 0 {
+				str += strings.Repeat(" ", indent)
+			}
 			str += fmt.Sprintf("\tFld: %s: (%s) %s\n", key, obj.FieldTable[key].Ftype, toStringHelper(klassString, *obj.FieldTable[key]))
 		}
 	} else {
 		//for i, field := range obj.Fields {
 		//	str += fmt.Sprintf("\tFld: %02d: (%s) %s\n", i, field.Ftype, toStringHelper(field))
 		//}
+		if indent > 0 {
+			str += strings.Repeat(" ", indent)
+		}
 		str += fmt.Sprintf("\tFld:(%s) %s", obj.Fields[0].Ftype, toStringHelper(klassString, obj.Fields[0]))
 	}
 

--- a/src/object/object_test.go
+++ b/src/object/object_test.go
@@ -77,7 +77,7 @@ func TestObjectToString1(t *testing.T) {
 	}
 	obj.FieldTable["myString"] = &myStringField
 
-	str := obj.ToString()
+	str := obj.ToString(42)
 	if len(str) == 0 {
 		t.Errorf("empty string for object.ToString()")
 	} else {
@@ -90,7 +90,7 @@ func TestObjectToString2(t *testing.T) {
 	t.Log("Test field slice toString processing")
 	literal := "This is a compact string from a Go string"
 	csObj := CreateCompactStringFromGoString(&literal)
-	retStr := csObj.ToString()
+	retStr := csObj.ToString(0)
 	if len(retStr) == 0 {
 		t.Errorf("empty string for object.ToString()")
 	} else {
@@ -104,7 +104,7 @@ func TestObjectToString2(t *testing.T) {
 
 	// Now, dump the same string as a byte array.
 	csObj.Klass = &klassType
-	retStr = csObj.ToString()
+	retStr = csObj.ToString(0)
 	if len(retStr) == 0 {
 		t.Errorf("empty string for object.ToString()")
 	} else {
@@ -116,62 +116,62 @@ func TestObjectToString2(t *testing.T) {
 		Fvalue: 1.0,
 	}
 	obj.Fields = append(obj.Fields, myFloatField)
-	t.Log(obj.ToString())
+	t.Log(obj.ToString(0))
 
 	myDoubleField := Field{
 		Ftype:  "D",
 		Fvalue: 2.0,
 	}
 	obj.Fields[0] = myDoubleField
-	t.Log(obj.ToString())
+	t.Log(obj.ToString(0))
 
 	myIntField := Field{
 		Ftype:  "I",
 		Fvalue: 42,
 	}
 	obj.Fields[0] = myIntField
-	t.Log(obj.ToString())
+	t.Log(obj.ToString(0))
 
 	myLongField := Field{
 		Ftype:  "J",
 		Fvalue: 42,
 	}
 	obj.Fields[0] = myLongField
-	t.Log(obj.ToString())
+	t.Log(obj.ToString(0))
 
 	myShortField := Field{
 		Ftype:  "S",
 		Fvalue: 42,
 	}
 	obj.Fields[0] = myShortField
-	t.Log(obj.ToString())
+	t.Log(obj.ToString(0))
 
 	myByteField := Field{
 		Ftype:  "B",
 		Fvalue: 0x61,
 	}
 	obj.Fields[0] = myByteField
-	t.Log(obj.ToString())
+	t.Log(obj.ToString(0))
 
 	myStaticTrueField := Field{
 		Ftype:  "XZ",
 		Fvalue: true,
 	}
 	obj.Fields[0] = myStaticTrueField
-	t.Log(obj.ToString())
+	t.Log(obj.ToString(0))
 
 	myFalseField := Field{
 		Ftype:  "Z",
 		Fvalue: false,
 	}
 	obj.Fields[0] = myFalseField
-	t.Log(obj.ToString())
+	t.Log(obj.ToString(0))
 
 	myCharField := Field{
 		Ftype:  "C",
 		Fvalue: 'C',
 	}
 	obj.Fields[0] = myCharField
-	t.Log(obj.ToString())
+	t.Log(obj.ToString(0))
 
 }


### PR DESCRIPTION
Whichever is there, use it, preferring FieldTable. 
E.g.
```double dd = 3.0d;```
uses the FieldTable where the key="value" table entry holds the double floating-point value (3.0 in this example).

**Summary**  

All primitives are working as expected.

**Exceptions**

- Inside the format string, %% is not recognized as meaning one % character.
- Inside the format string, %n is not recognized as meaning one \n character.
- %b and %B will not work for booleans. One has to specify %t or %v. No option to capitalize oboolean output.

**Use of object.ToString**

I incorporated object.ToString into the run.go emitTraceData function.
Note the new indentation parameter.
Reaction?
