### PR TITLE
Fix JACOBIN-420/421 + logTraceStack enhancement + show statics table

### DIFF
--- a/src/classloader/classes.go
+++ b/src/classloader/classes.go
@@ -212,9 +212,9 @@ func FetchMethodAndCP(className, methName, methType string) (MTentry, error) {
 			if methName == "main" {
 				// the starting className is always loaded, so if main() isn't found
 				// right away, just bail.
-
+				shutdown.Exit(shutdown.JVM_EXCEPTION)
 				noMainError(origClassName)
-				// noMainError() calls shutdown.Exit(). However, in test mode, shutdown.Eexit() doesn't exit,
+				// noMainError() calls shutdown.Exit(). However, in test mode, shutdown.Exit() doesn't exit,
 				// so the following error return is needed
 				return MTentry{}, errors.New("Error: main() method not found in class " + origClassName + "\n")
 			}

--- a/src/classloader/mTable_test.go
+++ b/src/classloader/mTable_test.go
@@ -1,0 +1,28 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2023 by the Jacobin Authors. All rights reserved.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)  Consult jacobin.org.
+ */
+
+package classloader
+
+import "testing"
+
+// additional tests for loading native methods into an MTable
+// are found in the gfunction package
+func TestMtableAdd(t *testing.T) {
+	mtbl := make(MT)
+	AddEntry(&mtbl, "test1", MTentry{
+		Meth:  nil,
+		MType: 'G',
+	})
+
+	if len(mtbl) != 1 {
+		t.Errorf("Expecting MTable size of 1, got: %d", len(mtbl))
+	}
+
+	if mtbl["test1"].MType != 'G' {
+		t.Errorf("Expecting fetch of a 'G' MTable rec, but got type: %c",
+			mtbl["test1"].MType)
+	}
+}

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -319,7 +319,7 @@ func newStringFromBytes(params []interface{}) interface{} {
 
 	// Fetch a pointer to the raw slice of bytes from params[0].
 	// Convert the raw slice of bytes to a Go string.
-	wholeString := getGoString(params[0])
+	wholeString := getGoString(params[1])
 
 	// Convert the Go string to a compact string object, usable by Java. Return to caller.
 	obj := object.CreateCompactStringFromGoString(&wholeString)
@@ -338,11 +338,11 @@ func newSubstringFromBytes(params []interface{}) interface{} {
 
 	// Fetch a pointer to the raw slice of bytes from params[0].
 	// Convert the raw slice of bytes to a Go string.
-	wholeString := getGoString(params[0])
+	wholeString := getGoString(params[1])
 
 	// Get substring offset and length
-	ssOffset := params[1].(int64)
-	ssLength := params[2].(int64)
+	ssOffset := params[2].(int64)
+	ssLength := params[3].(int64)
 
 	// Validate boundaries.
 	wholeLength := int64(len(wholeString))

--- a/src/jvm/goFunctionExec.go
+++ b/src/jvm/goFunctionExec.go
@@ -127,7 +127,7 @@ func runGmethod(mt classloader.MTentry, fs *list.List, className, methodName,
 		push(gf, (*params)[j])
 	}
 
-	// Set the Go frame TOS = parent frame TOS.
+	// Set the Go frame TOS --> first parameter.
 	gf.TOS = len(gf.OpStack) - 1
 	if localDebugging || MainThread.Trace {
 		_ = log.Log("runGmethod G method OpStack:", log.WARNING)

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -95,6 +95,7 @@ func StartExec(className string, mainThread *thread.ExecThread, globals *globals
 
 	err = runThread(&MainThread)
 	if err != nil {
+		statics.DumpStatics()
 		return err
 	}
 

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -2719,7 +2719,7 @@ func runFrame(fs *list.List) error {
 func logTraceStack(f *frames.Frame) {
 	var traceInfo, output string
 	if f.TOS == -1 {
-		traceInfo = fmt.Sprintf("%55s stack <empty>", "")
+		traceInfo = fmt.Sprintf("%55s %s.%s stack <empty>", "", f.ClName, f.MethName)
 		_ = log.Log(traceInfo, log.WARNING)
 		return
 	}
@@ -2741,9 +2741,9 @@ func logTraceStack(f *frames.Frame) {
 			output = fmt.Sprintf("%T %v ", f.OpStack[ii], f.OpStack[ii])
 		}
 		if f.TOS == ii {
-			traceInfo = fmt.Sprintf("%55s TOS   [%d] %s", "", ii, output)
+			traceInfo = fmt.Sprintf("%55s %s.%s TOS   [%d] %s", "", f.ClName, f.MethName, ii, output)
 		} else {
-			traceInfo = fmt.Sprintf("%55s stack [%d] %s", "", ii, output)
+			traceInfo = fmt.Sprintf("%55s %s.%s stack [%d] %s", "", f.ClName, f.MethName, ii, output)
 		}
 		_ = log.Log(traceInfo, log.WARNING)
 	}

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -118,6 +118,7 @@ func runThread(t *thread.ExecThread) error {
 			exceptions.ShowPanicCause(r)
 			exceptions.ShowFrameStack(t)
 			exceptions.ShowGoStackTrace(nil)
+			statics.DumpStatics()
 			return shutdown.Exit(shutdown.APP_EXCEPTION)
 		}
 		return shutdown.OK

--- a/src/util/execUtilities.go
+++ b/src/util/execUtilities.go
@@ -89,6 +89,10 @@ func ParseIncomingParamsFromMethTypeString(s string) []string {
 					return make([]string, 0)
 				}
 			}
+		default:
+			errMsg := fmt.Sprintf("ParseIncomingParamsFromMethTypeString default: illegal character '%c'", paramChars[i])
+			_ = log.Log(errMsg, log.SEVERE)
+			return make([]string, 0)
 		}
 	}
 	return params

--- a/src/util/execUtilities.go
+++ b/src/util/execUtilities.go
@@ -49,9 +49,19 @@ func ParseIncomingParamsFromMethTypeString(s string) []string {
 				elements = append(elements, '[')
 				i += 1
 			}
-			// i is now pointing to the primitive in the array
+			// i is now pointing to the type-character of the array
 			elements = append(elements, paramChars[i])
 			params = append(params, string(elements))
+			if paramChars[i] == 'L' {
+				for j := i + 1; j < len(paramChars); j++ {
+					if paramChars[j] != ';' { // the end of the link is a ;
+						continue
+					} else {
+						i = j // j now points to the ;, continue will add 1
+						break
+					}
+				}
+			}
 		}
 	}
 	return params

