### PR TITLE
Jacobin does not currently need codecov in github actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,9 +45,6 @@ jobs:
         export JACOBIN_EXE=`pwd`/jacobin 
         go test -v ./...
 
-    - name: Codecov
-      uses: codecov/codecov-action@main
-
   windows-build-and-test:
     strategy:
       matrix:
@@ -87,6 +84,3 @@ jobs:
         $Env:JACOBIN_EXE += '\src\jacobin.exe'
         $Env:JACOBIN_EXE
         go test -v ./...
-
-    - name: Codecov
-      uses: codecov/codecov-action@main

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        informational: true
-    patch:
-      default:
-        informational: true


### PR DESCRIPTION
As @platypusguy stated in JACOBIN-445, there is no current need to do code coverage processing in the github actions workflow. Should the need arise in the future, we can readily add those steps.