### PR TITLE
JACOBIN-456 Integer only

### DIFF
--- a/src/gfunction/javaPrimitives.go
+++ b/src/gfunction/javaPrimitives.go
@@ -509,7 +509,7 @@ func doubleDoubleValue(params []interface{}) interface{} {
 func integerValueOf(params []interface{}) interface{} {
 	// fmt.Printf("DEBUG integerValueOf at entry params[0]: (%T) %v\n", params[0], params[0])
 	int64Value := params[0].(int64)
-	return populateInteger(int64Value)
+	return populator("java/lang/Integer", types.Int, int64Value)
 }
 
 func integerDecode(params []interface{}) interface{} {
@@ -544,7 +544,7 @@ func integerDecode(params []interface{}) interface{} {
 	}
 
 	// Create Integer object.
-	return populateInteger(int64Value)
+	return populator("java/lang/Integer", types.Int, int64Value)
 }
 
 func integerParseInt(params []interface{}) interface{} {

--- a/src/gfunction/javaPrimitives.go
+++ b/src/gfunction/javaPrimitives.go
@@ -593,7 +593,7 @@ func integerParseInt(params []interface{}) interface{} {
 	if output > MaxIntValue {
 		return getGErrBlk(exceptions.NumberFormatException, "javaPrimitives.integerParseInt: upper limit is Integer.MAX_VALUE")
 	}
-	if output < -MinIntValue {
+	if output < MinIntValue {
 		return getGErrBlk(exceptions.NumberFormatException, "javaPrimitives.integerParseInt: lower limit is Integer.MIN_VALUE")
 	}
 

--- a/src/gfunction/javaPrimitives.go
+++ b/src/gfunction/javaPrimitives.go
@@ -21,6 +21,8 @@ import (
 // Radix boundaries:
 var minRadix int64 = 2
 var maxRadix int64 = 36
+var MaxIntValue int64 = 2147483647
+var MinIntValue int64 = -2147483648
 
 func Load_Primitives() map[string]GMeth {
 
@@ -586,6 +588,16 @@ func integerParseInt(params []interface{}) interface{} {
 		errMsg := fmt.Sprintf("javaPrimitives.integerParseInt: arg=%s, radix=%d, err: %s", strArg, rdx, err.Error())
 		return getGErrBlk(exceptions.NumberFormatException, errMsg)
 	}
+
+	// Check Integer boundaries.
+	if output > MaxIntValue {
+		return getGErrBlk(exceptions.NumberFormatException, "javaPrimitives.integerParseInt: upper limit is Integer.MAX_VALUE")
+	}
+	if output < -MinIntValue {
+		return getGErrBlk(exceptions.NumberFormatException, "javaPrimitives.integerParseInt: lower limit is Integer.MIN_VALUE")
+	}
+
+	// Return computed value.
 	return output
 }
 

--- a/src/gfunction/javaPrimitives.go
+++ b/src/gfunction/javaPrimitives.go
@@ -508,10 +508,8 @@ func doubleDoubleValue(params []interface{}) interface{} {
 
 func integerValueOf(params []interface{}) interface{} {
 	// fmt.Printf("DEBUG integerValueOf at entry params[0]: (%T) %v\n", params[0], params[0])
-	ii := params[0].(int64)
-	objPtr := object.MakePrimitiveObject("java/lang/Integer", types.Int, ii)
-	populateInteger(objPtr, ii)
-	return objPtr
+	int64Value := params[0].(int64)
+	return populateInteger(int64Value)
 }
 
 func integerDecode(params []interface{}) interface{} {
@@ -546,10 +544,7 @@ func integerDecode(params []interface{}) interface{} {
 	}
 
 	// Create Integer object.
-	objPtr := object.MakePrimitiveObject("java/lang/Integer", types.Int, int64Value)
-	populateInteger(objPtr, int64Value)
-
-	return objPtr
+	return populateInteger(int64Value)
 }
 
 func integerParseInt(params []interface{}) interface{} {

--- a/src/gfunction/primiFactory.go
+++ b/src/gfunction/primiFactory.go
@@ -1,6 +1,7 @@
 package gfunction
 
 import (
+	"fmt"
 	"jacobin/classloader"
 	"jacobin/exceptions"
 	"jacobin/object"
@@ -8,15 +9,15 @@ import (
 	"math"
 )
 
-func populateInteger(value int64) interface{} {
-	klass := classloader.MethAreaFetch("java/lang/Integer")
+func populator(classname string, fldtype string, value int64) interface{} {
+	klass := classloader.MethAreaFetch(classname)
 	if klass == nil {
-		errMsg := "populateInteger: Could not find java/lang/Integer in the MethodArea"
+		errMsg := fmt.Sprintf("populator: Could not find %s in the MethodArea", classname)
 		return getGErrBlk(exceptions.VirtualMachineError, errMsg)
 	}
 	klass.Data.ClInit = types.ClInitRun // just mark that String.<clinit>() has been run
-	objPtr := object.MakePrimitiveObject("java/lang/Integer", types.Int, value)
-	(*objPtr).FieldTable["value"] = &object.Field{types.Int, value}
+	objPtr := object.MakePrimitiveObject(classname, fldtype, value)
+	(*objPtr).FieldTable["value"] = &object.Field{fldtype, value}
 	return objPtr
 }
 

--- a/src/gfunction/primiFactory.go
+++ b/src/gfunction/primiFactory.go
@@ -9,7 +9,7 @@ import (
 	"math"
 )
 
-func populator(classname string, fldtype string, value int64) interface{} {
+func populator(classname string, fldtype string, value interface{}) interface{} {
 	klass := classloader.MethAreaFetch(classname)
 	if klass == nil {
 		errMsg := fmt.Sprintf("populator: Could not find %s in the MethodArea", classname)

--- a/src/gfunction/primiFactory.go
+++ b/src/gfunction/primiFactory.go
@@ -1,18 +1,31 @@
 package gfunction
 
 import (
+	"jacobin/classloader"
+	"jacobin/exceptions"
 	"jacobin/object"
+	"jacobin/types"
 	"math"
 )
 
-var singletonName = "value"
+func populateInteger(value int64) interface{} {
+	klass := classloader.MethAreaFetch("java/lang/Integer")
+	if klass == nil {
+		errMsg := "populateInteger: Could not find java/lang/Integer in the MethodArea"
+		return getGErrBlk(exceptions.VirtualMachineError, errMsg)
+	}
+	klass.Data.ClInit = types.ClInitRun // just mark that String.<clinit>() has been run
+	objPtr := object.MakePrimitiveObject("java/lang/Integer", types.Int, value)
+	(*objPtr).FieldTable["value"] = &object.Field{types.Int, value}
+	return objPtr
+}
 
 func populateByte(objPtr *object.Object, value int64) {
 	(*objPtr).FieldTable["BYTES"] = &object.Field{"I", 1}
 	(*objPtr).FieldTable["MAX_VALUE"] = &object.Field{"B", 0x7f}
 	(*objPtr).FieldTable["MIN_VALUE"] = &object.Field{"B", 0x80}
 	(*objPtr).FieldTable["SIZE"] = &object.Field{"I", 8}
-	(*objPtr).FieldTable[singletonName] = &object.Field{"B", value}
+	(*objPtr).FieldTable["value"] = &object.Field{"B", value}
 }
 
 func populateCharacter(objPtr *object.Object, value int64) {
@@ -85,7 +98,7 @@ func populateCharacter(objPtr *object.Object, value int64) {
 	(*objPtr).FieldTable["TITLECASE_LETTER"] = &object.Field{"B", 0x3}
 	(*objPtr).FieldTable["UNASSIGNED"] = &object.Field{"B", 0x0}
 	(*objPtr).FieldTable["UPPERCASE_LETTER"] = &object.Field{"B", 0x1}
-	(*objPtr).FieldTable[singletonName] = &object.Field{"C", value}
+	(*objPtr).FieldTable["value"] = &object.Field{"C", value}
 }
 
 func populateDouble(objPtr *object.Object, value float64) {
@@ -99,7 +112,7 @@ func populateDouble(objPtr *object.Object, value float64) {
 	(*objPtr).FieldTable["NEGATIVE_INFINITY"] = &object.Field{"D", math.Inf(-1)}
 	(*objPtr).FieldTable["POSITIVE_INFINITY"] = &object.Field{"D", math.Inf(+1)}
 	(*objPtr).FieldTable["SIZE"] = &object.Field{"I", 64}
-	(*objPtr).FieldTable[singletonName] = &object.Field{"D", value}
+	(*objPtr).FieldTable["value"] = &object.Field{"D", value}
 }
 
 func populateFloat(objPtr *object.Object, value float64) {
@@ -113,15 +126,7 @@ func populateFloat(objPtr *object.Object, value float64) {
 	(*objPtr).FieldTable["NEGATIVE_INFINITY"] = &object.Field{"F", math.Inf(-1)}
 	(*objPtr).FieldTable["POSITIVE_INFINITY"] = &object.Field{"F", math.Inf(+1)}
 	(*objPtr).FieldTable["SIZE"] = &object.Field{"I", 32}
-	(*objPtr).FieldTable[singletonName] = &object.Field{"D", value}
-}
-
-func populateInteger(objPtr *object.Object, value int64) {
-	(*objPtr).FieldTable["BYTES"] = &object.Field{"I", 4}
-	(*objPtr).FieldTable["MAX_VALUE"] = &object.Field{"I", 2147483647}
-	(*objPtr).FieldTable["MIN_VALUE"] = &object.Field{"I", -2147483648}
-	(*objPtr).FieldTable["SIZE"] = &object.Field{"I", 32}
-	(*objPtr).FieldTable[singletonName] = &object.Field{"I", value}
+	(*objPtr).FieldTable["value"] = &object.Field{"D", value}
 }
 
 func populateLong(objPtr *object.Object, value int64) {
@@ -129,7 +134,7 @@ func populateLong(objPtr *object.Object, value int64) {
 	(*objPtr).FieldTable["MAX_VALUE"] = &object.Field{"J", 9223372036854775807}
 	(*objPtr).FieldTable["MIN_VALUE"] = &object.Field{"J", -9223372036854775808}
 	(*objPtr).FieldTable["SIZE"] = &object.Field{"I", 64}
-	(*objPtr).FieldTable[singletonName] = &object.Field{"J", value}
+	(*objPtr).FieldTable["value"] = &object.Field{"J", value}
 }
 
 func populateShort(objPtr *object.Object, value int64) {
@@ -137,5 +142,5 @@ func populateShort(objPtr *object.Object, value int64) {
 	(*objPtr).FieldTable["MAX_VALUE"] = &object.Field{"S", 32767}
 	(*objPtr).FieldTable["MIN_VALUE"] = &object.Field{"S", -32768}
 	(*objPtr).FieldTable["SIZE"] = &object.Field{"I", 16}
-	(*objPtr).FieldTable[singletonName] = &object.Field{"S", value}
+	(*objPtr).FieldTable["value"] = &object.Field{"S", value}
 }

--- a/src/statics/loadPrimiStatics.go
+++ b/src/statics/loadPrimiStatics.go
@@ -1,0 +1,144 @@
+package statics
+
+// Reference: https://docs.oracle.com/en/java/javase/17/docs/api/constant-values.html
+
+import (
+	"jacobin/types"
+	"math"
+)
+
+func LoadStaticsByte() {
+	_ = AddStatic("java/lang/Byte.BYTES", Static{Type: types.Int, Value: int64(1)})
+	_ = AddStatic("java/lang/Byte.MAX_VALUE", Static{Type: types.Byte, Value: int64(0x7f)})
+	_ = AddStatic("java/lang/Byte.MIN_VALUE", Static{Type: types.Byte, Value: int64(0x80)})
+	_ = AddStatic("java/lang/Byte.SIZE", Static{Type: types.Int, Value: int64(8)})
+}
+
+func LoadStaticsCharacter() {
+	_ = AddStatic("java/lang/Character.BYTES", Static{Type: types.Int, Value: int64(2)})
+	_ = AddStatic("java/lang/Character.COMBINING_SPACING_MARK", Static{Type: types.Byte, Value: int64(0x8)})
+	_ = AddStatic("java/lang/Character.CONNECTOR_PUNCTUATION", Static{Type: types.Byte, Value: int64(0x17)})
+	_ = AddStatic("java/lang/Character.CONTROL", Static{Type: types.Byte, Value: int64(0xf)})
+	_ = AddStatic("java/lang/Character.CURRENCY_SYMBOL", Static{Type: types.Byte, Value: int64(0x1a)})
+	_ = AddStatic("java/lang/Character.DASH_PUNCTUATION", Static{Type: types.Byte, Value: int64(0x14)})
+	_ = AddStatic("java/lang/Character.DECIMAL_DIGIT_NUMBER", Static{Type: types.Byte, Value: int64(0x9)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_ARABIC_NUMBER", Static{Type: types.Byte, Value: int64(0x6)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_BOUNDARY_NEUTRAL", Static{Type: types.Byte, Value: int64(0x9)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_COMMON_NUMBER_SEPARATOR", Static{Type: types.Byte, Value: int64(0x7)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_EUROPEAN_NUMBER", Static{Type: types.Byte, Value: int64(0x3)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_EUROPEAN_NUMBER_SEPARATOR", Static{Type: types.Byte, Value: int64(0x4)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_EUROPEAN_NUMBER_TERMINATOR", Static{Type: types.Byte, Value: int64(0x5)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_FIRST_STRONG_ISOLATE", Static{Type: types.Byte, Value: int64(0x15)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_LEFT_TO_RIGHT", Static{Type: types.Byte, Value: int64(0x0)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_LEFT_TO_RIGHT_EMBEDDING", Static{Type: types.Byte, Value: int64(0xe)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_LEFT_TO_RIGHT_ISOLATE", Static{Type: types.Byte, Value: int64(0x13)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_LEFT_TO_RIGHT_OVERRIDE", Static{Type: types.Byte, Value: int64(0xf)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_NONSPACING_MARK", Static{Type: types.Byte, Value: int64(0x8)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_OTHER_NEUTRALS", Static{Type: types.Byte, Value: int64(0xd)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_PARAGRAPH_SEPARATOR", Static{Type: types.Byte, Value: int64(0xa)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_POP_DIRECTIONAL_FORMAT", Static{Type: types.Byte, Value: int64(0x12)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_POP_DIRECTIONAL_ISOLATE", Static{Type: types.Byte, Value: int64(0x16)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_RIGHT_TO_LEFT", Static{Type: types.Byte, Value: int64(0x1)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC", Static{Type: types.Byte, Value: int64(0x2)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_RIGHT_TO_LEFT_EMBEDDING", Static{Type: types.Byte, Value: int64(0x10)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_RIGHT_TO_LEFT_ISOLATE", Static{Type: types.Byte, Value: int64(0x14)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_RIGHT_TO_LEFT_OVERRIDE", Static{Type: types.Byte, Value: int64(0x11)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_SEGMENT_SEPARATOR", Static{Type: types.Byte, Value: int64(0xb)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_UNDEFINED", Static{Type: types.Byte, Value: int64(0xff)})
+	_ = AddStatic("java/lang/Character.DIRECTIONALITY_WHITESPACE", Static{Type: types.Byte, Value: int64(0xc)})
+	_ = AddStatic("java/lang/Character.ENCLOSING_MARK", Static{Type: types.Byte, Value: int64(0x7)})
+	_ = AddStatic("java/lang/Character.END_PUNCTUATION", Static{Type: types.Byte, Value: int64(0x16)})
+	_ = AddStatic("java/lang/Character.FINAL_QUOTE_PUNCTUATION", Static{Type: types.Byte, Value: int64(0x1e)})
+	_ = AddStatic("java/lang/Character.FORMAT", Static{Type: types.Byte, Value: int64(0x10)})
+	_ = AddStatic("java/lang/Character.INITIAL_QUOTE_PUNCTUATION", Static{Type: types.Byte, Value: int64(0x1d)})
+	_ = AddStatic("java/lang/Character.LETTER_NUMBER", Static{Type: types.Byte, Value: int64(0xa)})
+	_ = AddStatic("java/lang/Character.LINE_SEPARATOR", Static{Type: types.Byte, Value: int64(0xd)})
+	_ = AddStatic("java/lang/Character.LOWERCASE_LETTER", Static{Type: types.Byte, Value: int64(0x2)})
+	_ = AddStatic("java/lang/Character.MATH_SYMBOL", Static{Type: types.Byte, Value: int64(0x19)})
+	_ = AddStatic("java/lang/Character.MAX_CODE_POINT", Static{Type: types.Int, Value: int64(1114111)})
+	_ = AddStatic("java/lang/Character.MAX_HIGH_SURROGATE", Static{Type: types.Char, Value: rune(56319)})
+	_ = AddStatic("java/lang/Character.MAX_LOW_SURROGATE", Static{Type: types.Char, Value: rune(57343)})
+	_ = AddStatic("java/lang/Character.MAX_RADIX", Static{Type: types.Int, Value: int64(36)})
+	_ = AddStatic("java/lang/Character.MAX_SURROGATE", Static{Type: types.Char, Value: rune(57343)})
+	_ = AddStatic("java/lang/Character.MAX_VALUE", Static{Type: types.Char, Value: rune(65535)})
+	_ = AddStatic("java/lang/Character.MIN_CODE_POINT", Static{Type: types.Int, Value: int64(0)})
+	_ = AddStatic("java/lang/Character.MIN_HIGH_SURROGATE", Static{Type: types.Char, Value: rune(55296)})
+	_ = AddStatic("java/lang/Character.MIN_LOW_SURROGATE", Static{Type: types.Char, Value: rune(56320)})
+	_ = AddStatic("java/lang/Character.MIN_RADIX", Static{Type: types.Int, Value: int64(2)})
+	_ = AddStatic("java/lang/Character.MIN_SUPPLEMENTARY_CODE_POINT", Static{Type: types.Int, Value: int64(65536)})
+	_ = AddStatic("java/lang/Character.MIN_SURROGATE", Static{Type: types.Char, Value: rune(55296)})
+	_ = AddStatic("java/lang/Character.MIN_VALUE", Static{Type: types.Char, Value: rune(0)})
+	_ = AddStatic("java/lang/Character.MODIFIER_LETTER", Static{Type: types.Byte, Value: int64(0x4)})
+	_ = AddStatic("java/lang/Character.MODIFIER_SYMBOL", Static{Type: types.Byte, Value: int64(0x1b)})
+	_ = AddStatic("java/lang/Character.NON_SPACING_MARK", Static{Type: types.Byte, Value: int64(0x6)})
+	_ = AddStatic("java/lang/Character.OTHER_LETTER", Static{Type: types.Byte, Value: int64(0x5)})
+	_ = AddStatic("java/lang/Character.OTHER_NUMBER", Static{Type: types.Byte, Value: int64(0xb)})
+	_ = AddStatic("java/lang/Character.OTHER_PUNCTUATION", Static{Type: types.Byte, Value: int64(0x18)})
+	_ = AddStatic("java/lang/Character.OTHER_SYMBOL", Static{Type: types.Byte, Value: int64(0x1c)})
+	_ = AddStatic("java/lang/Character.PARAGRAPH_SEPARATOR", Static{Type: types.Byte, Value: int64(0xe)})
+	_ = AddStatic("java/lang/Character.PRIVATE_USE", Static{Type: types.Byte, Value: int64(0x12)})
+	_ = AddStatic("java/lang/Character.SIZE", Static{Type: types.Int, Value: int64(16)})
+	_ = AddStatic("java/lang/Character.SPACE_SEPARATOR", Static{Type: types.Byte, Value: int64(0xc)})
+	_ = AddStatic("java/lang/Character.START_PUNCTUATION", Static{Type: types.Byte, Value: int64(0x15)})
+	_ = AddStatic("java/lang/Character.SURROGATE", Static{Type: types.Byte, Value: int64(0x13)})
+	_ = AddStatic("java/lang/Character.TITLECASE_LETTER", Static{Type: types.Byte, Value: int64(0x3)})
+	_ = AddStatic("java/lang/Character.UNASSIGNED", Static{Type: types.Byte, Value: int64(0x0)})
+	_ = AddStatic("java/lang/Character.UPPERCASE_LETTER", Static{Type: types.Byte, Value: int64(0x1)})
+}
+
+func LoadStaticsDouble() {
+	_ = AddStatic("java/lang/Double.BYTES", Static{Type: types.Int, Value: int64(8)})
+	_ = AddStatic("java/lang/Double.MAX_EXPONENT", Static{Type: types.Int, Value: int64(1023)})
+	_ = AddStatic("java/lang/Double.MAX_VALUE", Static{Type: types.Double, Value: float64(1.7976931348623157e308)})
+	_ = AddStatic("java/lang/Double.MIN_EXPONENT", Static{Type: types.Int, Value: int64(-1022)})
+	_ = AddStatic("java/lang/Double.MIN_NORMAL", Static{Type: types.Double, Value: float64(2.2250738585072014e-308)})
+	_ = AddStatic("java/lang/Double.MIN_VALUE", Static{Type: types.Double, Value: float64(4.9e-324)})
+	_ = AddStatic("java/lang/Double.NaN", Static{Type: types.Double, Value: float64(math.NaN())})
+	_ = AddStatic("java/lang/Double.NEGATIVE_INFINITY", Static{Type: types.Double, Value: float64(math.Inf(-1))})
+	_ = AddStatic("java/lang/Double.POSITIVE_INFINITY", Static{Type: types.Double, Value: float64(math.Inf(+1))})
+	_ = AddStatic("java/lang/Double.SIZE", Static{Type: types.Int, Value: int64(64)})
+}
+
+func LoadStaticsFloat() {
+	_ = AddStatic("java/lang/Float.BYTES", Static{Type: types.Int, Value: int64(4)})
+	_ = AddStatic("java/lang/Float.MAX_EXPONENT", Static{Type: types.Int, Value: int64(127)})
+	_ = AddStatic("java/lang/Float.MAX_VALUE", Static{Type: types.Float, Value: float64(3.4028234663852886e38)})
+	_ = AddStatic("java/lang/Float.MIN_EXPONENT", Static{Type: types.Int, Value: int64(-126)})
+	_ = AddStatic("java/lang/Float.MIN_NORMAL", Static{Type: types.Float, Value: float64(1.1754943508222875e-38)})
+	_ = AddStatic("java/lang/Float.MIN_VALUE", Static{Type: types.Float, Value: float64(1.401298464324817e-45)})
+	_ = AddStatic("java/lang/Float.NaN", Static{Type: types.Float, Value: float64(math.NaN())})
+	_ = AddStatic("java/lang/Float.NEGATIVE_INFINITY", Static{Type: types.Float, Value: float64(math.Inf(-1))})
+	_ = AddStatic("java/lang/Float.POSITIVE_INFINITY", Static{Type: types.Float, Value: float64(math.Inf(+1))})
+	_ = AddStatic("java/lang/Float.SIZE", Static{Type: types.Int, Value: int64(32)})
+}
+
+func LoadStaticsInteger() {
+	_ = AddStatic("java/lang/Integer.BYTES", Static{Type: types.Int, Value: int64(4)})
+	_ = AddStatic("java/lang/Integer.MAX_VALUE", Static{Type: types.Int, Value: int64(2147483647)})
+	_ = AddStatic("java/lang/Integer.MIN_VALUE", Static{Type: types.Int, Value: int64(-2147483648)})
+	_ = AddStatic("java/lang/Integer.SIZE", Static{Type: types.Int, Value: int64(32)})
+}
+
+func LoadStaticsLong() {
+	_ = AddStatic("java/lang/Long.BYTES", Static{Type: types.Int, Value: int64(8)})
+	_ = AddStatic("java/lang/Long.MAX_VALUE", Static{Type: types.Long, Value: int64(9223372036854775807)})
+	_ = AddStatic("java/lang/Long.MIN_VALUE", Static{Type: types.Long, Value: int64(-9223372036854775808)})
+	_ = AddStatic("java/lang/Long.SIZE", Static{Type: types.Int, Value: int64(64)})
+}
+
+func LoadStaticsMath() {
+	_ = AddStatic("java/lang/Math.E", Static{Type: types.Double, Value: float64(2.718281828459045)})
+	_ = AddStatic("java/lang/Math.PI", Static{Type: types.Double, Value: float64(3.141592653589793)})
+}
+
+func LoadStaticsShort() {
+	_ = AddStatic("java/lang/Short.BYTES", Static{Type: types.Int, Value: int64(2)})
+	_ = AddStatic("java/lang/Short.MAX_VALUE", Static{Type: types.Short, Value: int64(32767)})
+	_ = AddStatic("java/lang/Short.MIN_VALUE", Static{Type: types.Short, Value: int64(-32768)})
+	_ = AddStatic("java/lang/Short.SIZE", Static{Type: types.Int, Value: int64(16)})
+}
+
+func LoadStaticsStrictMath() {
+	_ = AddStatic("java/lang/StrictMath.E", Static{Type: types.Double, Value: float64(2.718281828459045)})
+	_ = AddStatic("java/lang/StrictMath.PI", Static{Type: types.Double, Value: float64(3.141592653589793)})
+}

--- a/src/statics/statics.go
+++ b/src/statics/statics.go
@@ -64,7 +64,7 @@ func AddStatic(name string, s Static) error {
 // immediately necessary statics. It's called in jvmStart.go
 func PreloadStatics() {
 	LoadProgramStatics()
-	LoadStringStatics()
+	LoadStaticsString()
 	LoadStaticsInteger()
 }
 
@@ -75,10 +75,10 @@ func LoadProgramStatics() {
 		Static{Type: types.Int, Value: types.JavaBoolTrue})
 }
 
-// LoadStringStatics loads the statics from java/lang/String directly
+// LoadStaticsString loads the statics from java/lang/String directly
 // into the Statics table as part of the setup operations of Jacobin.
 // This is done primarily for speed.
-func LoadStringStatics() {
+func LoadStaticsString() {
 	_ = AddStatic("java/lang/String.COMPACT_STRINGS",
 		Static{Type: types.Bool, Value: true})
 	_ = AddStatic("java/lang/String.UTF16",

--- a/src/statics/statics.go
+++ b/src/statics/statics.go
@@ -65,6 +65,7 @@ func AddStatic(name string, s Static) error {
 func PreloadStatics() {
 	LoadProgramStatics()
 	LoadStringStatics()
+	LoadStaticsInteger()
 }
 
 // LoadProgramStatics loads static fields that the JVM expects to have


### PR DESCRIPTION
* Preloads for classes Byte, Character, Double, Float, Long, Math/StrictMath, and Short are compiled but not yet called by statics::PreloadStatics().
* The Integer statics preload are fully active.
* primiFactory::populator supports all primitives and does everything; went to school on stringClinit.
* All statics loaders have a name that follows a pattern: LoadStaticsX where X = String, Integer, Byte, etc.