### PR TITLE
Move 2 jacotest cases past isLatin1 native function

### DIFF
--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -28,6 +28,7 @@ func MTableLoadNatives(MTable *classloader.MT) {
 	loadlib(MTable, Load_Lang_Object())            // load the java.lang.Class golang functions
 	loadlib(MTable, Load_Misc_Unsafe())            // load the jdk.internal/misc/Unsafe functions
 	loadlib(MTable, Load_Lang_String())            // load the java.lang.String golang functions
+	loadlib(MTable, Load_Lang_StringBuilder())     // load the java.lang.StringBuilder golang functions
 	loadlib(MTable, Load_Lang_System())            // load the java.lang.System golang functions
 	loadlib(MTable, Load_Lang_StackTraceELement()) //  java.lang.StackTraceElement golang functions
 	loadlib(MTable, Load_Lang_Thread())            // load the java.lang.Thread golang functions

--- a/src/gfunction/javaLangStringBuilder.go
+++ b/src/gfunction/javaLangStringBuilder.go
@@ -1,0 +1,24 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2023 by  the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package gfunction
+
+// Implementation of some of the functions in Java/lang/Class.
+
+func Load_Lang_StringBuilder() map[string]GMeth {
+
+	MethodSignatures["java/lang/StringBuilder.isLatin1()Z"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  isLatin1,
+		}
+	return MethodSignatures
+}
+
+func isLatin1([]interface{}) interface{} {
+	// TODO: Someday, jacobin will need to discern between StringLatin1 and StringUTF16.
+	return int64(1)
+}

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -1874,7 +1874,14 @@ func runFrame(fs *list.List) error {
 				nameCPentry := CP.CpIndex[nameCPIndex]
 				fieldName := CP.Utf8Refs[nameCPentry.Slot]
 
-				objField := obj.FieldTable[fieldName]
+				objField, ok := obj.FieldTable[fieldName]
+				if !ok {
+					errMsg := fmt.Sprintf("PUTFIELD: In trying for a superclass field, %s referenced by %s.%s is not present",
+						fieldName, f.ClName, f.MethName)
+					_ = log.Log(errMsg, log.SEVERE)
+					logTraceStack(f)
+					return errors.New(errMsg)
+				}
 				objField.Fvalue = value
 				obj.FieldTable[fieldName] = objField
 			}


### PR DESCRIPTION
Mods:
* Added an ```isLatin1``` Go method to new source file ```javaLangStringBuilder.go```. Always true. Someday, it meeds to be a real test as indicated by the TODO comment.
* Fixed run.go PUTFIELD to diagnose a missing superclass field.