### PR TITLE
JACOBIN-474 use existing function to pop frame after gfunction completes

### DIFF
--- a/src/jvm/goFunctionExec.go
+++ b/src/jvm/goFunctionExec.go
@@ -181,7 +181,10 @@ func runGmethod(mt classloader.MTentry, fs *list.List, className, methodName,
 	// No errors.
 	// Pop off the G frame from the frame stack which
 	// makes the previous frame the current frame.
-	fs.Remove(fs.Front())                // pop off the G frame
+	err = frames.PopFrame(fs)
+	if err != nil {
+		return nil, err
+	}
 	f = fs.Front().Value.(*frames.Frame) // point f to the head (previous frame)
 	return f, nil
 }


### PR DESCRIPTION
```runGmethod``` was using a raw golang-list API to remove the top of the frame stack on a successful conclusion of a G method. This has been fixed to:
* use ```frames.PopFrame``` instead
* check for any returned errors