### PR TITLE
Fix GETFIELD, ARRAYLENGTH; Watch out for *object.Object in object.go, javaIoPrintStream.go

### DIFF
--- a/src/classloader/javaIoPrintStream.go
+++ b/src/classloader/javaIoPrintStream.go
@@ -133,17 +133,21 @@ func Load_Io_PrintStream() map[string]GMeth {
 // for this class. The first arg then gets the StringConst ref, which is an index
 // into the UTF8 entries of the CP. This string is then printed to stdout. There
 // is no return value.
-func Println(i []interface{}) interface{} {
-	strAddr := i[1].(*object.Object)
-	// t := (strAddr.Fields[0].Fvalue).(*[]types.JavaByte) // changed due to JAcOBIN-282
-	t := (strAddr.Fields[0].Fvalue).(*[]byte)
-
-	// goChars := make([]byte, len(*t), len(*t))
-	// for i, c := range *t {
-	// 	goChars[i] = byte(c)
-	// }
-
-	fmt.Println(string(*t))
+func Println(params []interface{}) interface{} {
+	strAddr := params[1].(*object.Object)
+	switch strAddr.Fields[0].Fvalue.(type) {
+	case *[]byte:
+		baPtr := (strAddr.Fields[0].Fvalue).(*[]byte)
+		fmt.Println(string(*baPtr))
+	case *object.Object:
+		objPtr := (strAddr.Fields[0].Fvalue).(*object.Object)
+		if len((*objPtr).Fields) > 0 {
+			baPtr := (*objPtr).Fields[0].Fvalue.(*[]byte)
+			fmt.Println(string(*baPtr))
+		}
+	default:
+		fmt.Printf("Println: Oops, cannot process type %T\n", strAddr.Fields[0].Fvalue)
+	}
 	return nil
 }
 
@@ -242,13 +246,23 @@ func PrintDouble(l []interface{}) interface{} {
 }
 
 // Print string
-func PrintS(i []interface{}) interface{} {
+func PrintS(params []interface{}) interface{} {
 	// TODO: Eventually will need to check whether or not i[1] is a compact string.
 	//       Presently, we assume it is.
-	// fmt.Printf("DEBUG PrintS got an Object\n")
-	strAddr := i[1].(*object.Object)
-	t := (strAddr.Fields[0].Fvalue).(*[]byte)
-	fmt.Print(string(*t))
+	strAddr := params[1].(*object.Object)
+	switch strAddr.Fields[0].Fvalue.(type) {
+	case *[]byte:
+		baPtr := (strAddr.Fields[0].Fvalue).(*[]byte)
+		fmt.Print(string(*baPtr))
+	case *object.Object:
+		objPtr := (strAddr.Fields[0].Fvalue).(*object.Object)
+		if len((*objPtr).Fields) > 0 {
+			baPtr := (*objPtr).Fields[0].Fvalue.(*[]byte)
+			fmt.Print(string(*baPtr))
+		}
+	default:
+		fmt.Printf("*** PrintS: Oops, cannot process type %T\n", strAddr.Fields[0].Fvalue)
+	}
 	return nil
 }
 

--- a/src/classloader/javaLangString.go
+++ b/src/classloader/javaLangString.go
@@ -413,7 +413,7 @@ func StringFormatter(params []interface{}) *object.Object {
 		//fmt.Printf("DEBUG valuesIn[i] klass: %s, fields: %v\n", *valuesIn[i].Klass, valuesIn[i].Fields)
 		if object.IsJavaString(valuesIn[i]) {
 			valuesOut = append(valuesOut, object.GetGoStringFromJavaStringPtr(valuesIn[i]))
-			fmt.Printf("DEBUG got a string: %s\n", object.GetGoStringFromJavaStringPtr(valuesIn[i]))
+			//fmt.Printf("DEBUG got a string: %s\n", object.GetGoStringFromJavaStringPtr(valuesIn[i]))
 		} else {
 			//str := valuesIn[i].FormatField()
 			//fmt.Printf("DEBUG StringFormatter valuesIn[%d] FormatField:\n%s", i, str)

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -1778,16 +1778,6 @@ func runFrame(fs *list.List) error {
 				fieldValue = objField.Fvalue // <<<< test for string and return pointer to String object
 			}
 
-			// If the field type is a string,
-			// wrap it in an object and push address onto the stack.
-			if fieldType == object.StringClassFdesc {
-				objPtr := object.NewString()
-				field := object.Field{fieldType, fieldValue}
-				(*objPtr).Fields[0] = field
-				push(f, objPtr)
-				//objPtr.DumpObject("DEBUG GETFIELD pushed string object", 0)
-				break
-			}
 			push(f, fieldValue)
 			//fmt.Printf("DEBUG GETFIELD pushed type %s, value %v\n", fieldType, fieldValue)
 

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -514,8 +514,21 @@ func runFrame(fs *list.List) error {
 				return errors.New(errMsg)
 			}
 
-			bAref := ref.(*object.Object)
-			arrayPtr := bAref.Fields[0].Fvalue.(*[]byte)
+			var bAref *object.Object
+			var arrayPtr *[]byte
+			switch ref.(type) {
+			case *object.Object:
+				bAref = ref.(*object.Object)
+				arrayPtr = bAref.Fields[0].Fvalue.(*[]byte)
+			case *[]uint8:
+				arrayPtr = ref.(*[]uint8)
+			default:
+				glob := globals.GetGlobalRef()
+				glob.ErrorGoStack = string(debug.Stack())
+				errMsg := fmt.Sprintf("BALOAD: Invalid type of object ref: %T", ref)
+				exceptions.Throw(exceptions.NullPointerException, errMsg)
+				return errors.New(errMsg)
+			}
 			size := int64(len(*arrayPtr))
 
 			if index >= size {
@@ -1729,17 +1742,30 @@ func runFrame(fs *list.List) error {
 				return errors.New(errMsg)
 			}
 
-			ref := pop(f).(*object.Object)
-			obj := *ref
+			// Get object reference from stack.
+			ref := pop(f)
+			switch ref.(type) {
+			case *object.Object:
+				break
+			default:
+				glob := globals.GetGlobalRef()
+				glob.ErrorGoStack = string(debug.Stack())
+				errMsg := fmt.Sprintf("GETFIELD: Invalid type of object ref: %T", ref)
+				_ = log.Log(errMsg, log.SEVERE)
+				return errors.New(errMsg)
+			}
 
-			// var fieldName string
+			// Extract field.
+			obj := *ref.(*object.Object)
 			var fieldType string
 			var fieldValue interface{}
 
-			if obj.Fields != nil {
+			if len(obj.FieldTable) < 1 {
+				// Extract field from FieldTable map.
 				fieldType = obj.Fields[fieldEntry.Slot].Ftype
 				fieldValue = obj.Fields[fieldEntry.Slot].Fvalue
-			} else { // retrieve by name
+			} else {
+				// Extract field from Fields slice.
 				fullFieldEntry := CP.FieldRefs[fieldEntry.Slot]
 				nameAndTypeCPIndex := fullFieldEntry.NameAndType
 				nameAndTypeIndex := CP.CpIndex[nameAndTypeCPIndex]
@@ -1747,11 +1773,23 @@ func runFrame(fs *list.List) error {
 				nameCPIndex := nameAndType.NameIndex
 				nameCPentry := CP.CpIndex[nameCPIndex]
 				fieldName := CP.Utf8Refs[nameCPentry.Slot]
-
 				objField := obj.FieldTable[fieldName]
+				fieldType = objField.Ftype
 				fieldValue = objField.Fvalue // <<<< test for string and return pointer to String object
 			}
+
+			// If the field type is a string,
+			// wrap it in an object and push address onto the stack.
+			if fieldType == object.StringClassFdesc {
+				objPtr := object.NewString()
+				field := object.Field{fieldType, fieldValue}
+				(*objPtr).Fields[0] = field
+				push(f, objPtr)
+				//objPtr.DumpObject("DEBUG GETFIELD pushed string object", 0)
+				break
+			}
 			push(f, fieldValue)
+			//fmt.Printf("DEBUG GETFIELD pushed type %s, value %v\n", fieldType, fieldValue)
 
 			// doubles and longs consume two slots on the op stack
 			// so push a second time
@@ -2238,8 +2276,11 @@ func runFrame(fs *list.List) error {
 				case types.FloatArray:
 					arrayPtr := r.Fields[0].Fvalue.(*[]float64)
 					size = int64(len(*arrayPtr))
-				default:
+				case types.IntArray:
 					arrayPtr := r.Fields[0].Fvalue.(*[]int64)
+					size = int64(len(*arrayPtr))
+				default:
+					arrayPtr := r.Fields[0].Fvalue.(*[]*object.Object)
 					size = int64(len(*arrayPtr))
 				}
 			}

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -510,7 +510,7 @@ func runFrame(fs *list.List) error {
 				glob := globals.GetGlobalRef()
 				glob.ErrorGoStack = string(debug.Stack())
 				errMsg := "BALOAD: Invalid (null) reference to an array"
-				exceptions.Throw(exceptions.NullPointerException, errMsg)
+				exceptions.Throw(exceptions.InvalidTypeException, errMsg)
 				return errors.New(errMsg)
 			}
 
@@ -526,7 +526,7 @@ func runFrame(fs *list.List) error {
 				glob := globals.GetGlobalRef()
 				glob.ErrorGoStack = string(debug.Stack())
 				errMsg := fmt.Sprintf("BALOAD: Invalid type of object ref: %T", ref)
-				exceptions.Throw(exceptions.NullPointerException, errMsg)
+				exceptions.Throw(exceptions.InvalidTypeException, errMsg)
 				return errors.New(errMsg)
 			}
 			size := int64(len(*arrayPtr))

--- a/src/object/String.go
+++ b/src/object/String.go
@@ -15,7 +15,7 @@ import (
 // them from scratch each time by walking through the constant pool.
 
 var StringClassName = "java/lang/String"
-var StringClassFdesc = "Ljava/lang/String;"
+var StringClassRef = "Ljava/lang/String;"
 var EmptyString = ""
 
 // NewString creates an empty string. However, it lacks an updated

--- a/src/object/String.go
+++ b/src/object/String.go
@@ -15,6 +15,7 @@ import (
 // them from scratch each time by walking through the constant pool.
 
 var StringClassName = "java/lang/String"
+var StringClassFdesc = "Ljava/lang/String;"
 var EmptyString = ""
 
 // NewString creates an empty string. However, it lacks an updated

--- a/src/object/object.go
+++ b/src/object/object.go
@@ -115,11 +115,14 @@ func fmtHelper(klassString string, field Field) string {
 	case types.Char, types.Static + types.Char:
 		return fmt.Sprintf("%q", field.Fvalue)
 	case types.ByteArray, types.Static + types.ByteArray:
-		fvalue := field.Fvalue
-		if fvalue == nil {
+		if field.Fvalue == nil {
 			return "<ERROR nil Fvalue!>"
 		}
-		bytesPtr := fvalue.(*[]byte)
+		switch field.Fvalue.(type) {
+		case *Object:
+			return "*** embedded object ***"
+		}
+		bytesPtr := field.Fvalue.(*[]byte)
 		if bytesPtr == nil {
 			return "<ERROR nil byte array ptr!>"
 		}


### PR DESCRIPTION
- run.go GETFIELD: If the field type is a string, wrap it in an object and push the object address onto the stack.
- run.go ARRAYLENGTH: Pointer to an array of objects is also a possibility.
- javaIoPrintStream.go Println & PrintS: Be prepared for *object.Object as well as *[]byte.
- String.go: added StringClassFdesc = "Ljava/lang/String;"
- object.go: Be prepared for *object.Object as well as *[]byte.


Note that exceptions.Throw (temporary code, to be replaced by Andrew's WIP) is duplicating the normal ShowPanicCause logging of a severe error message. This causes double-reporting in jacotest. I tried a fix by taking the log call out of of the temporary Throw function but this blew up several unit tests. Working on this. This can be addressed in jacotest as mentioned in JACOBIN-405.

