### PR TITLE
Fixes to Locale, String, and Print handling

### DIFF
--- a/src/gfunction/javaIoPrintStream.go
+++ b/src/gfunction/javaIoPrintStream.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"jacobin/exceptions"
 	"jacobin/object"
+	"jacobin/types"
 	"math"
 	"os"
 )
@@ -233,8 +234,12 @@ func PrintlnDouble(params []interface{}) interface{} {
 // Println an Object's contents
 func PrintlnObject(params []interface{}) interface{} {
 	objPtr := params[1].(*object.Object)
-	str := objPtr.FormatField("")
-	fmt.Fprintln(params[0].(*os.File), str)
+	fld := objPtr.FieldTable["value"]
+	if fld.Ftype == types.ByteArray {
+		fmt.Fprintln(params[0].(*os.File), string(fld.Fvalue.([]byte)))
+		return nil
+	}
+	fmt.Fprintln(params[0].(*os.File), fld.Fvalue)
 	return nil
 }
 
@@ -309,8 +314,12 @@ func PrintS(params []interface{}) interface{} {
 // Print an Object's contents
 func PrintObject(params []interface{}) interface{} {
 	objPtr := params[1].(*object.Object)
-	str := objPtr.FormatField("")
-	fmt.Fprint(params[0].(*os.File), str)
+	fld := objPtr.FieldTable["value"]
+	if fld.Ftype == types.ByteArray {
+		fmt.Fprint(params[0].(*os.File), string(fld.Fvalue.([]byte)))
+		return nil
+	}
+	fmt.Fprint(params[0].(*os.File), fld.Fvalue)
 	return nil
 }
 

--- a/src/gfunction/javaIoPrintStream.go
+++ b/src/gfunction/javaIoPrintStream.go
@@ -296,19 +296,28 @@ func PrintDouble(params []interface{}) interface{} {
 
 // Print string
 func PrintS(params []interface{}) interface{} {
-	// TODO: Eventually will need to check whether or not i[1] is a compact string.
-	//       Presently, we assume it is.
-	strAddr := params[1].(*object.Object)
-	fld := strAddr.FieldTable["value"]
-	switch fld.Fvalue.(type) {
+	switch params[1].(type) {
+	case *object.Object:
+		strAddr := params[1].(*object.Object)
+		fld := strAddr.FieldTable["value"]
+		switch fld.Fvalue.(type) {
+		case []byte:
+			bytes := fld.Fvalue.([]byte)
+			fmt.Fprint(params[0].(*os.File), string(bytes))
+		default:
+			errMsg := fmt.Sprintf("PrintS: cannot process type %T\n", fld.Fvalue)
+			return getGErrBlk(exceptions.IllegalArgumentException, errMsg)
+		}
 	case []byte:
-		bytes := fld.Fvalue.([]byte)
+		bytes := params[1].([]byte)
 		fmt.Fprint(params[0].(*os.File), string(bytes))
 	default:
-		errMsg := fmt.Sprintf("PrintS: cannot process type %T\n", fld.Fvalue)
+		errMsg := fmt.Sprintf("PrintS: cannot process params[1] type %T\n", params[1])
 		return getGErrBlk(exceptions.IllegalArgumentException, errMsg)
 	}
+
 	return nil
+
 }
 
 // Print an Object's contents

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -377,7 +377,13 @@ func newStringFromBytesSubset(params []interface{}) interface{} {
 	// Mark that String.<clinit>() has been run.
 	klass.Data.ClInit = types.ClInitRun
 
-	bytes := params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
+	var bytes []byte
+	switch params[1].(type) {
+	case *object.Object:
+		bytes = params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
+	case []byte:
+		bytes = params[1].([]byte)
+	}
 
 	// Get substring offset and length
 	ssOffset := params[2].(int64)

--- a/src/gfunction/javaUtilLocale.go
+++ b/src/gfunction/javaUtilLocale.go
@@ -7,7 +7,9 @@
 package gfunction
 
 import (
+	"bytes"
 	"jacobin/object"
+	"jacobin/types"
 	"os"
 )
 
@@ -50,50 +52,60 @@ func Load_Util_Locale() map[string]GMeth {
 }
 
 func localeFromLanguage(params []interface{}) interface{} {
-	// params[0]: input string
-	propObj := params[0].(*object.Object) // string
-	bytes := propObj.FieldTable["value"].Fvalue.([]byte)
-	str := string(bytes)
-	obj := object.CreateCompactStringFromGoString(&str)
-	return obj
+	// params[0]: Locale object to update
+	// params[1]: input language string
+	inObj := params[1].(*object.Object)
+	fld := inObj.FieldTable["value"]
+	bites := bytes.ToLower(fld.Fvalue.([]byte))
+	fld.Fvalue = bites
+	params[0].(*object.Object).FieldTable["value"] = fld
+	return nil
 }
 
 func localeFromLanguageCountry(params []interface{}) interface{} {
-	// params[0]: input string
-	propObj := params[0].(*object.Object) // string
-	bytes := propObj.FieldTable["value"].Fvalue.([]byte)
-	str1 := string(bytes)
+	// params[0]: Locale object to update
+	// params[1]: input language string
+	// params[2]: input country string
+	inObj := params[1].(*object.Object) // string
+	bites := inObj.FieldTable["value"].Fvalue.([]byte)
 
-	propObj = params[1].(*object.Object) // string
-	bytes = propObj.FieldTable["value"].Fvalue.([]byte)
-	str2 := string(bytes)
+	inObj = params[2].(*object.Object) // string
+	bytesCountry := inObj.FieldTable["value"].Fvalue.([]byte)
+	bites = append(bites, '_')
+	bites = append(bites, bytesCountry...)
 
-	str := str1 + "_" + str2
-	obj := object.CreateCompactStringFromGoString(&str)
-	return obj
+	bites = bytes.ToLower(bites)
+	fld := object.Field{Ftype: types.ByteArray, Fvalue: bites}
+	params[0].(*object.Object).FieldTable["value"] = fld
+	return nil
 }
 
 func localeFromLanguageCountryVariant(params []interface{}) interface{} {
-	// params[0]: input string
-	propObj := params[0].(*object.Object)
-	bytes := propObj.FieldTable["value"].Fvalue.([]byte)
-	str1 := string(bytes)
+	// params[0]: Locale object to update
+	// params[1]: input language string
+	// params[2]: input country string
+	// params[3]: input variant string
+	inObj := params[1].(*object.Object) // string
+	bites := inObj.FieldTable["value"].Fvalue.([]byte)
 
-	propObj = params[1].(*object.Object)
-	bytes = propObj.FieldTable["value"].Fvalue.([]byte)
-	str2 := string(bytes)
+	inObj = params[2].(*object.Object) // string
+	bytesCountry := inObj.FieldTable["value"].Fvalue.([]byte)
+	bites = append(bites, '_')
+	bites = append(bites, bytesCountry...)
 
-	propObj = params[2].(*object.Object)
-	bytes = propObj.FieldTable["value"].Fvalue.([]byte)
-	str3 := string(bytes)
+	inObj = params[3].(*object.Object) // string
+	bytesVariant := inObj.FieldTable["value"].Fvalue.([]byte)
+	bites = append(bites, '_')
+	bites = append(bites, bytesVariant...)
 
-	str := str1 + "_" + str2 + "_" + str3
-	obj := object.CreateCompactStringFromGoString(&str)
-	return obj
+	bites = bytes.ToLower(bites)
+	fld := object.Field{Ftype: types.ByteArray, Fvalue: bites}
+	params[0].(*object.Object).FieldTable["value"] = fld
+	return nil
 }
 
 func getDefaultLocale(params []interface{}) interface{} {
 	str := os.Getenv("LANGUAGE")
-	obj := object.CreateCompactStringFromGoString(&str)
+	obj := object.MakePrimitiveObject("java/util/Locale", types.ByteArray, []byte(str))
 	return obj
 }


### PR DESCRIPTION
* javaUtilLocale.go functions were returning an Object. However, the return should be nil. Just as with javaLangString.go functions that return nil, we should instead update the object indicated in params[0].
* javaIoPrintStream.go::PrintS must handle []byte as well as objectified strings in params[1].
* javaLangString.go::newStringFromBytesSubset, like newStringFromBytes, must handle []byte in params[1] as well as objectified strings.


How did I find these? In the jacotest.go/logs directory, I grepped "gfunction" on all the individual log files. Hits:
* JACOBIN-0322-default-locale
* JACOBIN-0325-super-1
* stringer-2