### PR TITLE
object protect field pointers against nil; use string quotes

### DIFF
--- a/src/classloader/javaLangString.go
+++ b/src/classloader/javaLangString.go
@@ -11,6 +11,7 @@ import (
 	"jacobin/exceptions"
 	"jacobin/object"
 	"jacobin/types"
+	"strings"
 )
 
 // IMPORTANT NOTE: Some String functions are placed in libs\javaLangStringMethods.go
@@ -142,11 +143,20 @@ func Load_Lang_String() map[string]GMeth {
 			GFunction:  noSupportYetInString,
 		}
 
-	// Return a formatted string using the specified format string and arguments.
+	// Return a formatted string using the reference object string as the format string
+	// and the supplied arguments as input object arguments.
 	// E.g. String string = String.format("%s %i", "ABC", 42);
 	MethodSignatures["java/lang/String.format(Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;"] =
 		GMeth{
 			ParamSlots: 2,
+			GFunction:  sprintf,
+		}
+
+	// This method is equivalent to String.format(this, args).
+	MethodSignatures["java/lang/String.formatted([Ljava/lang/Object;)Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 1,
+			ObjectRef:  true, // The format string object reference will be in params[0] and parameter object slice in params[1]
 			GFunction:  sprintf,
 		}
 
@@ -157,21 +167,28 @@ func Load_Lang_String() map[string]GMeth {
 			GFunction:  noSupportYetInString,
 		}
 
-	// Return a formatted string using this string as the format string, and the supplied arguments.
-	// This method is equivalent to String.format(this, args).
-	MethodSignatures["java/lang/String.formatted([Ljava/lang/Object;)Ljava/lang/String;"] =
-		GMeth{
-			ParamSlots: 1,
-			ObjectRef:  true, // The format string object reference will be in params[0] and parameter object slice in params[1]
-			GFunction:  sprintf,
-		}
-
 	// Return the length of a String..
 	MethodSignatures["java/lang/String.length()I"] =
 		GMeth{
 			ParamSlots: 0,
 			ObjectRef:  true,
 			GFunction:  stringLength,
+		}
+
+	// Return a string in all lower case, using the reference object string as input.
+	MethodSignatures["java/lang/String.toLowerCase()Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 0,
+			ObjectRef:  true,
+			GFunction:  toLowerCase,
+		}
+
+	// Return a string in all lower case, using the reference object string as input.
+	MethodSignatures["java/lang/String.toUpperCase()Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 0,
+			ObjectRef:  true,
+			GFunction:  toUpperCase,
 		}
 
 	return MethodSignatures
@@ -369,4 +386,23 @@ func stringLength(params []interface{}) interface{} {
 		bytesPtr = parmObj.Fields[0].Fvalue.(*[]byte)
 	}
 	return int64(len(*bytesPtr))
+
+}
+
+func toLowerCase(params []interface{}) interface{} {
+	// params[0]: input string
+	propObj := params[0].(*object.Object) // string
+	strPtr := propObj.Fields[0].Fvalue.(*[]byte)
+	str := strings.ToLower(string(*strPtr))
+	obj := object.CreateCompactStringFromGoString(&str)
+	return obj
+}
+
+func toUpperCase(params []interface{}) interface{} {
+	// params[0]: input string
+	propObj := params[0].(*object.Object) // string
+	strPtr := propObj.Fields[0].Fvalue.(*[]byte)
+	str := strings.ToUpper(string(*strPtr))
+	obj := object.CreateCompactStringFromGoString(&str)
+	return obj
 }

--- a/src/exceptions/errors.go
+++ b/src/exceptions/errors.go
@@ -88,6 +88,10 @@ func ShowFrameStack(t *thread.ExecThread) {
 func GrabFrameStack(fs *list.List) []string {
 	var stackListing []string
 
+	if fs == nil {
+		// return an empty stack listing
+		return stackListing
+	}
 	frameStack := fs.Front()
 	if frameStack == nil {
 		// return an empty stack listing

--- a/src/exceptions/exception.go
+++ b/src/exceptions/exception.go
@@ -240,7 +240,13 @@ func Throw(exceptionType int, msg string) {
 	if glob.JacobinName == "test" {
 		return
 	}
-	stack := string(debug.Stack())
+	var stack string
+	bytes := debug.Stack()
+	if len(bytes) > 0 {
+		stack = string(bytes)
+	} else {
+		stack = ""
+	}
 	glob.ErrorGoStack = stack
 	ShowPanicCause(msg)
 	ShowFrameStack(&thread.ExecThread{})

--- a/src/exceptions/exception.go
+++ b/src/exceptions/exception.go
@@ -236,8 +236,11 @@ func Throw(exceptionType int, msg string) {
 	_ = log.Log(msg, log.SEVERE)
 
 	// TODO: Temporary until error/exception processing is complete.
-	stack := string(debug.Stack())
 	glob := globals.GetGlobalRef()
+	if glob.JacobinName == "test" {
+		return
+	}
+	stack := string(debug.Stack())
 	glob.ErrorGoStack = stack
 	ShowPanicCause(msg)
 	ShowFrameStack(&thread.ExecThread{})

--- a/src/exceptions/exception.go
+++ b/src/exceptions/exception.go
@@ -7,8 +7,11 @@
 package exceptions
 
 import (
+	"jacobin/globals"
 	"jacobin/log"
 	"jacobin/shutdown"
+	"jacobin/thread"
+	"runtime/debug"
 )
 
 // List of Java exceptions (as of Java 17)
@@ -231,6 +234,15 @@ func Throw(exceptionType int, msg string) {
 	   		"%s%sin %s, in%s, at bytecode[]: %d", JacobinRuntimeErrLiterals[excType], ": ", clName, methName, cp)
 	*/
 	_ = log.Log(msg, log.SEVERE)
+
+	// TODO: Temporary until error/exception processing is complete.
+	stack := string(debug.Stack())
+	glob := globals.GetGlobalRef()
+	glob.ErrorGoStack = stack
+	ShowPanicCause(msg)
+	ShowFrameStack(&thread.ExecThread{})
+	ShowGoStackTrace(nil)
+	_ = shutdown.Exit(shutdown.APP_EXCEPTION)
 }
 
 // JVMexception reports runtime exceptions occurring in the JVM (rather than in the app)


### PR DESCRIPTION
* ```object.go```: In some of the exception-runaway instances, FieldTables and Fields slices were 1/2-baked. In tracing, note these nil pointers instead of crashing.
* ```object.go```: When formatting fields for tracing, it was noticed that byte array output ([B) sometimes showed a blank value. These were actually nil strings. Added double-quotes (") as brackets to string formatting.
* ```exception.go```: Added temporary code to cease execution in ```Throw``` to eliminate the runaway effect (E.g. ```PUTSTATIC: type unrecognized: <nil>```). Yes, I did check the JacobinName for "test" (pesky unit tests!).
* ```JavaLangString.go```: New G functions: objectRef.toLower and objectRef.toUpper. Trying to avoid Locale as much as possible.