### PR TITLE
tracing issues, object issues

### DIFF
--- a/src/classloader/javaLangString.go
+++ b/src/classloader/javaLangString.go
@@ -316,12 +316,14 @@ func StringFormatter(params []interface{}) *object.Object {
 			case types.Byte:
 				valuesOut = append(valuesOut, fvalue.(int64))
 			case types.Bool:
-				fmt.Printf("DEBUG %T %v\n", fvalue, fvalue)
+				//fmt.Printf("DEBUG %T %v\n", fvalue, fvalue)
+				var zz bool
 				if fvalue.(int64) == 0 {
-					valuesOut = append(valuesOut, false)
+					zz = false
 				} else {
-					valuesOut = append(valuesOut, true)
+					zz = true
 				}
+				valuesOut = append(valuesOut, zz)
 			case types.Char:
 				valuesOut = append(valuesOut, fvalue.(int64))
 			case types.Double:

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -2634,7 +2634,7 @@ func emitTraceData(f *frames.Frame) string {
 		switch f.OpStack[f.TOS].(type) {
 		// if the value at TOS is a string, say so and print the first 10 chars of the string
 		case *object.Object:
-			if f.OpStack[f.TOS].(*object.Object) == object.Null {
+			if object.IsNull(f.OpStack[f.TOS].(*object.Object)) {
 				stackTop = fmt.Sprintf("null")
 			} else {
 				objPtr := f.OpStack[f.TOS].(*object.Object)

--- a/src/object/object.go
+++ b/src/object/object.go
@@ -90,11 +90,13 @@ func toStringHelper(klassString string, field Field) string {
 // ToString dumps the contents of an object to a formatted multi-line string
 func (objPtr *Object) ToString(indent int) string {
 	var str string
+	var klassString string
 	obj := *objPtr
-	klassString := *obj.Klass
 	if obj.Klass != nil {
+		klassString = *obj.Klass
 		str = klassString + "\n"
 	} else {
+		klassString = "n/a"
 		str = "class type: n/a \n"
 	}
 
@@ -112,7 +114,12 @@ func (objPtr *Object) ToString(indent int) string {
 		if indent > 0 {
 			str += strings.Repeat(" ", indent)
 		}
-		str += fmt.Sprintf("\tFld:(%s) %s", obj.Fields[0].Ftype, toStringHelper(klassString, obj.Fields[0]))
+		if len(obj.Fields) > 0 {
+			str += fmt.Sprintf("\tFld:(%s) %s", obj.Fields[0].Ftype, toStringHelper(klassString, obj.Fields[0]))
+		} else {
+			str += "\tFld:EMPTY!!!"
+		}
+
 	}
 
 	return str


### PR DESCRIPTION
* ```classloader/javaLangString.go``` - Commented out a left-over DEBUG printf.
* ```jvm/run.go``` - use the object.IsNull function which checks for 2 possible nil conditions.
* ```object/object.go``` - guard against (a) nil klass pointer and (b) object which has no field information in FieldTable nor in the Fields slice.

In tracing jacotest case ```stringer-2```, it was observed that under some string-handling circumstances, both of the above object anomalies occured. Needs further analysis as to why.