### PR TITLE
JACOBIN-450 Base of G migration + 6 converted math functions + more

### DIFF
--- a/src/exceptions/throw.go
+++ b/src/exceptions/throw.go
@@ -7,8 +7,11 @@
 package exceptions
 
 import (
+	"fmt"
 	"jacobin/classloader"
 	"jacobin/frames"
+	"jacobin/globals"
+	"jacobin/log"
 	"jacobin/opcodes"
 	"jacobin/util"
 )
@@ -23,6 +26,19 @@ import (
 // accomplish this, we generate bytecodes which are then placed in the frame of
 // the current thread.
 func ThrowEx(which int, msg string, f *frames.Frame) {
+
+	// If tracing, announce.
+	helloMsg := fmt.Sprintf("[ThrowEx] Arrived, which: %d, msg: %s", which, msg)
+	log.Log(helloMsg, log.TRACE_INST)
+
+	// If in a unit test, log a severe message and return.
+	glob := globals.GetGlobalRef()
+	if glob.JacobinName == "test" {
+		errMsg := fmt.Sprintf("[ThrowEx][test] %s", msg)
+		log.Log(errMsg, log.SEVERE)
+		return
+	}
+
 	// the name of the exception as shown to the user
 	exceptionNameForUser := JVMexceptionNames[which]
 

--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -9,12 +9,28 @@ package gfunction
 import "jacobin/classloader"
 
 // GMeth is the entry in the MTable for Go functions. See MTable comments for details.
-// Fu is a go function. All go functions accept a possibly empty slice of interface{} and
-// return a possibly nil interface{}
+// * ParamSlots - the number of user parameters in a G function. E.g. For atan2, this would be 2.
+// * GFunction - a go function. All go functions accept a possibly empty slice of interface{} and
+//               return an interface{} which might be nil (E.g. Java void).
+// * NeedsContext - does this method need a pointer to the frame stack? Defaults to false.
 type GMeth struct {
 	ParamSlots   int
 	GFunction    func([]interface{}) interface{}
-	NeedsContext bool // does this method need a pointer to the frame stack? Defaults to false.
+	NeedsContext bool 
+}
+
+// G function error block.
+type GErrBlk struct {
+	ExceptionType int
+	ErrMsg        string
+}
+
+// Construct a G function error block. Return a ptr to it.
+func getGErrBlk(exceptionType int, errMsg string) *GErrBlk {
+	var gErrBlk GErrBlk
+	gErrBlk.ExceptionType = exceptionType
+	gErrBlk.ErrMsg = errMsg
+	return &gErrBlk
 }
 
 // MTableLoadNatives loads the Go methods from files that contain them. It does this

--- a/src/gfunction/javaIoPrintStream.go
+++ b/src/gfunction/javaIoPrintStream.go
@@ -277,7 +277,13 @@ func Printf(params []interface{}) interface{} {
 	var intfSprintf = new([]interface{})
 	*intfSprintf = append(*intfSprintf, params[1])
 	*intfSprintf = append(*intfSprintf, params[2])
-	objPtr := StringFormatter(*intfSprintf)
+	retval := StringFormatter(*intfSprintf)
+	switch retval.(type) {
+	case *object.Object:
+	default:
+		return retval
+	}
+	objPtr := retval.(*object.Object)
 	str := object.GetGoStringFromJavaStringPtr(objPtr)
 	fmt.Print(str)
 	return params[0] // Return the PrintStream object

--- a/src/gfunction/javaLangMath.go
+++ b/src/gfunction/javaLangMath.go
@@ -220,9 +220,9 @@ func Load_Lang_Math() map[string]GMeth {
 func mathClinit([]interface{}) interface{} {
 	klass := classloader.MethAreaFetch("java/lang/Math")
 	if klass == nil {
-		errMsg := "In <clinit>, expected java/lang/Math to be in the MethodArea, but it was not"
+		errMsg := "mathClinit, expected java/lang/Math to be in the MethodArea, but it was not"
 		_ = log.Log(errMsg, log.SEVERE)
-		exceptions.Throw(exceptions.VirtualMachineError, errMsg)
+		exceptions.ThrowEx(exceptions.VirtualMachineError, errMsg, nil)
 	}
 	return nil
 }

--- a/src/gfunction/javaLangMath.go
+++ b/src/gfunction/javaLangMath.go
@@ -322,9 +322,9 @@ func floorFloat64(params []interface{}) interface{} {
 
 // Largest (closest to positive infinity) int value that is less than or equal
 // to the algebraic quotient.
-func floorDivInt64(dividend int64, divisor int64) int64 {
+func floorDivInt64(dividend int64, divisor int64) interface{} {
 	if divisor == 0 {
-		exceptions.Throw(exceptions.ArithmeticException, "floorDivInt64: Divide by zero attempted")
+		return getGErrBlk(exceptions.ArithmeticException, "floorDivInt64: Divide by zero attempted")
 	}
 	if dividend <= math.MinInt64 && divisor == -1 {
 		return math.MinInt64
@@ -347,16 +347,30 @@ func floorDivJx(params []interface{}) interface{} {
 }
 
 // Largest (closest to positive infinity) int value that is less than or equal
-// to the algebraic quotient. Param[0]=dividend and param[1]=divisor.
+// to the algebraic quotient.
+// params[0]=dividend=x
+// params[1]=divisor=y
 // floorDiv(x, y) * y + floorMod(x, y) = x
 // Therefore, floorMod(x, y) = x - floorDiv(x, y) * y
 func floorModII(params []interface{}) interface{} {
-	fldiv := (floorDivII(params)).(int64)
-	return params[0].(int64) - fldiv*params[1].(int64)
+	fldiv := floorDivII(params)
+	switch fldiv.(type) {
+	case *GErrBlk:
+		// Return the G function error block
+		return fldiv
+	}
+	result := params[0].(int64) - fldiv.(int64)*params[1].(int64)
+	return result
 }
 func floorModJx(params []interface{}) interface{} {
-	fldiv := (floorDivJx(params)).(int64)
-	return params[0].(int64) - fldiv*params[2].(int64)
+	fldiv := floorDivJx(params)
+	switch fldiv.(type) {
+	case *GErrBlk:
+		// Return the G function error block
+		return fldiv
+	}
+	result := params[0].(int64) - fldiv.(int64)*params[2].(int64)
+	return result
 }
 
 // FMA (fused multiply add) the three arguments; that is, returns the exact product

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -277,8 +277,8 @@ func Load_Lang_String() map[string]GMeth {
 func stringClinit([]interface{}) interface{} {
 	klass := classloader.MethAreaFetch("java/lang/String")
 	if klass == nil {
-		errMsg := "In stringClinit, expected java/lang/String to be in the MethodArea, but it was not"
-		exceptions.Throw(exceptions.VirtualMachineError, errMsg)
+		errMsg := "stringClinit: Expected java/lang/String to be in the MethodArea, but it was not"
+		return getGErrBlk(exceptions.VirtualMachineError, errMsg)
 	}
 	klass.Data.ClInit = types.ClInitRun // just mark that String.<clinit>() has been run
 	return nil

--- a/src/gfunction/javaLangSystem.go
+++ b/src/gfunction/javaLangSystem.go
@@ -108,9 +108,9 @@ func Load_Lang_System() map[string]GMeth {
 func clinit([]interface{}) interface{} {
 	klass := classloader.MethAreaFetch("java/lang/System")
 	if klass == nil {
-		errMsg := "In <clinit>, expected java/lang/System to be in the MethodArea, but it was not"
+		errMsg := "System <clinit>: Expected java/lang/System to be in the MethodArea, but it was not"
 		_ = log.Log(errMsg, log.SEVERE)
-		exceptions.Throw(exceptions.VirtualMachineError, errMsg)
+		exceptions.ThrowEx(exceptions.VirtualMachineError, errMsg, nil)
 	}
 	if klass.Data.ClInit != types.ClInitRun {
 		_ = statics.AddStatic("java/lang/System.in", statics.Static{Type: "L", Value: object.Null})

--- a/src/gfunction/jdkMiscUnsafe.go
+++ b/src/gfunction/jdkMiscUnsafe.go
@@ -7,7 +7,6 @@
 package gfunction
 
 import (
-	"errors"
 	"jacobin/exceptions"
 	"jacobin/object"
 )
@@ -51,8 +50,7 @@ func arrayBaseOffset(param []interface{}) interface{} {
 	p := param[0]
 	if p == nil || p == object.Null {
 		errMsg := "jdk.internal.misc.Unsafe::arrayBaseOffset() was passed a null pointer"
-		exceptions.Throw(exceptions.NullPointerException, errMsg)
-		return errors.New(errMsg)
+		return getGErrBlk(exceptions.NullPointerException, errMsg)
 	}
 	return int64(0) // this should work...
 }

--- a/src/jvm/TestHexIDIVexception_test.go
+++ b/src/jvm/TestHexIDIVexception_test.go
@@ -132,8 +132,8 @@ func TestHexIDIVException(t *testing.T) {
 
 	os.Stderr = normalStderr
 	os.Stdout = normalStdout
-	if !strings.Contains(string(msgStderr), "java.lang.ArithmeticException: IDIV: division by zero") {
-		t.Errorf("Error expected 'java.lang.ArithmeticException: IDIV: division by zero', got: %s\n",
-			string(msgStderr))
+	msgExpected := "IDIV: division by zero"
+	if !strings.Contains(string(msgStderr), msgExpected) {
+		t.Errorf("Error expected '%s', got: %s\n", msgExpected, string(msgStderr))
 	}
 }

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -160,7 +160,7 @@ frameInterpreter:
 	// if the return value (here, retval) is not nil, it is placed on the stack
 	// of the calling frame.
 	if f.Ftype == 'G' {
-		retval, slotCount, err := runGframe(f)
+		retval, slotCount, err := runGframe(fs, f)
 
 		if retval != nil {
 			f = fs.Front().Next().Value.(*frames.Frame)


### PR DESCRIPTION
Impacted source code:
- exceptions/throw.go
- jvm/TestHexIDIVexception_test.go
- jvm/goFunctionExec.go
- jvm/run.go
- gfunction/gfunction.go
- gfunction/javaIoPrintStream.go
- gfunction/javaLangMath.go
- gfunction/javaLangString.go
- gfunction/javaLangSystem.go
- gfunction/jdkMiscUnsafe.go

More and more.
Little by little.

No javaPrimitives.go functions yet.