### PR TITLE
JACOBIN-398 While tracing, FormatField returning "<ERROR..." --> DumpObject(title=why?/what?, indentation=0)

### DIFF
--- a/src/object/object.go
+++ b/src/object/object.go
@@ -106,7 +106,7 @@ func fmtHelper(klassString string, field Field) string {
 	case types.ByteArray, types.Static + types.ByteArray:
 		fvalue := field.Fvalue
 		if fvalue == nil {
-			return "<ERROR nil Fvalue ptr!>"
+			return "<ERROR nil Fvalue!>"
 		}
 		bytesPtr := fvalue.(*[]byte)
 		if bytesPtr == nil {

--- a/src/object/object.go
+++ b/src/object/object.go
@@ -77,31 +77,48 @@ func fmtHelper(klassString string, field Field) string {
 		return fmt.Sprintf("\"%s\"", string(bytes))
 	}
 	switch field.Ftype {
-	case types.Double, types.Float:
+	case types.Double, types.Float, types.Static + types.Double, types.Static + types.Float:
 		return fmt.Sprintf("%f", field.Fvalue)
-	case types.Int, types.Long, types.Short:
+	case types.Int, types.Long, types.Short, types.Static + types.Int, types.Static + types.Long, types.Static + types.Short:
 		return fmt.Sprintf("%d", field.Fvalue)
-	case types.Byte:
+	case types.Byte, types.Static + types.Byte:
 		return fmt.Sprintf("%02x", field.Fvalue)
-	case types.Bool:
-		return fmt.Sprintf("%t", field.Fvalue)
-	case types.Char:
+	case types.Bool, types.Static + types.Bool:
+		// TODO: Why does FieldTable[key] pass an int64 YET Fields[index] passes a bool???
+		switch field.Fvalue.(type) {
+		case bool:
+			if field.Fvalue.(bool) {
+				return "true"
+			} else {
+				return "false"
+			}
+		case int64:
+			if field.Fvalue.(int64) != 0 {
+				return "true"
+			} else {
+				return "false"
+			}
+		default:
+			return fmt.Sprintf("<ERROR Ftype=bool but unexpected Fvalue variable type: %T !>", field.Fvalue)
+		}
+	case types.Char, types.Static + types.Char:
 		return fmt.Sprintf("%q", field.Fvalue)
-	case types.ByteArray:
+	case types.ByteArray, types.Static + types.ByteArray:
 		fvalue := field.Fvalue
 		if fvalue == nil {
-			return "<NIL FVALUE (PTR)!>"
+			return "<ERROR nil Fvalue ptr!>"
 		}
 		bytesPtr := fvalue.(*[]byte)
 		if bytesPtr == nil {
-			return "<NIL BYTE ARRAY PTR!>"
+			return "<ERROR nil byte array ptr!>"
 		}
 		if len(*bytesPtr) < 1 {
-			return "<nil>"
+			return "<nil byte array>"
 		}
 		return fmt.Sprintf("% x", *bytesPtr)
 	}
 
+	// Default action:
 	return fmt.Sprintf("%v", field.Fvalue)
 }
 
@@ -115,60 +132,112 @@ func (objPtr *Object) FormatField() string {
 	if obj.Klass != nil {
 		klassString = *obj.Klass
 	} else {
-		klassString = "<class MISSING!>" // Why is there no class name pointer for this object?
+		klassString = "<ERROR nil class pointer!>" // Why is there no class name pointer for this object?
+		obj.DumpObject(klassString, 0)
+		return klassString
 	}
 
 	if len(obj.FieldTable) > 0 {
 		// Using key="value" in the FieldTable
 		ptr := obj.FieldTable[key]
 		if ptr == nil {
-			return fmt.Sprintf("<FieldTable[%s] PTR IS NIL!>", key)
+			str := fmt.Sprintf("<ERROR nil FieldTable[%s] ptr!>", key)
+			obj.DumpObject(str, 0)
+			return str
 		}
 		field := *ptr
-		output = fmt.Sprintf("%s: (%s) %s", key, obj.FieldTable[key].Ftype, fmtHelper(klassString, field))
+		str := fmtHelper(klassString, field)
+		output = fmt.Sprintf("%s: (%s) %s", key, obj.FieldTable[key].Ftype, str)
+		if strings.HasPrefix(str, "<ERROR") {
+			obj.DumpObject(str, 0)
+		}
 	} else {
 		// Using [0] in the Fields slice
 		if len(obj.Fields) > 0 {
 			field := obj.Fields[0]
-			output += fmt.Sprintf("(%s) %s", obj.Fields[0].Ftype, fmtHelper(klassString, field))
+			str := fmtHelper(klassString, field)
+			output = fmt.Sprintf("(%s) %s", obj.Fields[0].Ftype, str)
+			if strings.HasPrefix(str, "<ERROR") {
+				obj.DumpObject(str, 0)
+			}
 		} else {
-			output = "<field MISSING!>"
+			// Field table and field slice are both empty.
+			output = "<ERROR field empty!>"
+			obj.DumpObject(output, 0)
 		}
 	}
 
 	return output
 }
 
-// FormatField dumps the contents of an object to a formatted multi-line string
-func (objPtr *Object) ToString(indent int) string {
-	var str string
-	var klassString string
+// DumpObject displays every attribute of an Object, formatted as multi-line printed output.
+// 3 sections:
+// * Class name
+// * Field table
+// * Field slice
+func (objPtr *Object) DumpObject(title string, indent int) {
 	obj := *objPtr
-	if obj.Klass != nil {
-		klassString = *obj.Klass
-		str = klassString + "\n"
-	} else {
-		klassString = "n/a"
-		str = "class type: n/a \n"
-	}
+	output := ""
+	var klassString string
 
+	// Emit BEGIN
+	if indent > 0 {
+		output += strings.Repeat(" ", indent)
+	}
+	output += "DumpObject " + title + " {\n"
+
+	// Emit klass line
+	if indent > 0 {
+		output += strings.Repeat(" ", indent)
+	}
+	if obj.Klass != nil {
+		klassString = "\tClass: " + *obj.Klass
+	} else {
+		klassString = "\t<class MISSING!>"
+	}
+	output += klassString + "\n"
+
+	// Emit FieldTable.
+	if indent > 0 {
+		output += strings.Repeat(" ", indent)
+	}
 	if len(obj.FieldTable) > 0 {
+		output += "\tField Table:\n"
 		for key := range obj.FieldTable {
 			if indent > 0 {
-				str += strings.Repeat(" ", indent)
+				output += strings.Repeat(" ", indent)
 			}
-			str += fmt.Sprintf("Fld %s: (%s) %s\n", key, obj.FieldTable[key].Ftype, fmtHelper(klassString, *obj.FieldTable[key]))
+			ptr := obj.FieldTable[key]
+			if ptr == nil {
+				output += fmt.Sprintf("\t\t<ERROR nil FieldTable[%s] ptr!>\n", key)
+			} else {
+				output += fmt.Sprintf("\t\tFld %s: (%s) %s\n", key, obj.FieldTable[key].Ftype, fmtHelper(klassString, *obj.FieldTable[key]))
+			}
 		}
 	} else {
-		if indent > 0 {
-			str += strings.Repeat(" ", indent)
-		}
-		if len(obj.Fields) > 0 {
-			str += fmt.Sprintf("Fld (%s) %s", obj.Fields[0].Ftype, fmtHelper(klassString, obj.Fields[0]))
-		} else {
-			str += "Fld <empty>"
-		}
+		output += fmt.Sprintf("\tField Table is <empty>\n")
 	}
 
-	return str
+	// Emit Fields slice.
+	if indent > 0 {
+		output += strings.Repeat(" ", indent)
+	}
+	nflds := len(obj.Fields)
+	if nflds > 0 {
+		output += fmt.Sprintf("\tField Slice (%d):\n", nflds)
+		for _, fld := range obj.Fields {
+			output += fmt.Sprintf("\t\tFld (%s) %s\n", fld.Ftype, fmtHelper(klassString, fld))
+		}
+	} else {
+		output += "\tField Slice is <empty>\n"
+	}
+
+	// Emit END
+	if indent > 0 {
+		output += strings.Repeat(" ", indent)
+	}
+	output += "}\n"
+
+	// Print output all at once.
+	fmt.Print(output)
 }

--- a/src/object/object.go
+++ b/src/object/object.go
@@ -141,7 +141,7 @@ func (objPtr *Object) FormatField() string {
 		// Using key="value" in the FieldTable
 		ptr := obj.FieldTable[key]
 		if ptr == nil {
-			str := fmt.Sprintf("<ERROR nil FieldTable[%s] ptr!>", key)
+			str := fmt.Sprintf("<ERROR FieldTable[\"%s\"] not found!>", key)
 			obj.DumpObject(str, 0)
 			return str
 		}

--- a/src/object/object_test.go
+++ b/src/object/object_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 )
 
-func TestObjectToString1(t *testing.T) {
-	t.Log("Test field table toString processing")
+func TestDumpObject1(t *testing.T) {
+	t.Log("Test Object.FieldTable DumpObject processing")
 	obj := MakeEmptyObject()
 	klassType := filepath.FromSlash("java/lang/madeUpClass")
 	obj.Klass = &klassType
@@ -77,25 +77,15 @@ func TestObjectToString1(t *testing.T) {
 	}
 	obj.FieldTable["myString"] = &myStringField
 
-	str := obj.ToString(42)
-	if len(str) == 0 {
-		t.Errorf("empty string for object.ToString()")
-	} else {
-		t.Log(str)
-	}
+	obj.DumpObject(klassType, 3)
 }
 
 // Test field slice toString processing
-func TestObjectToString2(t *testing.T) {
-	t.Log("Test field slice toString processing")
+func TestDumpObject2(t *testing.T) {
+	t.Log("Test Object.Fields slice DumpObject processing")
 	literal := "This is a compact string from a Go string"
 	csObj := CreateCompactStringFromGoString(&literal)
-	retStr := csObj.ToString(0)
-	if len(retStr) == 0 {
-		t.Errorf("empty string for object.ToString()")
-	} else {
-		t.Log(retStr)
-	}
+	csObj.DumpObject(literal, 0)
 
 	// Create a custom object.
 	obj := MakeEmptyObject()
@@ -104,74 +94,151 @@ func TestObjectToString2(t *testing.T) {
 
 	// Now, dump the same string as a byte array.
 	csObj.Klass = &klassType
-	retStr = csObj.ToString(0)
-	if len(retStr) == 0 {
-		t.Errorf("empty string for object.ToString()")
-	} else {
-		t.Log(retStr)
-	}
+	csObj.DumpObject("[B string]", 0)
 
 	myFloatField := Field{
 		Ftype:  "F",
 		Fvalue: 1.0,
 	}
 	obj.Fields = append(obj.Fields, myFloatField)
-	t.Log(obj.ToString(0))
+	obj.DumpObject("F", 0)
 
 	myDoubleField := Field{
 		Ftype:  "D",
 		Fvalue: 2.0,
 	}
 	obj.Fields[0] = myDoubleField
-	t.Log(obj.ToString(0))
+	obj.DumpObject("D", 0)
 
 	myIntField := Field{
 		Ftype:  "I",
 		Fvalue: 42,
 	}
 	obj.Fields[0] = myIntField
-	t.Log(obj.ToString(0))
+	obj.DumpObject("I", 0)
 
 	myLongField := Field{
 		Ftype:  "J",
 		Fvalue: 42,
 	}
 	obj.Fields[0] = myLongField
-	t.Log(obj.ToString(0))
+	obj.DumpObject("J", 0)
 
 	myShortField := Field{
 		Ftype:  "S",
 		Fvalue: 42,
 	}
 	obj.Fields[0] = myShortField
-	t.Log(obj.ToString(0))
+	obj.DumpObject("S", 0)
 
 	myByteField := Field{
 		Ftype:  "B",
 		Fvalue: 0x61,
 	}
 	obj.Fields[0] = myByteField
-	t.Log(obj.ToString(0))
-
-	myStaticTrueField := Field{
-		Ftype:  "XZ",
-		Fvalue: true,
-	}
-	obj.Fields[0] = myStaticTrueField
-	t.Log(obj.ToString(0))
+	obj.DumpObject("B", 0)
 
 	myFalseField := Field{
 		Ftype:  "Z",
 		Fvalue: false,
 	}
 	obj.Fields[0] = myFalseField
-	t.Log(obj.ToString(0))
+	obj.DumpObject("false Z", 0)
+
+	myStaticTrueField := Field{
+		Ftype:  "XZ",
+		Fvalue: true,
+	}
+	obj.Fields[0] = myStaticTrueField
+	obj.DumpObject("true XZ", 0)
 
 	myCharField := Field{
 		Ftype:  "C",
 		Fvalue: 'C',
 	}
 	obj.Fields[0] = myCharField
-	t.Log(obj.ToString(0))
+	obj.DumpObject("C", 0)
+
+}
+
+func TestFormatField(t *testing.T) {
+	t.Log("Test field slice DumpObject processing")
+
+	obj := MakeEmptyObject()
+	klassType := filepath.FromSlash("java/lang/madeUpClass")
+	obj.Klass = &klassType
+
+	myFloatField := Field{
+		Ftype:  "F",
+		Fvalue: 1.0,
+	}
+	obj.FieldTable["myFloat"] = &myFloatField
+
+	myDoubleField := Field{
+		Ftype:  "D",
+		Fvalue: 2.0,
+	}
+	obj.FieldTable["myDouble"] = &myDoubleField
+
+	myIntField := Field{
+		Ftype:  "I",
+		Fvalue: 42,
+	}
+	obj.FieldTable["myInt"] = &myIntField
+
+	myLongField := Field{
+		Ftype:  "J",
+		Fvalue: 42,
+	}
+	obj.FieldTable["myLong"] = &myLongField
+
+	myShortField := Field{
+		Ftype:  "S",
+		Fvalue: 42,
+	}
+	obj.FieldTable["myShort"] = &myShortField
+
+	myByteField := Field{
+		Ftype:  "B",
+		Fvalue: 0x61,
+	}
+	obj.FieldTable["myByte"] = &myByteField
+
+	myStaticTrueField := Field{
+		Ftype:  "XZ",
+		Fvalue: true,
+	}
+	obj.FieldTable["myStaticTrue"] = &myStaticTrueField
+
+	myFalseField := Field{
+		Ftype:  "Z",
+		Fvalue: false,
+	}
+	obj.FieldTable["myFalse"] = &myFalseField
+
+	myCharField := Field{
+		Ftype:  "C",
+		Fvalue: 'C',
+	}
+	obj.FieldTable["myChar"] = &myCharField
+
+	myStringField1 := Field{
+		Ftype:  "Ljava/lang/String;",
+		Fvalue: "Hello, Unka Andoo !",
+	}
+	obj.FieldTable["myString"] = &myStringField1
+
+	str := obj.FormatField()
+	t.Log("Key \"value\" is missing:")
+	t.Log(str)
+
+	myStringField2 := Field{
+		Ftype:  "Ljava/lang/String;",
+		Fvalue: "Hello, Unka Andoo !",
+	}
+	obj.FieldTable["value"] = &myStringField2
+	str = obj.FormatField()
+	t.Log("Key \"value\" is present:")
+	t.Log(str)
 
 }


### PR DESCRIPTION
While tracing, if there are field formatting errors for any reason, we will now dump the entire object.

Error conditions diagnosed in ```FormatField```:
* <ERROR nil class pointer!>
* <ERROR FieldTable["value"] not found!> when FieldTable is nonempty

Error conditions diagnosed in ```fmtHelper (called by FormatField)```:
* <ERROR Ftype=bool but unexpected Fvalue variable type: observed-type !>
* <ERROR nil Fvalue!> E.g. Ftype is [B but the byte array pointer is nil

An object dump will always attempt to depict both the FieldTable contents and the Fields slice contents.
See the ```object/object_test.go``` unit testing.

E.g. Dump an object with a non-empty FieldTable but an empty Fields slice:
```
   DumpObject java/lang/madeUpClass {
   	Class: java/lang/madeUpClass
   	Field Table:
   		Fld myChar: (C) 'C'
   		Fld myFloat: (F) 1.000000
   		Fld myLong: (J) 42
   		Fld myByte: (B) 61
   		Fld myStaticTrue: (XZ) true
   		Fld myString: (Ljava/lang/String;) Hello, Unka Andoo !
   		Fld myDouble: (D) 2.000000
   		Fld myInt: (I) 42
   		Fld myShort: (S) 42
   		Fld myFalse: (Z) false
   	Field Slice is <empty>
   }
```

E.g. Dump an object with a non-empty Fields slice but an empty FieldTable:
```
DumpObject [B string] {
	Class: java/lang/madeUpClass
	Field Table is <empty>
	Field Slice (11):
		Fld ([B) 54 68 69 73 20 69 73 20 61 20 63 6f 6d 70 61 63 74 20 73 74 72 69 6e 67 20 66 72 6f 6d 20 61 20 47 6f 20 73 74 72 69 6e 67
		Fld (B) 00
		Fld (I) 0
		Fld (XZ) true
		Fld (L) <nil>
		Fld (L) <nil>
		Fld (L) <nil>
		Fld (L) <nil>
		Fld (L) <nil>
		Fld (Z) false
		Fld (L) <nil>
}
```

E.g. Currently, jacotest case "zippy" exhibits an object with both field structures being non-empty but missing the "value" field in the FieldTable. This error is caught in ```FormatField```:
```
DumpObject <ERROR FieldTable["value"] not found!> {
	Class: java/io/File
	Field Table:
		Fld serialVersionUID: (XJ) 0
		Fld PREFIX_LENGTH_OFFSET: (XJ) 0
		Fld fs: (XLjava/io/FileSystem;) <nil>
		Fld pathSeparatorChar: (XC) '\x00'
		Fld pathSeparator: (XLjava/lang/String;) <nil>
		Fld UNSAFE: (XLjdk/internal/misc/Unsafe;) <nil>
		Fld filePath: (Ljava/nio/file/Path;) <nil>
		Fld prefixLength: (I) 0
		Fld status: (Ljava/io/File$PathStatus;) <nil>
		Fld separatorChar: (XC) '\x00'
		Fld separator: (XLjava/lang/String;) <nil>
		Fld PATH_OFFSET: (XJ) 0
		Fld $assertionsDisabled: (XZ) false
		Fld path: (Ljava/lang/String;) <nil>
	Field Slice (14):
		Fld (XLjava/io/FileSystem;) <nil>
		Fld (Ljava/lang/String;) <nil>
		Fld (Ljava/io/File$PathStatus;) <nil>
		Fld (I) 0
		Fld (XC) '\x00'
		Fld (XLjava/lang/String;) <nil>
		Fld (XC) '\x00'
		Fld (XLjava/lang/String;) <nil>
		Fld (XLjdk/internal/misc/Unsafe;) <nil>
		Fld (XJ) 0
		Fld (XJ) 0
		Fld (XJ) 0
		Fld (Ljava/nio/file/Path;) <nil>
		Fld (XZ) false
}
```
