### PR TITLE
JACOBIN-412 make the global struct a singleton across all packages

### DIFF
--- a/src/gfunction/javaLangThrowable.go
+++ b/src/gfunction/javaLangThrowable.go
@@ -98,7 +98,9 @@ func fillInStackTrace(params []interface{}) interface{} {
 		ste, err := global.FuncInstantiateClass("java/lang/StackTraceElement", nil)
 		if err != nil {
 			_ = log.Log("Throwable.fillInStackTrace: error creating 'java/lang/StackTraceElement", log.SEVERE)
-			return ste.(*object.Object)
+			//return ste.(*object.Object)
+			ste = nil
+			return ste
 		}
 		fmt.Println(thisFrame.Value)
 	}

--- a/src/globals/globals.go
+++ b/src/globals/globals.go
@@ -9,6 +9,7 @@ package globals
 import (
 	"bufio"
 	"container/list"
+	"errors"
 	"fmt"
 	// "jacobin/thread"
 	"os"
@@ -119,7 +120,7 @@ func InitGlobals(progName string) Globals {
 		JVMframeStack:        nil,
 		JvmFrameStackShown:   false,
 		GoStackShown:         false,
-		FuncInstantiateClass: nil,
+		FuncInstantiateClass: fakeInstantiateClass,
 	}
 
 	InitJavaHome()
@@ -248,4 +249,10 @@ func cleanupPath(path string) string {
 // This creates that list.
 func InitArrayAddressList() *list.List {
 	return list.New()
+}
+
+// Fake InstantiateClass
+func fakeInstantiateClass(classname string, frameStack *list.List) (any, error) {
+	fmt.Printf("\n***** fakeInstantiateClass: classname=%s\n", classname)
+	return nil, errors.New("fakeInstantiateClass: By definition, my execution is an error!")
 }

--- a/src/jvm/cli.go
+++ b/src/jvm/cli.go
@@ -19,7 +19,7 @@ import (
 
 // HandleCli handles all args from the command line, including those from environment
 // variables that the JVM recognizes and prepends to the list of command-line options
-// func HandleCli(osArgs []string, Global *globals.Globals) (err error) {
+// func HandleCli(osArgs []string, globPtr *globals.Globals) (err error) {
 func HandleCli(osArgs []string, Global *globals.Globals) (err error) {
 	var javaEnvOptions = getEnvArgs()
 	_ = log.Log("Java environment variables: "+javaEnvOptions, log.FINE)
@@ -59,7 +59,7 @@ func HandleCli(osArgs []string, Global *globals.Globals) (err error) {
 		}
 
 		// if the option is the name of the class to execute, note that then get
-		// all successive arguments and store them as app args in Global
+		// all successive arguments and store them as app args in globPtr
 		if strings.HasSuffix(option, ".class") {
 			Global.StartingClass = option
 			for i = i + 1; i < len(args); i++ {
@@ -77,7 +77,7 @@ func HandleCli(osArgs []string, Global *globals.Globals) (err error) {
 		}
 
 		// TODO: check for JAR specified and process the JAR. At present, it will
-		// recognize the JAR file and insert it into Global, and copy all succeeding args
+		// recognize the JAR file and insert it into globPtr, and copy all succeeding args
 		// to app args. However, it does not recognize the JAR file as an executable.
 
 	}

--- a/src/jvm/cli_test.go
+++ b/src/jvm/cli_test.go
@@ -81,7 +81,7 @@ func TestHandleUsageMessage(t *testing.T) {
 	}
 
 	if global.ExitNow != true {
-		t.Error("'jacobin -help' should have set Global.exitNow to true to signal end of processing")
+		t.Error("'jacobin -help' should have set globPtr.exitNow to true to signal end of processing")
 	}
 }
 
@@ -107,7 +107,7 @@ func TestShowUsageMessageExitsProperlyWith__Help(t *testing.T) {
 	os.Stderr = normalStderr
 
 	if global.ExitNow != true {
-		t.Error("'jacobin --help' should set Global.exitNow to true but did not")
+		t.Error("'jacobin --help' should set globPtr.exitNow to true but did not")
 	}
 }
 
@@ -306,7 +306,7 @@ func TestSpecifyClientVM(t *testing.T) {
 	global := globals.InitGlobals("test")
 	LoadOptionsTable(global)
 	if global.VmModel != "server" {
-		t.Error("Initialization of Global.vmModel was not set to 'server' Got: " +
+		t.Error("Initialization of globPtr.vmModel was not set to 'server' Got: " +
 			global.VmModel)
 	}
 

--- a/src/jvm/option_table_loader.go
+++ b/src/jvm/option_table_loader.go
@@ -17,7 +17,7 @@ import (
 	"os"
 )
 
-// This set of routines loads the Global.Options table with the various
+// This set of routines loads the globPtr.Options table with the various
 // JVM command-line options for use later by the CLI processing logic.
 //
 // The table is initially created in globals.go and its declaration contains a
@@ -120,7 +120,7 @@ func clientVM(pos int, name string, gl *globals.Globals) (int, error) {
 }
 
 // for -jar option. Get the next arg, which must be the JAR filename, and then all remaining args
-// are app args, which are duly added to Global.appArgs
+// are app args, which are duly added to globPtr.appArgs
 func getJarFilename(pos int, name string, gl *globals.Globals) (int, error) {
 	setOptionToSeen("-jar", gl)
 	if len(gl.Args) > pos+1 {


### PR DESCRIPTION
Updated sources:
```
	modified:   src/globals/globals.go - created the fakeInstantiateClass function
	modified:   src/jvm/jvmStart.go - work from a pointer to global like everyone else
	modified:   src/gfunction/javaLangThrowable.go - When an error is returned from InstantiateClass,
                               return a nil value for *object.Object.
```
Refactored in jvmStart.go: Global --> globPtr, so variable name change only:
```
	modified:   src/jvm/cli.go
	modified:   src/jvm/cli_test.go
	modified:   src/jvm/option_table_loader.go
```