### PR TITLE
JACOBIN-444, JACOBIN-445

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,15 +17,15 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@main
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@main
       with:
-        go-version: '1.21.4'
+        go-version: '1.21.x'
       
     - name: Setup JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@main
       with:
         distribution: 'oracle'
         java-version: '17'
@@ -46,7 +46,7 @@ jobs:
         go test -v ./...
 
     - name: Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@main
 
   windows-build-and-test:
     strategy:
@@ -54,15 +54,15 @@ jobs:
         os: [windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@main
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@main
       with:
-        go-version: '1.21.4'
+        go-version: '1.21.x'
       
     - name: Setup JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@main
       with:
         distribution: 'oracle'
         java-version: '17'
@@ -89,4 +89,4 @@ jobs:
         go test -v ./...
 
     - name: Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@main

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
**JACOBIN-444**

The original versions of github actions workflow .yml files for boith jacobin and jacotest.go were based on github actions examples that make use of versioned copies of actions. However, most folks (users) simply want the "latest, stable" version. 

This has been an irritant for some time. The solution has been available for a long time: use a version reference of "main".

E.g. ```uses: actions/checkout@v3``` -----> ```uses: actions/checkout@main```

**JACOBIN-445**

There is no codecov.yml file. I am trying out a simple, informational-only file.