### PR TITLE
Move along some jacotest failures to INVOKEINTERFACE

### DIFF
--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -25,6 +25,7 @@ func MTableLoadNatives(MTable *classloader.MT) {
 	loadlib(MTable, Load_Io_PrintStream())         // load the java.io.prinstream golang functions
 	loadlib(MTable, Load_Lang_Class())             // load the java.lang.Class golang functions
 	loadlib(MTable, Load_Lang_Math())              // load the java.lang.Math golang functions
+	loadlib(MTable, Load_Lang_Object())            // load the java.lang.Class golang functions
 	loadlib(MTable, Load_Misc_Unsafe())            // load the jdk.internal/misc/Unsafe functions
 	loadlib(MTable, Load_Lang_String())            // load the java.lang.String golang functions
 	loadlib(MTable, Load_Lang_System())            // load the java.lang.System golang functions
@@ -51,4 +52,9 @@ func loadlib(tbl *classloader.MT, libMeths map[string]GMeth) {
 
 		classloader.AddEntry(tbl, key, tableEntry)
 	}
+}
+
+// do-nothing Go function shared by several source files
+func justReturn([]interface{}) interface{} {
+	return nil
 }

--- a/src/gfunction/javaLangObject.go
+++ b/src/gfunction/javaLangObject.go
@@ -1,0 +1,19 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2023 by  the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package gfunction
+
+// Implementation of some of the functions in Java/lang/Class.
+
+func Load_Lang_Object() map[string]GMeth {
+
+	MethodSignatures["java/lang/Object.<init>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+	return MethodSignatures
+}

--- a/src/gfunction/javaLangSystem.go
+++ b/src/gfunction/javaLangSystem.go
@@ -225,8 +225,3 @@ func getProperty(params []interface{}) interface{} {
 	obj := object.CreateCompactStringFromGoString(&value)
 	return obj
 }
-
-// do-nothing function
-func justReturn([]interface{}) interface{} {
-	return nil
-}

--- a/src/gfunction/javaPrimitives.go
+++ b/src/gfunction/javaPrimitives.go
@@ -164,43 +164,43 @@ func Load_Primitives() map[string]GMeth {
 	MethodSignatures["java/lang/Byte.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  primitivesJustReturn,
+			GFunction:  justReturn,
 		}
 
 	MethodSignatures["java/lang/Boolean.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  primitivesJustReturn,
+			GFunction:  justReturn,
 		}
 
 	MethodSignatures["java/lang/Integer.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  primitivesJustReturn,
+			GFunction:  justReturn,
 		}
 
 	MethodSignatures["java/lang/Long.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  primitivesJustReturn,
+			GFunction:  justReturn,
 		}
 
 	MethodSignatures["java/lang/Float.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  primitivesJustReturn,
+			GFunction:  justReturn,
 		}
 
 	MethodSignatures["java/lang/Double.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  primitivesJustReturn,
+			GFunction:  justReturn,
 		}
 
 	MethodSignatures["java/lang/Short.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  primitivesJustReturn,
+			GFunction:  justReturn,
 		}
 
 	return MethodSignatures
@@ -499,8 +499,4 @@ func booleanValueOf(params []interface{}) interface{} {
 	zz := params[0].(int64)
 	objPtr := object.MakePrimitiveObject("java/lang/Boolean", types.Bool, zz)
 	return objPtr
-}
-
-func primitivesJustReturn(params []interface{}) interface{} {
-	return nil
 }

--- a/src/gfunction/jdkMiscUnsafe.go
+++ b/src/gfunction/jdkMiscUnsafe.go
@@ -39,7 +39,7 @@ func Load_Misc_Unsafe() map[string]GMeth {
 	MethodSignatures["jdk/internal/misc/Unsafe.<clinit>()V"] = // offset to start of first item in an array
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  unsafeClinit,
+			GFunction:  justReturn, // Unsafe <clinit>
 		}
 
 	return MethodSignatures
@@ -55,8 +55,4 @@ func arrayBaseOffset(param []interface{}) interface{} {
 		return errors.New(errMsg)
 	}
 	return int64(0) // this should work...
-}
-
-func unsafeClinit([]interface{}) interface{} {
-	return nil
 }

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -2376,11 +2376,15 @@ func runFrame(fs *list.List) error {
 						if *sptr == className || strings.HasPrefix(className, *sptr) {
 							break // exit this bytecode processing
 						} else {
+							/*** TODO: bypass this Throw action. Right thing to do?
 							glob := globals.GetGlobalRef()
 							glob.ErrorGoStack = string(debug.Stack())
 							errMsg := fmt.Sprintf("CHECKCAST: %s is not castable with respect to %s", className, *sptr)
 							exceptions.Throw(exceptions.ClassCastException, errMsg)
 							return errors.New(errMsg)
+							***/
+							warnMsg := fmt.Sprintf("CHECKCAST: casting %s to %s might be unpleasant!", className, *sptr)
+							_ = log.Log(warnMsg, log.WARNING)
 						}
 					} else {
 						glob := globals.GetGlobalRef()


### PR DESCRIPTION
* In run.go CHECKCAST, when the array types do not match:
     - Commented out the Throw set up and execution. Let it continue with a warning, pending resolution of JACOBIN-413.
     - TODO comment inserted as a reminder.
* Centralised all of the *justReturn() G functions in one, located in gfunction/gfunction.go. Only one is enough.

One can see 2 jacotest cases, ```stringer-1``` and ```vector-survivor-2```, continuing on to attempt an INVOKEINTERFACE:
* ```stringer-1``` attempts a String.contains(CharSequence).
* ```vector-survivor-2``` attempts a Vector(Collection).