### PR TITLE
JACOBIN-462 Self-protection and flexibility updates to gfunction/javaIoPrintStream.go

### DIFF
--- a/src/gfunction/javaIoPrintStream.go
+++ b/src/gfunction/javaIoPrintStream.go
@@ -159,6 +159,10 @@ func Load_Io_PrintStream() map[string]GMeth {
 func Println(params []interface{}) interface{} {
 	switch params[1].(type) {
 	case *object.Object:
+	case []byte:
+		str := string(params[1].([]byte))
+		fmt.Println(str)
+		return nil
 	default:
 		errMsg := fmt.Sprintf("Println: expected params[1] of type *object.Object but observed type %T\n", params[1])
 		return getGErrBlk(exceptions.VirtualMachineError, errMsg)

--- a/src/gfunction/javaIoPrintStream.go
+++ b/src/gfunction/javaIoPrintStream.go
@@ -165,7 +165,7 @@ func Println(params []interface{}) interface{} {
 		return nil
 	default:
 		errMsg := fmt.Sprintf("Println: expected params[1] of type *object.Object but observed type %T\n", params[1])
-		return getGErrBlk(exceptions.VirtualMachineError, errMsg)
+		return getGErrBlk(exceptions.IllegalArgumentException, errMsg)
 	}
 	strAddr := params[1].(*object.Object)
 	fld := strAddr.FieldTable["value"]
@@ -175,7 +175,7 @@ func Println(params []interface{}) interface{} {
 		fmt.Println(str)
 	default:
 		errMsg := fmt.Sprintf("Println: expected Fvalue of type []byte but observed type %T\n", fld.Fvalue)
-		return getGErrBlk(exceptions.VirtualMachineError, errMsg)
+		return getGErrBlk(exceptions.IllegalArgumentException, errMsg)
 	}
 	return nil
 }

--- a/src/gfunction/javaIoPrintStream.go
+++ b/src/gfunction/javaIoPrintStream.go
@@ -8,6 +8,7 @@ package gfunction
 
 import (
 	"fmt"
+	"jacobin/exceptions"
 	"jacobin/object"
 	"math"
 )
@@ -154,14 +155,14 @@ func Load_Io_PrintStream() map[string]GMeth {
 	return MethodSignatures
 }
 
-// Println is the go equivalent of System.out.println(). It accepts two args,
-// which are passed in a two-entry slice of type interface{}. The first arg is an
-// index in the CP to a StringConst entry; the second arg is an index into the
-// array of static fields, Statics. The entry there includes a pointer to the CP
-// for this class. The first arg then gets the StringConst ref, which is an index
-// into the UTF8 entries of the CP. This string is then printed to stdout. There
-// is no return value.
+// Println is the go equivalent of System.out.println().
 func Println(params []interface{}) interface{} {
+	switch params[1].(type) {
+	case *object.Object:
+	default:
+		errMsg := fmt.Sprintf("Println: expected params[1] of type *object.Object but observed type %T\n", params[1])
+		return getGErrBlk(exceptions.VirtualMachineError, errMsg)
+	}
 	strAddr := params[1].(*object.Object)
 	fld := strAddr.FieldTable["value"]
 	switch fld.Fvalue.(type) {
@@ -169,7 +170,8 @@ func Println(params []interface{}) interface{} {
 		str := string(fld.Fvalue.([]byte))
 		fmt.Println(str)
 	default:
-		fmt.Printf("Println: Oops, cannot process type %T\n", fld.Fvalue)
+		errMsg := fmt.Sprintf("Println: expected Fvalue of type []byte but observed type %T\n", fld.Fvalue)
+		return getGErrBlk(exceptions.VirtualMachineError, errMsg)
 	}
 	return nil
 }


### PR DESCRIPTION
We still need to find out the root cause of JACOBIN-462.
The signature for gfunction/javaIoPrintStream.go Println() is java/io/PrintStream.println(Ljava/lang/String;)V.
But, the incoming argument (params[1]) is of type []byte.

In hindsight after looking at the frame locals, I've come to the conclusion that Println should accept both types in params[1]:
* *object.Object - originating from simple String variables
* []byte - originating from String fields of an object
