### PR TITLE
Go 1.21.4

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.21.4'
       
     - name: Setup JDK
       uses: actions/setup-java@v3
@@ -59,7 +59,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.21.4'
       
     - name: Setup JDK
       uses: actions/setup-java@v3

--- a/src/go.mod
+++ b/src/go.mod
@@ -5,4 +5,7 @@ module jacobin
 // go 1.20  // as of 25-iii-2023 -- upgraded to 1.21 per JACOBIN-330
 //
 // as of 11-viii-2023 (v. 0.4.0):
-go 1.21
+// go 1.21
+//
+// as of 2023-11-08
+go 1.21.4


### PR DESCRIPTION
Impacted files:
* src/go.mod
* .github/workflows/go.yml (2 places in the file)

@platypusguy 
Note that your local machine Go is already up-to-date with this Go stable version release due to updating jacotest.go.
In the future, we should coordinate them together.