### PR TITLE
JACOBIN-406 Tracing statics should show values from Statics table

### DIFF
--- a/src/classloader/javaIoPrintStream.go
+++ b/src/classloader/javaIoPrintStream.go
@@ -196,7 +196,7 @@ func PrintlnDouble(l []interface{}) interface{} {
 // Println an Object's contents
 func PrintlnObject(params []interface{}) interface{} {
 	objPtr := params[1].(*object.Object)
-	str := objPtr.FormatField()
+	str := objPtr.FormatField("")
 	fmt.Println(str)
 	return nil
 }
@@ -269,7 +269,7 @@ func PrintS(params []interface{}) interface{} {
 // Print an Object's contents
 func PrintObject(params []interface{}) interface{} {
 	objPtr := params[1].(*object.Object)
-	str := objPtr.FormatField()
+	str := objPtr.FormatField("")
 	fmt.Print(str)
 	return nil
 }

--- a/src/classloader/javaLangClass.go
+++ b/src/classloader/javaLangClass.go
@@ -12,6 +12,7 @@ import (
 	"jacobin/log"
 	"jacobin/object"
 	"jacobin/shutdown"
+	"jacobin/statics"
 )
 
 // Implementation of some of the functions in Java/lang/Class.
@@ -117,6 +118,6 @@ func getAssertionsEnabledStatus(params []interface{}) interface{} {
 	// note that statics have been preloaded before this function
 	// can be called, and CLI processing has also occurred. So, we
 	// know we have the latest assertion-enabled status.
-	x := Statics["main.$assertionsDisabled"].Value.(int64)
+	x := statics.Statics["main.$assertionsDisabled"].Value.(int64)
 	return 1 - x // return the 0 if disabled, 1 if not.
 }

--- a/src/classloader/javaLangString.go
+++ b/src/classloader/javaLangString.go
@@ -603,7 +603,7 @@ func valueOfLong(params []interface{}) interface{} {
 func valueOfObject(params []interface{}) interface{} {
 	// params[0]: input Object
 	ptrObj := params[0].(*object.Object)
-	str := ptrObj.FormatField()
+	str := ptrObj.FormatField("")
 	obj := object.CreateCompactStringFromGoString(&str)
 	return obj
 }

--- a/src/classloader/javaLangSystem.go
+++ b/src/classloader/javaLangSystem.go
@@ -13,6 +13,7 @@ import (
 	"jacobin/log"
 	"jacobin/object"
 	"jacobin/shutdown"
+	"jacobin/statics"
 	"jacobin/types"
 	"os"
 	"os/user"
@@ -111,9 +112,9 @@ func clinit([]interface{}) interface{} {
 		exceptions.Throw(exceptions.VirtualMachineError, errMsg)
 	}
 	if klass.Data.ClInit != types.ClInitRun {
-		_ = AddStatic("java/lang/System.in", Static{Type: "L", Value: object.Null})
-		_ = AddStatic("java/lang/System.err", Static{Type: "L", Value: object.Null})
-		_ = AddStatic("java/lang/System.out", Static{Type: "L", Value: object.Null})
+		_ = statics.AddStatic("java/lang/System.in", statics.Static{Type: "L", Value: object.Null})
+		_ = statics.AddStatic("java/lang/System.err", statics.Static{Type: "L", Value: object.Null})
+		_ = statics.AddStatic("java/lang/System.out", statics.Static{Type: "L", Value: object.Null})
 		klass.Data.ClInit = types.ClInitRun
 	}
 	return nil

--- a/src/jvm/instantiate.go
+++ b/src/jvm/instantiate.go
@@ -14,6 +14,7 @@ import (
 	"jacobin/log"
 	"jacobin/object"
 	"jacobin/shutdown"
+	"jacobin/statics"
 	"jacobin/types"
 	"strings"
 	"unsafe"
@@ -238,7 +239,7 @@ func createField(f classloader.Field, k *classloader.Klass, classname string) (*
 	} // end of search through attributes
 
 	if f.IsStatic {
-		s := classloader.Static{
+		s := statics.Static{
 			Type:  presentType, // we use the type without the 'X' prefix in the statics table.
 			Value: fieldToAdd.Fvalue,
 		}
@@ -246,9 +247,9 @@ func createField(f classloader.Field, k *classloader.Klass, classname string) (*
 		fieldName := k.Data.CP.Utf8Refs[f.Name]
 		fullFieldName := classname + "." + fieldName
 
-		_, alreadyPresent := classloader.Statics[fullFieldName]
+		_, alreadyPresent := statics.Statics[fullFieldName]
 		if !alreadyPresent { // add only if field has not been pre-loaded
-			_ = classloader.AddStatic(fullFieldName, s)
+			_ = statics.AddStatic(fullFieldName, s)
 		}
 	}
 	return fieldToAdd, nil

--- a/src/jvm/jvmStart.go
+++ b/src/jvm/jvmStart.go
@@ -13,6 +13,7 @@ import (
 	"jacobin/globals"
 	"jacobin/log"
 	"jacobin/shutdown"
+	"jacobin/statics"
 	"jacobin/thread"
 	"jacobin/types"
 	"os"
@@ -58,7 +59,7 @@ func JVMrun() int {
 	var status error
 
 	// load static variables. Needs to be here b/c CLI might modify their values
-	classloader.StaticsPreload()
+	statics.StaticsPreload()
 
 	// handle the command-line interface (cli) -- i.e., process the args
 	LoadOptionsTable(Global)
@@ -111,8 +112,8 @@ func JVMrun() int {
 	// that it's set in the Statics table w/ an entry corresponding to the main class
 	// Otherwise, it was previously set to disabled
 	if Global.Options["-ea"].Set {
-		_ = classloader.AddStatic("main.$assertionsDisabled",
-			classloader.Static{Type: types.Int, Value: types.JavaBoolFalse})
+		_ = statics.AddStatic("main.$assertionsDisabled",
+			statics.Static{Type: types.Int, Value: types.JavaBoolFalse})
 	}
 
 	// the following was commented out per JACOBIN-327.

--- a/src/jvm/option_table_loader.go
+++ b/src/jvm/option_table_loader.go
@@ -9,10 +9,10 @@ package jvm
 import (
 	"errors"
 	"fmt"
-	"jacobin/classloader"
 	"jacobin/execdata"
 	"jacobin/globals"
 	"jacobin/log"
+	"jacobin/statics"
 	"jacobin/types"
 	"os"
 )
@@ -193,8 +193,8 @@ func enableTraceInstructions(pos int, argValue string, gl *globals.Globals) (int
 
 func enableAssertions(pos int, name string, gl *globals.Globals) (int, error) {
 	setOptionToSeen("-ea", gl)
-	classloader.AddStatic("main.$assertionsDisabled",
-		classloader.Static{Type: types.Int, Value: types.JavaBoolFalse})
+	statics.AddStatic("main.$assertionsDisabled",
+		statics.Static{Type: types.Int, Value: types.JavaBoolFalse})
 	return pos, nil
 }
 

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -19,6 +19,7 @@ import (
 	"jacobin/object"
 	"jacobin/opcodes"
 	"jacobin/shutdown"
+	"jacobin/statics"
 	"jacobin/thread"
 	"jacobin/types"
 	"jacobin/util"
@@ -94,6 +95,11 @@ func StartExec(className string, mainThread *thread.ExecThread, globals *globals
 	if err != nil {
 		return err
 	}
+
+	if MainThread.Trace {
+		statics.DumpStatics()
+	}
+	
 	return nil
 }
 
@@ -1534,13 +1540,13 @@ func runFrame(fs *list.List) error {
 			fieldName = className + "." + fieldName
 
 			// was this static field previously loaded? Is so, get its location and move on.
-			prevLoaded, ok := classloader.Statics[fieldName]
+			prevLoaded, ok := statics.Statics[fieldName]
 			if !ok { // if field is not already loaded, then
 				// the class has not been instantiated, so
 				// instantiate the class
 				_, err := InstantiateClass(className, fs)
 				if err == nil {
-					prevLoaded, ok = classloader.Statics[fieldName]
+					prevLoaded, ok = statics.Statics[fieldName]
 				} else {
 					glob := globals.GetGlobalRef()
 					glob.ErrorGoStack = string(debug.Stack())
@@ -1621,13 +1627,13 @@ func runFrame(fs *list.List) error {
 			fieldName = className + "." + fieldName
 
 			// was this static field previously loaded? Is so, get its location and move on.
-			prevLoaded, ok := classloader.Statics[fieldName]
+			prevLoaded, ok := statics.Statics[fieldName]
 			if !ok { // if field is not already loaded, then
 				// the class has not been instantiated, so
 				// instantiate the class
 				_, err := InstantiateClass(className, fs)
 				if err == nil {
-					prevLoaded, ok = classloader.Statics[fieldName]
+					prevLoaded, ok = statics.Statics[fieldName]
 				} else {
 					glob := globals.GetGlobalRef()
 					glob.ErrorGoStack = string(debug.Stack())
@@ -1654,13 +1660,13 @@ func runFrame(fs *list.List) error {
 				// be stored as a boolean, a byte (in an array), or int64
 				// We want all forms normalized to int64
 				value = pop(f).(int64) & 0x01
-				classloader.Statics[fieldName] = classloader.Static{
+				statics.Statics[fieldName] = statics.Static{
 					Type:  prevLoaded.Type,
 					Value: value,
 				}
 			case types.Char, types.Short, types.Int, types.Long:
 				value = pop(f).(int64)
-				classloader.Statics[fieldName] = classloader.Static{
+				statics.Statics[fieldName] = statics.Static{
 					Type:  prevLoaded.Type,
 					Value: value,
 				}
@@ -1674,13 +1680,13 @@ func runFrame(fs *list.List) error {
 				case byte:
 					val = v.(byte)
 				}
-				classloader.Statics[fieldName] = classloader.Static{
+				statics.Statics[fieldName] = statics.Static{
 					Type:  prevLoaded.Type,
 					Value: val,
 				}
 			case types.Float, types.Double:
 				value = pop(f).(float64)
-				classloader.Statics[fieldName] = classloader.Static{
+				statics.Statics[fieldName] = statics.Static{
 					Type:  prevLoaded.Type,
 					Value: value,
 				}
@@ -1692,7 +1698,7 @@ func runFrame(fs *list.List) error {
 				value = pop(f)
 				switch value.(type) {
 				case *object.Object:
-					classloader.Statics[fieldName] = classloader.Static{
+					statics.Statics[fieldName] = statics.Static{
 						Type:  prevLoaded.Type,
 						Value: value,
 					}
@@ -1708,7 +1714,7 @@ func runFrame(fs *list.List) error {
 					obj.Fields = append(obj.Fields, objField)
 					obj.FieldTable = nil
 
-					classloader.Statics[fieldName] = classloader.Static{
+					statics.Statics[fieldName] = statics.Static{
 						Type:  objField.Ftype,
 						Value: value,
 					}
@@ -2690,7 +2696,7 @@ func logTraceStack(f *frames.Frame) {
 				output = fmt.Sprintf("<null>")
 			} else {
 				objPtr := f.OpStack[ii].(*object.Object)
-				output = objPtr.FormatField()
+				output = objPtr.FormatField("")
 			}
 		case *[]uint8:
 			value := f.OpStack[ii]
@@ -2723,7 +2729,7 @@ func emitTraceData(f *frames.Frame) string {
 				stackTop = fmt.Sprintf("<null>")
 			} else {
 				objPtr := f.OpStack[f.TOS].(*object.Object)
-				stackTop = objPtr.FormatField()
+				stackTop = objPtr.FormatField("")
 			}
 		case *[]uint8:
 			value := f.OpStack[f.TOS]

--- a/src/jvm/run_test.go
+++ b/src/jvm/run_test.go
@@ -14,6 +14,7 @@ import (
 	"jacobin/log"
 	"jacobin/object"
 	"jacobin/opcodes"
+	"jacobin/statics"
 	"jacobin/thread"
 	"jacobin/types"
 	"math"
@@ -2003,7 +2004,7 @@ func TestGetStaticBoolean(t *testing.T) {
 	f.Meth = append(f.Meth, 0x00)
 	f.Meth = append(f.Meth, 0x01) // Go to slot 0x0001 in the CP
 
-	classloader.StaticsPreload() // load the statics table with the String class
+	statics.StaticsPreload() // load the statics table with the String class
 
 	CP := classloader.CPool{}
 	CP.CpIndex = make([]classloader.CpEntry, 10, 10)

--- a/src/object/object_test.go
+++ b/src/object/object_test.go
@@ -228,8 +228,8 @@ func TestFormatField(t *testing.T) {
 	}
 	obj.FieldTable["myString"] = &myStringField1
 
-	t.Log("NOTE: Key \"value\" will be diagnosed as missing:")
-	str := obj.FormatField()
+	t.Log("NOTE: Key \"Fred\" will be diagnosed as missing:")
+	str := obj.FormatField("Fred")
 	t.Log(str)
 
 	t.Log("NOTE: Will add a key \"value\" field.")
@@ -237,10 +237,10 @@ func TestFormatField(t *testing.T) {
 		Ftype:  "Ljava/lang/String;",
 		Fvalue: "Hello, Unka Andoo !",
 	}
-	obj.FieldTable["value"] = &myStringField2
+	obj.FieldTable["Fred"] = &myStringField2
 
 	t.Log("Will try FormatField again.")
-	str = obj.FormatField()
+	str = obj.FormatField("Fred")
 	t.Log(str)
 
 }


### PR DESCRIPTION
This is a first attempt at getting the object package functions FormatField and DumpObject to access the Statics table when fields are of ```types.Static```.

Ran into a Go diagnostic about a cycle (A calls B who calls C who calls A). Solved this by creating package ```statics``` and moving ```statics.go``` there. Added function ```GetFieldValue``` and ```DumpStatics``` to that source file. Unfortunately, a number of files were impacted by the package name change. 

**The list of impacted source files by this PR:**
new file:   src/statics/statics.go
deleted:    src/classloader/statics.go
	modified:   src/classloader/javaIoPrintStream.go
	modified:   src/classloader/javaLangClass.go
	modified:   src/classloader/javaLangString.go
	modified:   src/classloader/javaLangSystem.go
	modified:   src/jvm/instantiate.go
	modified:   src/jvm/jvmStart.go
	modified:   src/jvm/option_table_loader.go
	modified:   src/jvm/run.go
	modified:   src/jvm/run_test.go
	modified:   src/object/object.go
	modified:   src/object/object_test.go

**New tracing function** (```DumpStatics```): At the end of the main thread, if tracing is enabled, the statics table is output to the console.