### PR TITLE
Miscellaneous Minor Tweaks

### DIFF
--- a/src/jvm/instantiate.go
+++ b/src/jvm/instantiate.go
@@ -198,11 +198,11 @@ func createField(f classloader.Field, k *classloader.Klass, classname string) (*
 
 	presentType := fieldToAdd.Ftype
 	if f.IsStatic {
-		// in the instantiated class, add an 'X' before the
+		// in the instantiated class, add a types.Static before the
 		// type, which notifies future users that the field
 		// is static and should be fetched from the Statics
 		// table.
-		fieldToAdd.Ftype = "X" + presentType
+		fieldToAdd.Ftype = types.Static + presentType
 	}
 
 	// static fields can have ConstantValue attributes,

--- a/src/object/object.go
+++ b/src/object/object.go
@@ -137,6 +137,19 @@ func (objPtr *Object) FormatField() string {
 		return klassString
 	}
 
+	// Check use of the Fields slice
+	if len(obj.Fields) > 0 {
+		// Using [0] in the Fields slice
+		field := obj.Fields[0]
+		str := fmtHelper(klassString, field)
+		if strings.HasPrefix(str, "<ERROR") {
+			obj.DumpObject(str, 0)
+		}
+		output = fmt.Sprintf("(%s) %s", obj.Fields[0].Ftype, str)
+		return output
+	}
+
+	// Check use of the FieldTable map
 	if len(obj.FieldTable) > 0 {
 		// Using key="value" in the FieldTable
 		ptr := obj.FieldTable[key]
@@ -147,26 +160,16 @@ func (objPtr *Object) FormatField() string {
 		}
 		field := *ptr
 		str := fmtHelper(klassString, field)
-		output = fmt.Sprintf("%s: (%s) %s", key, obj.FieldTable[key].Ftype, str)
 		if strings.HasPrefix(str, "<ERROR") {
 			obj.DumpObject(str, 0)
 		}
-	} else {
-		// Using [0] in the Fields slice
-		if len(obj.Fields) > 0 {
-			field := obj.Fields[0]
-			str := fmtHelper(klassString, field)
-			output = fmt.Sprintf("(%s) %s", obj.Fields[0].Ftype, str)
-			if strings.HasPrefix(str, "<ERROR") {
-				obj.DumpObject(str, 0)
-			}
-		} else {
-			// Field table and field slice are both empty.
-			output = "<ERROR field empty!>"
-			obj.DumpObject(output, 0)
-		}
+		output = fmt.Sprintf("%s: (%s) %s", key, obj.FieldTable[key].Ftype, str)
+		return output
 	}
 
+	// Field table and field slice are both empty.
+	output = "<ERROR field empty!>"
+	obj.DumpObject(output, 0)
 	return output
 }
 

--- a/src/object/object.go
+++ b/src/object/object.go
@@ -201,8 +201,9 @@ func (objPtr *Object) DumpObject(title string, indent int) {
 	if indent > 0 {
 		output += strings.Repeat(" ", indent)
 	}
-	if len(obj.FieldTable) > 0 {
-		output += "\tField Table:\n"
+	nflds := len(obj.FieldTable)
+	if nflds > 0 {
+		output += fmt.Sprintf("\tField Table (%d):\n", nflds)
 		for key := range obj.FieldTable {
 			if indent > 0 {
 				output += strings.Repeat(" ", indent)
@@ -222,7 +223,7 @@ func (objPtr *Object) DumpObject(title string, indent int) {
 	if indent > 0 {
 		output += strings.Repeat(" ", indent)
 	}
-	nflds := len(obj.Fields)
+	nflds = len(obj.Fields)
 	if nflds > 0 {
 		output += fmt.Sprintf("\tField Slice (%d):\n", nflds)
 		for _, fld := range obj.Fields {

--- a/src/object/object_test.go
+++ b/src/object/object_test.go
@@ -228,17 +228,19 @@ func TestFormatField(t *testing.T) {
 	}
 	obj.FieldTable["myString"] = &myStringField1
 
+	t.Log("NOTE: Key \"value\" will be diagnosed as missing:")
 	str := obj.FormatField()
-	t.Log("Key \"value\" is missing:")
 	t.Log(str)
 
+	t.Log("NOTE: Will add a key \"value\" field.")
 	myStringField2 := Field{
 		Ftype:  "Ljava/lang/String;",
 		Fvalue: "Hello, Unka Andoo !",
 	}
 	obj.FieldTable["value"] = &myStringField2
+
+	t.Log("Will try FormatField again.")
 	str = obj.FormatField()
-	t.Log("Key \"value\" is present:")
 	t.Log(str)
 
 }


### PR DESCRIPTION
1. In i```nstantiate.go```, use types.Static instead of literal "X".
```
	if f.IsStatic {
		// in the instantiated class, add a types.Static before the
		// type, which notifies future users that the field
		// is static and should be fetched from the Statics
		// table.
		fieldToAdd.Ftype = types.Static + presentType // <------------------ replaced "X"
	}

```

2. ```DumpObject```: show FieldTable number of fields (like as done with the Fields slice).

3. ```FormatField```: check slices first. If the slices are non-empty, use the first element. This reduces significantly the number of diagnostic DumpObject calls made by FormatField for FieldData (map) which lacks a "value" element.

4. ```FormatField```: make the FieldData, Fields, and default code sections more independent so that it would be quite simple to revert the priority of checking between FieldData and Fields.

5. Updated ```object/object_test.go``` to exercise before and after adding a "value" key to FieldData.