### PR TITLE
Suggestion for unit tests: add display of expectation

### DIFF
--- a/src/gfunction/javaLangString_test.go
+++ b/src/gfunction/javaLangString_test.go
@@ -39,7 +39,8 @@ func TestStringToUpperCase(t *testing.T) {
 	params := []interface{}{s}
 	s2 := toUpperCase(params)
 	sUpper := object.GetGoStringFromJavaStringPtr(s2.(*object.Object))
-	if string(sUpper) != "HELLO" {
-		t.Errorf("string toUpperCase failed, expected: HELLO, observed: %s", sUpper)
+	expValue := "HELLO"
+	if string(sUpper) != expValue {
+		t.Errorf("string toUpperCase failed, expected: %s, observed: %s", expValue, sUpper)
 	}
 }

--- a/src/gfunction/javaLangString_test.go
+++ b/src/gfunction/javaLangString_test.go
@@ -40,6 +40,6 @@ func TestStringToUpperCase(t *testing.T) {
 	s2 := toUpperCase(params)
 	sUpper := object.GetGoStringFromJavaStringPtr(s2.(*object.Object))
 	if string(sUpper) != "HELLO" {
-		t.Errorf("string ToUpperCase failed, got %s", sUpper)
+		t.Errorf("string toUpperCase failed, expected: HELLO, observed: %s", sUpper)
 	}
 }


### PR DESCRIPTION
It's helpful when looking through failed unit test results to see the expected value as well as the observed value.
