### PR TITLE
JACOBIN-463 String Repo functions, separate from older ones

### DIFF
--- a/src/classloader/methArea.go
+++ b/src/classloader/methArea.go
@@ -72,7 +72,7 @@ func MethAreaDelete(key string) {
 	}
 }
 
-// Wait for klass.Status to no longer be "I" (I = initializing)
+// Wait for klass.Status to no longer be 'I' (I = initializing)
 // TODO: must be a better way to do this!
 func WaitForClassStatus(className string) error {
 	_ = log.Log("WaitForClassStatus: class name: "+className, log.CLASS)

--- a/src/classloader/parser.go
+++ b/src/classloader/parser.go
@@ -477,7 +477,7 @@ func parseFields(bytes []byte, loc int, klass *ParsedClass) (int, error) {
 				switch desc {
 				case types.Ref, types.Bool: // TODO: Find out how to process these
 					f.constValue = nil
-				case types.Byte: // byte--same logic as for "I", only error message is different
+				case types.Byte: // byte--same logic as for types.Int, only error message is different
 					indexIntoCP := int(attribute.attrContent[0])*256 +
 						int(attribute.attrContent[1])
 					entryInCp := klass.cpIndex[indexIntoCP]
@@ -486,7 +486,7 @@ func parseFields(bytes []byte, loc int, klass *ParsedClass) (int, error) {
 							klass.utf8Refs[f.name].content)
 					}
 					f.constValue = klass.intConsts[entryInCp.slot]
-				case types.Char: // char--same logic as for "I", only error message is different
+				case types.Char: // char--same logic as for types.Int, only error message is different
 					indexIntoCP := int(attribute.attrContent[0])*256 +
 						int(attribute.attrContent[1])
 					entryInCp := klass.cpIndex[indexIntoCP]

--- a/src/jvm/run_LL-end_test.go
+++ b/src/jvm/run_LL-end_test.go
@@ -724,7 +724,7 @@ func TestPutFieldSimpleInt(t *testing.T) {
 	// and finally the UTF8 records pointed to by the NameAndType entry above
 	CP.Utf8Refs = make([]string, 2)
 	CP.Utf8Refs[0] = "value"
-	CP.Utf8Refs[1] = "I"
+	CP.Utf8Refs[1] = types.Int
 	f.CP = &CP
 
 	// now create the object we're updating, with one int field
@@ -773,7 +773,7 @@ func TestPutFieldDouble(t *testing.T) {
 	// and finally the UTF8 records pointed to by the NameAndType entry above
 	CP.Utf8Refs = make([]string, 2)
 	CP.Utf8Refs[0] = "value"
-	CP.Utf8Refs[1] = "D"
+	CP.Utf8Refs[1] = types.Double
 
 	f.CP = &CP
 

--- a/src/object/String.go
+++ b/src/object/String.go
@@ -7,13 +7,8 @@
 package object
 
 import (
-	"fmt"
 	"jacobin/statics"
 	"jacobin/types"
-	"os"
-	"sort"
-	"strings"
-	"sync"
 )
 
 // Strings are so commonly used in Java, that it makes sense
@@ -117,59 +112,4 @@ func IsJavaString(unknown any) bool {
 	}
 
 	return *objPtr.Klass == "java/lang/String"
-}
-
-/*
---------------------------------
-The new string primitives follow
---------------------------------
-*/
-
-var stringTable = make(map[string]uint32)
-var stringList []string
-var stringNext = uint32(0)
-var stringLock sync.Mutex
-
-func GetStringIndex(arg *string) uint32 {
-	index, ok := stringTable[*arg]
-	if ok {
-		return index
-	}
-	stringLock.Lock()
-	index = stringNext
-	stringTable[*arg] = index
-	stringList = append(stringList, *arg)
-	stringNext++
-	stringLock.Unlock()
-	return index
-}
-
-func GetStringPointer(index uint32) *string {
-	return &stringList[index]
-}
-
-func GetStringRepoSize() uint32 {
-	return stringNext
-}
-
-func DumpStringRepo() {
-	stringLock.Lock()
-	_, _ = fmt.Fprintln(os.Stderr, "\n===== DumpStringRepo BEGIN")
-	// Create an array of keys.
-	keys := make([]string, 0, len(stringTable))
-	for key := range stringTable {
-		keys = append(keys, key)
-	}
-	// Sort the keys.
-	// All the upper case entries precede all the lower case entries.
-	sort.Strings(keys)
-	// In key sequence order, display the key and its value.
-	for _, key := range keys {
-		if !strings.HasPrefix(key, "java/") && !strings.HasPrefix(key, "jdk/") &&
-			!strings.HasPrefix(key, "javax/") && !strings.HasPrefix(key, "sun") {
-			_, _ = fmt.Fprintf(os.Stderr, "%d\t%s\n", stringTable[key], key)
-		}
-	}
-	_, _ = fmt.Fprintln(os.Stderr, "===== DumpStringRepo END")
-	stringLock.Unlock()
 }

--- a/src/object/String.go
+++ b/src/object/String.go
@@ -7,8 +7,12 @@
 package object
 
 import (
+	"fmt"
 	"jacobin/statics"
 	"jacobin/types"
+	"os"
+	"sort"
+	"strings"
 	"sync"
 )
 
@@ -142,4 +146,30 @@ func GetStringIndex(arg *string) uint32 {
 
 func GetStringPointer(index uint32) *string {
 	return &stringList[index]
+}
+
+func GetStringRepoSize() uint32 {
+	return stringNext
+}
+
+func DumpStringRepo() {
+	stringLock.Lock()
+	_, _ = fmt.Fprintln(os.Stderr, "\n===== DumpStringRepo BEGIN")
+	// Create an array of keys.
+	keys := make([]string, 0, len(stringTable))
+	for key := range stringTable {
+		keys = append(keys, key)
+	}
+	// Sort the keys.
+	// All the upper case entries precede all the lower case entries.
+	sort.Strings(keys)
+	// In key sequence order, display the key and its value.
+	for _, key := range keys {
+		if !strings.HasPrefix(key, "java/") && !strings.HasPrefix(key, "jdk/") &&
+			!strings.HasPrefix(key, "javax/") && !strings.HasPrefix(key, "sun") {
+			_, _ = fmt.Fprintf(os.Stderr, "%d\t%s\n", stringTable[key], key)
+		}
+	}
+	_, _ = fmt.Fprintln(os.Stderr, "===== DumpStringRepo END")
+	stringLock.Unlock()
 }

--- a/src/object/StringRepo.go
+++ b/src/object/StringRepo.go
@@ -1,0 +1,125 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2023 by Andrew Binstock. All rights reserved.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)
+ */
+
+package object
+
+import (
+	"fmt"
+	"jacobin/types"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"unsafe"
+)
+
+/*
+------------------------------------------
+The string repo mid-level functions follow
+------------------------------------------
+*/
+
+// MakeEmptyStringObject() creates an empty object.Object.
+// It is expected that the caller will fill in the FieldTable.
+func MakeEmptyStringObject() *Object {
+	object := Object{}
+	ptrObject := uintptr(unsafe.Pointer(&object))
+	object.Mark.Hash = uint32(ptrObject)
+
+	// TODO: Change object.Klass to be type uint32
+	object.Klass = &StringClassName // java/lang/String
+
+	// initialize the map of this object's fields
+	object.FieldTable = make(map[string]Field)
+	return &object
+}
+
+func NewRepoStringFromGoString(str string) *Object {
+	objPtr := MakeEmptyStringObject()
+	/* TODO - Is ignoring the COMPACT_STRINGS flag valid?
+	if statics.GetStaticValue("java/lang/String", "COMPACT_STRINGS") == types.JavaBoolFalse {
+		objPtr.FieldTable["value"] = Field{types.RuneArray, in}
+	} else {
+		objPtr.FieldTable["value"] = Field{types.StringIndex, GetStringIndex(&in)}
+	}
+	*/
+	objPtr.FieldTable["value"] = Field{types.StringIndex, GetStringIndex(&str)}
+	return objPtr
+}
+
+// convenience method to extract a Go string from a repository string
+func GetGoStringFromObject(strPtr *Object) string {
+	obj := *strPtr
+	index := obj.FieldTable["value"].Fvalue.(uint32)
+	return *GetStringPointer(index)
+}
+
+/*
+------------------------------------------
+The string repo primitive functions follow
+------------------------------------------
+*/
+
+var stringTable = make(map[string]uint32)
+var stringList []string = nil
+var stringNext = uint32(0)
+var stringLock sync.Mutex
+
+func GetStringIndex(arg *string) uint32 {
+	index, ok := stringTable[*arg]
+	if ok {
+		return index
+	}
+	stringLock.Lock()
+	index = stringNext
+	stringTable[*arg] = index
+	stringList = append(stringList, *arg)
+	stringNext++
+	stringLock.Unlock()
+	return index
+}
+
+func GetStringPointer(index uint32) *string {
+	return &stringList[index]
+}
+
+func GetStringRepoSize() uint32 {
+	return stringNext
+}
+
+func EmptyStringRepo() {
+	stringLock.Lock()
+	stringTable = make(map[string]uint32)
+	stringNext = 0
+	stringList = nil
+	stringLock.Unlock()
+}
+
+func DumpStringRepo(context string) {
+	stringLock.Lock()
+	if len(context) > 0 {
+		_, _ = fmt.Fprintf(os.Stdout, "\n===== DumpStringRepo BEGIN context: %s\n", context)
+	} else {
+		_, _ = fmt.Fprintln(os.Stdout, "\n===== DumpStringRepo BEGIN")
+	}
+	// Create an array of keys.
+	keys := make([]string, 0, len(stringTable))
+	for key := range stringTable {
+		keys = append(keys, key)
+	}
+	// Sort the keys.
+	// All the upper case entries precede all the lower case entries.
+	sort.Strings(keys)
+	// In key sequence order, display the key and its value.
+	for _, key := range keys {
+		if !strings.HasPrefix(key, "java/") && !strings.HasPrefix(key, "jdk/") &&
+			!strings.HasPrefix(key, "javax/") && !strings.HasPrefix(key, "sun") {
+			_, _ = fmt.Fprintf(os.Stdout, "%d\t%s\n", stringTable[key], key)
+		}
+	}
+	_, _ = fmt.Fprintln(os.Stdout, "===== DumpStringRepo END")
+	stringLock.Unlock()
+}

--- a/src/object/String_new-ish_test.go
+++ b/src/object/String_new-ish_test.go
@@ -72,7 +72,7 @@ func randomString(length int) string {
 }
 
 func TestStringIndexPrimitives_2(t *testing.T) {
-	var LIMIT uint32 = 10000
+	var LIMIT uint32 = 1000000
 	t.Logf("string slice size to be filled up: %d\n", LIMIT)
 	finalIndex := LIMIT - 1
 	midIndex := LIMIT / 2

--- a/src/object/String_new-ish_test.go
+++ b/src/object/String_new-ish_test.go
@@ -11,59 +11,17 @@ import (
 	"testing"
 )
 
-func TestStringIndexPrimitives_1(t *testing.T) {
-	var index uint32
-	var str string
-	str1 := "abc"
-	str2 := "def"
-
-	index = GetStringIndex(&str1)
-	str = *GetStringPointer(index)
-	t.Logf("str1 index %d: %s\n", index, str)
-	if index != 0 {
-		t.Errorf("Expected string index 0 but observed: %d", index)
-	}
-	if str != str1 {
-		t.Errorf("Expected string value %s but observed: %s", str1, str)
-	}
-
-	index = GetStringIndex(&str2)
-	str = *GetStringPointer(index)
-	t.Logf("str2 index %d: %s\n", index, str)
-	if index != 1 {
-		t.Errorf("Expected string index 1 but observed: %d", index)
-	}
-	if str != str2 {
-		t.Errorf("Expected string value %s but observed: %s", str2, str)
-	}
-
-	index = GetStringIndex(&str1)
-	str = *GetStringPointer(index)
-	t.Logf("str1 index %d: %s\n", index, str)
-	if index != 0 {
-		t.Errorf("Expected string index 0 but observed: %d", index)
-	}
-	if str != str1 {
-		t.Errorf("Expected string value %s but observed: %s", str1, str)
-	}
-
-	index = GetStringIndex(&str2)
-	str = *GetStringPointer(index)
-	t.Logf("str2 index %d: %s\n", index, str)
-	if index != 1 {
-		t.Errorf("Expected string index 1 but observed: %d", index)
-	}
-	if str != str2 {
-		t.Errorf("Expected string value %s but observed: %s", str2, str)
-	}
-}
-
 const (
 	letterBytes  = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	stringLength = 100
 )
 
-func randomString(length int) string {
+func randomString(maxlength int) string {
+	halflength := maxlength / 2
+	length := rand.Intn(maxlength)
+	if length < halflength {
+		length += halflength
+	}
 	bb := make([]byte, length)
 	for i := range bb {
 		bb[i] = letterBytes[rand.Intn(len(letterBytes))]
@@ -71,16 +29,80 @@ func randomString(length int) string {
 	return string(bb)
 }
 
+func TestStringIndexPrimitives_1(t *testing.T) {
+	var index uint32
+	var str string
+	str1 := "Mary had a little lamb"
+	str2 := "Whose fleece was white as snow"
+
+	index = GetStringIndex(&str1)
+	str = *GetStringPointer(index)
+	t.Logf("str1 index %d: %s\n", index, str)
+	if index != 0 {
+		t.Errorf("Expected string index 0 but observed: %d", index)
+	}
+	if str != str1 {
+		t.Errorf("Expected string value %s but observed: %s", str1, str)
+	}
+
+	index = GetStringIndex(&str2)
+	str = *GetStringPointer(index)
+	t.Logf("str2 index %d: %s\n", index, str)
+	if index != 1 {
+		t.Errorf("Expected string index 1 but observed: %d", index)
+	}
+	if str != str2 {
+		t.Errorf("Expected string value %s but observed: %s", str2, str)
+	}
+
+	index = GetStringIndex(&str1)
+	str = *GetStringPointer(index)
+	t.Logf("str1 index %d: %s\n", index, str)
+	if index != 0 {
+		t.Errorf("Expected string index 0 but observed: %d", index)
+	}
+	if str != str1 {
+		t.Errorf("Expected string value %s but observed: %s", str1, str)
+	}
+
+	index = GetStringIndex(&str2)
+	str = *GetStringPointer(index)
+	t.Logf("str2 index %d: %s\n", index, str)
+	if index != 1 {
+		t.Errorf("Expected string index 1 but observed: %d", index)
+	}
+	if str != str2 {
+		t.Errorf("Expected string value %s but observed: %s", str2, str)
+	}
+
+	for ix := 0; ix < 18; ix++ {
+		str = randomString(stringLength)
+		index = GetStringIndex(&str)
+	}
+
+	sz := GetStringRepoSize()
+	if sz != 20 {
+		t.Errorf("Expected string value 20 but observed: %d", sz)
+	}
+
+	DumpStringRepo()
+}
+
 func TestStringIndexPrimitives_2(t *testing.T) {
 	var LIMIT uint32 = 1000000
 	t.Logf("string slice size to be filled up: %d\n", LIMIT)
 	finalIndex := LIMIT - 1
 	midIndex := LIMIT / 2
+	midString := "Mary had a little lamb"
 	var str string
 	var index uint32
 	var ix uint32
 	for ix = 0; ix < LIMIT; ix++ {
-		str = randomString(stringLength)
+		if ix == midIndex {
+			str = midString
+		} else {
+			str = randomString(stringLength)
+		}
 		index = GetStringIndex(&str)
 	}
 	t.Logf("last index value: %d\n", index)
@@ -88,7 +110,15 @@ func TestStringIndexPrimitives_2(t *testing.T) {
 	t.Logf("str1 index 0: %s\n", str)
 	str = *GetStringPointer(midIndex)
 	t.Logf("str1 index %d: %s\n", midIndex, str)
+	if str != midString {
+		t.Errorf("Expected mid-string value %s but observed: %s", midString, str)
+	}
 	str = *GetStringPointer(finalIndex)
 	t.Logf("str1 index %d: %s\n", finalIndex, str)
+
+	sz := GetStringRepoSize()
+	if sz != LIMIT {
+		t.Errorf("Expected string value %d but observed: %d", LIMIT, sz)
+	}
 
 }

--- a/src/object/String_new-ish_test.go
+++ b/src/object/String_new-ish_test.go
@@ -39,40 +39,40 @@ func TestStringIndexPrimitives_1(t *testing.T) {
 	str = *GetStringPointer(index)
 	t.Logf("str1 index %d: %s\n", index, str)
 	if index != 0 {
-		t.Errorf("Expected string index 0 but observed: %d", index)
+		t.Errorf("Expected string str1 index 0 but observed: %d", index)
 	}
 	if str != str1 {
-		t.Errorf("Expected string value %s but observed: %s", str1, str)
+		t.Errorf("Expected string str1 value %s but observed: %s", str1, str)
 	}
 
 	index = GetStringIndex(&str2)
 	str = *GetStringPointer(index)
 	t.Logf("str2 index %d: %s\n", index, str)
 	if index != 1 {
-		t.Errorf("Expected string index 1 but observed: %d", index)
+		t.Errorf("Expected string str2 index 1 but observed: %d", index)
 	}
 	if str != str2 {
-		t.Errorf("Expected string value %s but observed: %s", str2, str)
+		t.Errorf("Expected string str2 value %s but observed: %s", str2, str)
 	}
 
 	index = GetStringIndex(&str1)
 	str = *GetStringPointer(index)
 	t.Logf("str1 index %d: %s\n", index, str)
 	if index != 0 {
-		t.Errorf("Expected string index 0 but observed: %d", index)
+		t.Errorf("Expected string str1 index 0 but observed: %d", index)
 	}
 	if str != str1 {
-		t.Errorf("Expected string value %s but observed: %s", str1, str)
+		t.Errorf("Expected string str1 value %s but observed: %s", str1, str)
 	}
 
 	index = GetStringIndex(&str2)
 	str = *GetStringPointer(index)
 	t.Logf("str2 index %d: %s\n", index, str)
 	if index != 1 {
-		t.Errorf("Expected string index 1 but observed: %d", index)
+		t.Errorf("Expected string str2 index 1 but observed: %d", index)
 	}
 	if str != str2 {
-		t.Errorf("Expected string value %s but observed: %s", str2, str)
+		t.Errorf("Expected string str2 value %s but observed: %s", str2, str)
 	}
 
 	for ix := 0; ix < 18; ix++ {
@@ -82,7 +82,7 @@ func TestStringIndexPrimitives_1(t *testing.T) {
 
 	sz := GetStringRepoSize()
 	if sz != 20 {
-		t.Errorf("Expected string value 20 but observed: %d", sz)
+		t.Errorf("Expected string repo size 20 but observed: %d", sz)
 	}
 
 	DumpStringRepo()
@@ -118,7 +118,7 @@ func TestStringIndexPrimitives_2(t *testing.T) {
 
 	sz := GetStringRepoSize()
 	if sz != LIMIT {
-		t.Errorf("Expected string value %d but observed: %d", LIMIT, sz)
+		t.Errorf("Expected string repo size %d but observed: %d", LIMIT, sz)
 	}
 
 }

--- a/src/object/String_repo_mid_level_test.go
+++ b/src/object/String_repo_mid_level_test.go
@@ -1,0 +1,34 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2024 by the Jacobin Authors. All rights reserved.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)  Consult jacobin.org.
+ */
+
+package object
+
+import (
+	"testing"
+)
+
+// Test MakeEmptyStringObject
+func TestStringMidLevel_1(t *testing.T) {
+	objPtr := MakeEmptyStringObject()
+	if *(objPtr.Klass) != StringClassName {
+		t.Errorf("Expected Klass to be %s but observed: %s", StringClassName, *(objPtr.Klass))
+	}
+	sz := len(objPtr.FieldTable)
+	if sz > 0 {
+		t.Errorf("Expected FieldTable size 0 but observed: %d", sz)
+	}
+}
+
+// Test NewRepoStringFromGoString and GetGoStringFromObject
+func TestStringMidLevel_2(t *testing.T) {
+	str1 := "The rain in Spain falls mainly on the plain"
+	objPtr := NewRepoStringFromGoString(str1)
+	objPtr.DumpObject("TestNewRepoStringFromGoString", 0)
+	str2 := GetGoStringFromObject(objPtr)
+	if str1 != str2 {
+		t.Errorf("Expected GetGoStringFromObject to return %s but observed: %s", str1, str2)
+	}
+}

--- a/src/object/String_repo_primitives_test.go
+++ b/src/object/String_repo_primitives_test.go
@@ -30,10 +30,17 @@ func randomString(maxlength int) string {
 }
 
 func TestStringIndexPrimitives_1(t *testing.T) {
-	var index uint32
+	index := uint32(0)
 	var str string
 	str1 := "Mary had a little lamb"
 	str2 := "Whose fleece was white as snow"
+
+	EmptyStringRepo()
+	DumpStringRepo("TestStringIndexPrimitives_1: should be empty")
+	sz := GetStringRepoSize()
+	if sz != 0 {
+		t.Errorf("Expected string repo size 0 but observed: %d", sz)
+	}
 
 	index = GetStringIndex(&str1)
 	str = *GetStringPointer(index)
@@ -80,23 +87,33 @@ func TestStringIndexPrimitives_1(t *testing.T) {
 		index = GetStringIndex(&str)
 	}
 
-	sz := GetStringRepoSize()
+	sz = GetStringRepoSize()
 	if sz != 20 {
 		t.Errorf("Expected string repo size 20 but observed: %d", sz)
 	}
 
-	DumpStringRepo()
+	DumpStringRepo("TestStringIndexPrimitives_1: final repo")
 }
 
 func TestStringIndexPrimitives_2(t *testing.T) {
-	var LIMIT uint32 = 1000000
+	var LIMIT uint32 = 10
 	t.Logf("string slice size to be filled up: %d\n", LIMIT)
 	finalIndex := LIMIT - 1
+	t.Logf("final index value: %d\n", finalIndex)
 	midIndex := LIMIT / 2
+	t.Logf("mid index value: %d\n", midIndex)
 	midString := "Mary had a little lamb"
+	var index uint32 = 0
 	var str string
-	var index uint32
 	var ix uint32
+
+	EmptyStringRepo()
+	DumpStringRepo("TestStringIndexPrimitives_2: should be empty")
+	sz := GetStringRepoSize()
+	if sz != 0 {
+		t.Errorf("Expected string repo size 0 but observed: %d", sz)
+	}
+
 	for ix = 0; ix < LIMIT; ix++ {
 		if ix == midIndex {
 			str = midString
@@ -104,6 +121,7 @@ func TestStringIndexPrimitives_2(t *testing.T) {
 			str = randomString(stringLength)
 		}
 		index = GetStringIndex(&str)
+		t.Logf("DEBUG %d) string %d %s\n", ix, index, str)
 	}
 	t.Logf("last index value: %d\n", index)
 	str = *GetStringPointer(0)
@@ -116,9 +134,12 @@ func TestStringIndexPrimitives_2(t *testing.T) {
 	str = *GetStringPointer(finalIndex)
 	t.Logf("str1 index %d: %s\n", finalIndex, str)
 
-	sz := GetStringRepoSize()
+	sz = GetStringRepoSize()
 	if sz != LIMIT {
 		t.Errorf("Expected string repo size %d but observed: %d", LIMIT, sz)
+	}
+	if sz < 100 {
+		DumpStringRepo("TestStringIndexPrimitives_2: final repo")
 	}
 
 }

--- a/src/object/format.go
+++ b/src/object/format.go
@@ -64,6 +64,8 @@ func fmtHelper(field Field, className string, fieldName string) string {
 
 	// Process the other types.
 	switch ftype {
+	case types.StringIndex:
+		return *GetStringPointer(fvalue.(uint32))
 	case types.Bool:
 		// Special handling for boolean.
 		if flagStatic {

--- a/src/object/format_test.go
+++ b/src/object/format_test.go
@@ -7,6 +7,7 @@
 package object
 
 import (
+	"jacobin/types"
 	"path/filepath"
 	"testing"
 )
@@ -18,55 +19,55 @@ func TestDumpObjectFieldTable(t *testing.T) {
 	obj.Klass = &klassType
 
 	myFloatField := Field{
-		Ftype:  "F",
+		Ftype:  types.Float,
 		Fvalue: 1.0,
 	}
 	obj.FieldTable["myFloat"] = myFloatField
 
 	myDoubleField := Field{
-		Ftype:  "D",
+		Ftype:  types.Double,
 		Fvalue: 2.0,
 	}
 	obj.FieldTable["myDouble"] = myDoubleField
 
 	myIntField := Field{
-		Ftype:  "I",
+		Ftype:  types.Int,
 		Fvalue: 42,
 	}
 	obj.FieldTable["myInt"] = myIntField
 
 	myLongField := Field{
-		Ftype:  "J",
+		Ftype:  types.Long,
 		Fvalue: 42,
 	}
 	obj.FieldTable["myLong"] = myLongField
 
 	myShortField := Field{
-		Ftype:  "S",
+		Ftype:  types.Short,
 		Fvalue: 42,
 	}
 	obj.FieldTable["myShort"] = myShortField
 
 	myByteField := Field{
-		Ftype:  "B",
+		Ftype:  types.Byte,
 		Fvalue: 0x61,
 	}
 	obj.FieldTable["myByte"] = myByteField
 
 	myStaticTrueField := Field{
-		Ftype:  "XZ",
+		Ftype:  types.Static + types.Bool,
 		Fvalue: true,
 	}
 	obj.FieldTable["myStaticTrue"] = myStaticTrueField
 
 	myFalseField := Field{
-		Ftype:  "Z",
+		Ftype:  types.Bool,
 		Fvalue: false,
 	}
 	obj.FieldTable["myFalse"] = myFalseField
 
 	myCharField := Field{
-		Ftype:  "C",
+		Ftype:  types.Char,
 		Fvalue: 'C',
 	}
 	obj.FieldTable["myChar"] = myCharField
@@ -88,55 +89,55 @@ func TestFormatField(t *testing.T) {
 	obj.Klass = &klassType
 
 	myFloatField := Field{
-		Ftype:  "F",
+		Ftype:  types.Float,
 		Fvalue: 1.0,
 	}
 	obj.FieldTable["myFloat"] = myFloatField
 
 	myDoubleField := Field{
-		Ftype:  "D",
+		Ftype:  types.Double,
 		Fvalue: 2.0,
 	}
 	obj.FieldTable["myDouble"] = myDoubleField
 
 	myIntField := Field{
-		Ftype:  "I",
+		Ftype:  types.Int,
 		Fvalue: 42,
 	}
 	obj.FieldTable["myInt"] = myIntField
 
 	myLongField := Field{
-		Ftype:  "J",
+		Ftype:  types.Long,
 		Fvalue: 42,
 	}
 	obj.FieldTable["myLong"] = myLongField
 
 	myShortField := Field{
-		Ftype:  "S",
+		Ftype:  types.Short,
 		Fvalue: 42,
 	}
 	obj.FieldTable["myShort"] = myShortField
 
 	myByteField := Field{
-		Ftype:  "B",
+		Ftype:  types.Byte,
 		Fvalue: 0x61,
 	}
 	obj.FieldTable["myByte"] = myByteField
 
 	myStaticTrueField := Field{
-		Ftype:  "XZ",
+		Ftype:  types.Static + types.Bool,
 		Fvalue: true,
 	}
 	obj.FieldTable["myStaticTrue"] = myStaticTrueField
 
 	myFalseField := Field{
-		Ftype:  "Z",
+		Ftype:  types.Bool,
 		Fvalue: false,
 	}
 	obj.FieldTable["myFalse"] = myFalseField
 
 	myCharField := Field{
-		Ftype:  "C",
+		Ftype:  types.Char,
 		Fvalue: 'C',
 	}
 	obj.FieldTable["myChar"] = myCharField

--- a/src/statics/statics_test.go
+++ b/src/statics/statics_test.go
@@ -73,15 +73,15 @@ func TestStatics1(t *testing.T) {
 	Set statics values.
 	*/
 	LoadProgramStatics()
-	tAddStatic(t, "AlphaBetaGamma.ONE", "B", uint8(0x31))
-	tAddStatic(t, "AlphaBetaGamma.QM", "C", '?')
-	tAddStatic(t, "AlphaBetaGamma.PI", "D", 3.14159265)
-	tAddStatic(t, "AlphaBetaGamma.TEN", "F", 10.0)
-	tAddStatic(t, "AlphaBetaGamma.D-ADAMS", "I", 42)
-	tAddStatic(t, "AlphaBetaGamma.BILLION", "J", 2000000000)
+	tAddStatic(t, "AlphaBetaGamma.ONE", types.Byte, uint8(0x31))
+	tAddStatic(t, "AlphaBetaGamma.QM", types.Char, '?')
+	tAddStatic(t, "AlphaBetaGamma.PI", types.Double, 3.14159265)
+	tAddStatic(t, "AlphaBetaGamma.TEN", types.Float, 10.0)
+	tAddStatic(t, "AlphaBetaGamma.D-ADAMS", types.Int, 42)
+	tAddStatic(t, "AlphaBetaGamma.BILLION", types.Long, 2000000000)
 	tAddStatic(t, "AlphaBetaGamma.WILLIE", "LAlphaBetaGamma;", ref)
-	tAddStatic(t, "AlphaBetaGamma.THIRTEEN", "S", 13)
-	tAddStatic(t, "AlphaBetaGamma.TRUE", "Z", true)
+	tAddStatic(t, "AlphaBetaGamma.THIRTEEN", types.Short, 13)
+	tAddStatic(t, "AlphaBetaGamma.TRUE", types.Bool, true)
 	// Omitted: [x
 	// Omitted: G
 	// Omitted: T to avoid a cycle (object >> statics >> object)


### PR DESCRIPTION
String repository source file changes:
- new file:   object/StringRepo.go - all of the new string repository functions go here
- new file:   object/String_repo_mid_level_test.go - Test mid-level functions
- new file:   object/String_repo_primitives_test.go - Test primitive functions
- modified:   object/String.go - Repo functions moved to StringRepo.go
- deleted:    object/String_new-ish_test.go - renamed as object/String_repo_primitives_test.go
- modified:   object/format.go - Dump Object is now conscious of types.StringIndex

The other file changes were to make use of the symbolic types definitions. No functional changes were made.