--- a/src/util/execUtilities.go
+++ b/src/util/execUtilities.go
@@ -6,7 +6,11 @@
 
 package util
 
-import "jacobin/types"
+import (
+	"fmt"
+	"jacobin/log"
+	"jacobin/types"
+)
 
 // ParseIncomingParamsFromMethTypeString takes a type string from a CP
 // and parses its passed-in parameters, returning them in reduced form
@@ -19,6 +23,7 @@ func ParseIncomingParamsFromMethTypeString(s string) []string {
 	}
 
 	paramChars := []byte(s)
+	paramLen := len(paramChars)
 	for i := 0; i < len(paramChars); i++ {
 		switch paramChars[i] {
 		case '(':
@@ -35,7 +40,8 @@ func ParseIncomingParamsFromMethTypeString(s string) []string {
 			params = append(params, types.Double)
 		case 'L':
 			params = append(params, types.Ref)
-			for j := i + 1; j < len(paramChars); j++ {
+			var j int
+			for j = i + 1; j < paramLen; j++ {
 				if paramChars[j] != ';' { // the end of the link is a ;
 					continue
 				} else {
@@ -43,23 +49,44 @@ func ParseIncomingParamsFromMethTypeString(s string) []string {
 					break
 				}
 			}
+			if j >= paramLen {
+				errMsg := fmt.Sprintf("ParseIncomingParamsFromMethTypeString case 'L': failed to find final ';'")
+				_ = log.Log(errMsg, log.SEVERE)
+				return make([]string, 0)
+			}
 		case '[': // arrays
 			elements := make([]byte, 0)
-			for paramChars[i] == '[' {
+			for paramChars[i] == '[' && i < paramLen {
 				elements = append(elements, '[')
 				i += 1
+			}
+			if i >= paramLen {
+				errMsg := fmt.Sprintf("ParseIncomingParamsFromMethTypeString case '[': unending '[' repetitions")
+				_ = log.Log(errMsg, log.SEVERE)
+				return make([]string, 0)
+			}
+			if paramChars[i] == ')' {
+				errMsg := fmt.Sprintf("ParseIncomingParamsFromMethTypeString case '[': no array type specified")
+				_ = log.Log(errMsg, log.SEVERE)
+				return make([]string, 0)
 			}
 			// i is now pointing to the type-character of the array
 			elements = append(elements, paramChars[i])
 			params = append(params, string(elements))
 			if paramChars[i] == 'L' {
-				for j := i + 1; j < len(paramChars); j++ {
+				var j int
+				for j = i + 1; j < paramLen; j++ {
 					if paramChars[j] != ';' { // the end of the link is a ;
 						continue
 					} else {
 						i = j // j now points to the ;, continue will add 1
 						break
 					}
+				}
+				if j >= paramLen {
+					errMsg := fmt.Sprintf("ParseIncomingParamsFromMethTypeString case '[': failed to find final ';'")
+					_ = log.Log(errMsg, log.SEVERE)
+					return make([]string, 0)
 				}
 			}
 		}

--- a/src/util/execUtilities_test.go
+++ b/src/util/execUtilities_test.go
@@ -7,6 +7,7 @@
 package util
 
 import (
+	"fmt"
 	"jacobin/types"
 	"testing"
 )
@@ -42,14 +43,40 @@ func TestParseIncomingParamsFromMethType(t *testing.T) {
 // test that pointer/reference in the params is handled correctly
 // especially, that references (start with L and with ;) are correctly
 // parsed and represented in the output
-func TestParseIncomingReferenceParamsFromMethType(t *testing.T) {
-	res := ParseIncomingParamsFromMethTypeString("(LString;Ljava/lang/Integer;JJ)")
-	if len(res) != 4 { // short, byte and int all become 'I'
-		t.Errorf("Expected 4 parsed parameters, got %d", len(res))
+
+// Parameter-driven checker
+func checker(t *testing.T, methType string, expCount int, expString string) {
+	res := ParseIncomingParamsFromMethTypeString(methType)
+	if len(res) != expCount { // short, byte and int all become 'I'
+		t.Errorf("Expected %d parsed parameters, got %d", expCount, len(res))
+		for ii := 0; ii < len(res); ii++ {
+			fmt.Printf("Parameter %d: %v\n", ii, res[ii])
+		}
 	}
 
-	var params string = res[0] + res[1] + res[2] + res[3]
-	if params != "LLJJ" {
-		t.Errorf("Expected param string of 'LLJJ', got: %s", params)
+	var paramString string
+	for ii := 0; ii < len(res); ii++ {
+		paramString += res[ii]
 	}
+	if paramString != expString {
+		t.Errorf("Expected param string of '%s', got: %s", expString, paramString)
+	}
+}
+
+// Individual tests for ParseIncomingParamsFromMethTypeString
+
+func TestParseIncomingReferenceParamsFromMethType1(t *testing.T) {
+	checker(t, "(LString;Ljava/lang/Integer;JJ)V", 4, "LLJJ")
+}
+
+func TestParseIncomingReferenceParamsFromMethType2(t *testing.T) {
+	checker(t, "(Ljava/lang/String;Ljava/lang/String;)Ljava/nio/file/Path;", 2, "LL")
+}
+
+func TestParseIncomingReferenceParamsFromMethType3(t *testing.T) {
+	checker(t, "(Ljava/lang/String;[Ljava/lang/String;)Ljava/nio/file/Path;", 2, "L[L")
+}
+
+func TestParseIncomingReferenceParamsFromMethType4(t *testing.T) {
+	checker(t, "([Ljava/lang/String;)V", 1, "[L")
 }

--- a/src/util/execUtilities_test.go
+++ b/src/util/execUtilities_test.go
@@ -59,7 +59,7 @@ func checker(t *testing.T, methType string, expCount int, expString string) {
 		paramString += res[ii]
 	}
 	if paramString != expString {
-		t.Errorf("Expected param string of '%s', got: %s", expString, paramString)
+		t.Errorf("Expected param string of '%s', got: '%s'", expString, paramString)
 	}
 }
 
@@ -91,4 +91,32 @@ func TestParseIncomingReferenceParamsFromMethType6(t *testing.T) {
 
 func TestParseIncomingReferenceParamsFromMethType7(t *testing.T) {
 	checker(t, "(F[Ljava/lang/String;J[Ljava/lang/String;D)V", 5, "F[LJ[LD")
+}
+
+func TestParseIncomingReferenceParamsFromMethType8(t *testing.T) {
+	checker(t, "(F[[[[[Ljava/lang/String;J[Ljava/lang/String;D)V", 5, "F[[[[[LJ[LD")
+}
+
+func TestParseIncomingReferenceParamsFromMethType9(t *testing.T) {
+	checker(t, "(Labc)V", 0, "")
+}
+
+func TestParseIncomingReferenceParamsFromMethType10(t *testing.T) {
+	checker(t, "([Labc)V", 0, "")
+}
+
+func TestParseIncomingReferenceParamsFromMethType11(t *testing.T) {
+	checker(t, "([[[Labc)V", 0, "")
+}
+
+func TestParseIncomingReferenceParamsFromMethType12(t *testing.T) {
+	checker(t, "([[[[)V", 0, "")
+}
+
+func TestParseIncomingReferenceParamsFromMethType13(t *testing.T) {
+	checker(t, "([[[[I)V", 1, "[[[[I")
+}
+
+func TestParseIncomingReferenceParamsFromMethType14(t *testing.T) {
+	checker(t, "(JF[[[[[Ljava/lang/String;[[[J)V", 4, "JF[[[[[L[[[J")
 }

--- a/src/util/execUtilities_test.go
+++ b/src/util/execUtilities_test.go
@@ -80,3 +80,15 @@ func TestParseIncomingReferenceParamsFromMethType3(t *testing.T) {
 func TestParseIncomingReferenceParamsFromMethType4(t *testing.T) {
 	checker(t, "([Ljava/lang/String;)V", 1, "[L")
 }
+
+func TestParseIncomingReferenceParamsFromMethType5(t *testing.T) {
+	checker(t, "([Ljava/lang/String;JLjava/lang/String;)V", 3, "[LJL")
+}
+
+func TestParseIncomingReferenceParamsFromMethType6(t *testing.T) {
+	checker(t, "([Ljava/lang/String;J[Ljava/lang/String;)V", 3, "[LJ[L")
+}
+
+func TestParseIncomingReferenceParamsFromMethType7(t *testing.T) {
+	checker(t, "(F[Ljava/lang/String;J[Ljava/lang/String;D)V", 5, "F[LJ[LD")
+}

--- a/src/util/execUtilities_test.go
+++ b/src/util/execUtilities_test.go
@@ -45,10 +45,10 @@ func TestParseIncomingParamsFromMethType(t *testing.T) {
 // parsed and represented in the output
 
 // Parameter-driven checker
-func checker(t *testing.T, methType string, expCount int, expString string) {
+func checker(t *testing.T, caller int, methType string, expCount int, expString string) {
 	res := ParseIncomingParamsFromMethTypeString(methType)
 	if len(res) != expCount { // short, byte and int all become 'I'
-		t.Errorf("Expected %d parsed parameters, got %d", expCount, len(res))
+		t.Errorf("[%d] Expected %d parsed parameters, got %d", caller, expCount, len(res))
 		for ii := 0; ii < len(res); ii++ {
 			fmt.Printf("Parameter %d: %v\n", ii, res[ii])
 		}
@@ -59,64 +59,80 @@ func checker(t *testing.T, methType string, expCount int, expString string) {
 		paramString += res[ii]
 	}
 	if paramString != expString {
-		t.Errorf("Expected param string of '%s', got: '%s'", expString, paramString)
+		t.Errorf("[%d] Expected param string of '%s', got: '%s'", caller, expString, paramString)
 	}
 }
 
 // Individual tests for ParseIncomingParamsFromMethTypeString
 
 func TestParseIncomingReferenceParamsFromMethType1(t *testing.T) {
-	checker(t, "(LString;Ljava/lang/Integer;JJ)V", 4, "LLJJ")
+	checker(t, 1, "(LString;Ljava/lang/Integer;JJ)V", 4, "LLJJ")
 }
 
 func TestParseIncomingReferenceParamsFromMethType2(t *testing.T) {
-	checker(t, "(Ljava/lang/String;Ljava/lang/String;)Ljava/nio/file/Path;", 2, "LL")
+	checker(t, 2, "(Ljava/lang/String;Ljava/lang/String;)Ljava/nio/file/Path;", 2, "LL")
 }
 
 func TestParseIncomingReferenceParamsFromMethType3(t *testing.T) {
-	checker(t, "(Ljava/lang/String;[Ljava/lang/String;)Ljava/nio/file/Path;", 2, "L[L")
+	checker(t, 3, "(Ljava/lang/String;[Ljava/lang/String;)Ljava/nio/file/Path;", 2, "L[L")
 }
 
 func TestParseIncomingReferenceParamsFromMethType4(t *testing.T) {
-	checker(t, "([Ljava/lang/String;)V", 1, "[L")
+	checker(t, 4, "([Ljava/lang/String;)V", 1, "[L")
 }
 
 func TestParseIncomingReferenceParamsFromMethType5(t *testing.T) {
-	checker(t, "([Ljava/lang/String;JLjava/lang/String;)V", 3, "[LJL")
+	checker(t, 5, "([Ljava/lang/String;JLjava/lang/String;)V", 3, "[LJL")
 }
 
 func TestParseIncomingReferenceParamsFromMethType6(t *testing.T) {
-	checker(t, "([Ljava/lang/String;J[Ljava/lang/String;)V", 3, "[LJ[L")
+	checker(t, 6, "([Ljava/lang/String;J[Ljava/lang/String;)V", 3, "[LJ[L")
 }
 
 func TestParseIncomingReferenceParamsFromMethType7(t *testing.T) {
-	checker(t, "(F[Ljava/lang/String;J[Ljava/lang/String;D)V", 5, "F[LJ[LD")
+	checker(t, 7, "(F[Ljava/lang/String;J[Ljava/lang/String;D)V", 5, "F[LJ[LD")
 }
 
 func TestParseIncomingReferenceParamsFromMethType8(t *testing.T) {
-	checker(t, "(F[[[[[Ljava/lang/String;J[Ljava/lang/String;D)V", 5, "F[[[[[LJ[LD")
+	checker(t, 8, "(F[[[[[Ljava/lang/String;J[Ljava/lang/String;D)V", 5, "F[[[[[LJ[LD")
 }
 
 func TestParseIncomingReferenceParamsFromMethType9(t *testing.T) {
-	checker(t, "(Labc)V", 0, "")
+	checker(t, 9, "(Labc)V", 0, "")
 }
 
 func TestParseIncomingReferenceParamsFromMethType10(t *testing.T) {
-	checker(t, "([Labc)V", 0, "")
+	checker(t, 10, "([Labc)V", 0, "")
 }
 
 func TestParseIncomingReferenceParamsFromMethType11(t *testing.T) {
-	checker(t, "([[[Labc)V", 0, "")
+	checker(t, 11, "([[[Labc)V", 0, "")
 }
 
 func TestParseIncomingReferenceParamsFromMethType12(t *testing.T) {
-	checker(t, "([[[[)V", 0, "")
+	checker(t, 12, "([[[[)V", 0, "")
 }
 
 func TestParseIncomingReferenceParamsFromMethType13(t *testing.T) {
-	checker(t, "([[[[I)V", 1, "[[[[I")
+	checker(t, 13, "([[[[I)V", 1, "[[[[I")
 }
 
 func TestParseIncomingReferenceParamsFromMethType14(t *testing.T) {
-	checker(t, "(JF[[[[[Ljava/lang/String;[[[J)V", 4, "JF[[[[[L[[[J")
+	checker(t, 14, "(JF[[[[[Ljava/lang/String;[[[J)V", 4, "JF[[[[[L[[[J")
+}
+
+func TestParseIncomingReferenceParamsFromMethType15(t *testing.T) {
+	checker(t, 15, "(JD[[[[[Ljava/lang/String;[[[J%)V", 0, "")
+}
+
+func TestParseIncomingReferenceParamsFromMethType16(t *testing.T) {
+	checker(t, 16, "(JD[[I[[[Ljava/lang/String;[[[J)V", 5, "JD[[I[[[L[[[J")
+}
+
+func TestParseIncomingReferenceParamsFromMethType17(t *testing.T) {
+	checker(t, 17, "(JD[I[F[[[Ljava/lang/String;%[[[J)V", 0, "")
+}
+
+func TestParseIncomingReferenceParamsFromMethType18(t *testing.T) {
+	checker(t, 18, "(JD[I[F[[[Ljava/lang/String;[[[J)V", 6, "JD[I[F[[[L[[[J")
 }


### PR DESCRIPTION
* Fix JACOBIN-420 : Context - execUtilities.go ParseIncomingParamsFromMethTypeString. While scanning the input string and detecting case '[' (array), the element type is ascertained. But, when the type indicates a reference array (L), we were not flushing to the semicolon (;) as the parallel case 'L' does. This has been addressed to employ the same flushing technique.
* Fix JACOBIN-420 : Context - execUtilities.go ParseIncomingParamsFromMethTypeString. Was not checking for the error cases:
     - No semicolon present to terminate an L element.
     - In the array case, no element type present (encountered a right parenthesis immediately after the last [-character).
     - Illegal characters that start an element type.
* Fix JACOBIN-421 : new String issues. First parameter now holds the "java/lang/String" object, not the first parameter supplied by the user.
* More ParseIncomingParamsFromMethTypeString unit tests have been added to execUtilities_test.go.
* In run.go, when a thread returns an error or when untrapped panic occurs, dump the statics table.  
* In run.go, logTraceStack has been enhanced to show the class.method information.