### PR TITLE
JACOBIN-439 Inhibit warning message for multidimensional REF arrays

### DIFF
--- a/src/jvm/arrays_test.go
+++ b/src/jvm/arrays_test.go
@@ -119,13 +119,12 @@ func TestAaloadWithNil(t *testing.T) {
 	}
 }
 
-// NEWARRAY: create an array of integers.
-// AASTORE: store value in array of bytes.
+// NEWARRAY: create an array of T_INT.
+// AASTORE: store the array.
 //
-// Create an array of 30 elements, store ptr value in array[20],
-// then go through all the elements in the array, and test for
-// a non-nil value. Should result in a single non-nil value.
-// TODO: Needs to be fixed, the array should be an array of references created with ANEWARRAY
+// Create an array of 30 elements and store ptr value in array[20].
+// Then, go through all the elements in the array and test for
+// a zero value in each element.
 func TestAastore(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
 	push(&f, int64(30))                   // make the array 30 elements big

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -2117,7 +2117,7 @@ frameInterpreter:
 			f.PC += 1
 
 			actualType := object.JdkArrayTypeToJacobinType(arrayType)
-			if actualType == object.ERROR {
+			if actualType == object.ERROR || actualType == object.REF {
 				glob.ErrorGoStack = string(debug.Stack())
 				errMsg := "NEWARRAY: Invalid array type specified"
 				_ = log.Log(errMsg, log.SEVERE)

--- a/src/object/arrays.go
+++ b/src/object/arrays.go
@@ -7,7 +7,6 @@
 package object
 
 import (
-	"jacobin/log"
 	"jacobin/types"
 )
 
@@ -115,7 +114,7 @@ func Make1DimArray(arrType uint8, size int64) *Object {
 		of = Field{Ftype: types.FloatArray, Fvalue: &farArr}
 		o.Fields = append(o.Fields, of)
 	case REF: // reference/pointer arrays
-		_ = log.Log("object.Make1DimArray() should not be used to create a Reference Array", log.WARNING)
+		// JACOBIN-439: _ = log.Log("object.Make1DimArray() should not be used to create a Reference Array", log.WARNING)
 		rarArr := make([]*Object, size)
 		of = Field{Ftype: types.RefArray, Fvalue: &rarArr}
 		o.Fields = append(o.Fields, of)


### PR DESCRIPTION
See discussion in 
https://jacobin.myjetbrains.com/youtrack/issue/JACOBIN-439/object.Make1DimArray-should-not-be-used-to-create-a-Reference-Array

Modifications:
* jvm/run.go NEWARRAY: Diagnose references as well as ERROR.
* jvm/arrays_test.go: 
     - Fixed the unit tests.
     - Added unit test ```TestNewrrayInvalidTypeRef```.
     - Renamed unit test ```TestNewrrayInvalidType``` to ```TestNewrrayInvalidTypeError```.
     - Changed ```TestAastore``` to use NEWARRAY (as coded) but with an integer array. There is an ANEWARRAY test subsequently in unit test ```TestAnewrray```.