### PR TITLE
JACOBIN-475 : array load/store opcodes handle objects or arrays

### DIFF
--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -143,6 +143,12 @@ func Load_Lang_String() map[string]GMeth {
 			GFunction:  noSupportYetInString,
 		}
 
+	MethodSignatures["java/lang/String.charAt(I)C"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringCharAt,
+		}
+
 	// Return a formatted string using the reference object string as the format string
 	// and the supplied arguments as input object arguments.
 	// E.g. String string = String.format("%s %i", "ABC", 42);
@@ -185,6 +191,13 @@ func Load_Lang_String() map[string]GMeth {
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  toUpperCase,
+		}
+
+	// Return a string in all lower case, using the reference object string as input.
+	MethodSignatures["java/lang/String.trim()Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trimString,
 		}
 
 	// Return a string representing a boolean value.
@@ -294,6 +307,26 @@ func stringClinit([]interface{}) interface{} {
 func noSupportYetInString([]interface{}) interface{} {
 	errMsg := fmt.Sprintf("%s: No support yet for user-specified character sets and Unicode code point arrays", object.StringClassName)
 	return getGErrBlk(exceptions.UnsupportedEncodingException, errMsg)
+}
+
+// Get character at the given index.
+func stringCharAt(params []interface{}) interface{} {
+	// Unpack the reference string and convert it to a rune array.
+	ptrObj := params[0].(*object.Object)
+	fld := ptrObj.FieldTable["value"]
+	if fld.Ftype != types.StringIndex {
+		errMsg := "stringEquals: reference object must be a String"
+		return getGErrBlk(exceptions.VirtualMachineError, errMsg)
+	}
+	str := object.GetGoStringFromObject(ptrObj)
+	runeArray := []rune(str)
+
+	// Get index.
+	index := params[1].(int64)
+
+	// Return indexed character.
+	runeValue := runeArray[index]
+	return int64(runeValue)
 }
 
 // Are 2 strings equal?
@@ -531,6 +564,13 @@ func toLowerCase(params []interface{}) interface{} {
 func toUpperCase(params []interface{}) interface{} {
 	// params[0]: input string
 	str := strings.ToUpper(object.GetGoStringFromObject(params[0].(*object.Object)))
+	obj := object.NewPoolStringFromGoString(str)
+	return obj
+}
+
+func trimString(params []interface{}) interface{} {
+	// params[0]: input string
+	str := strings.Trim(object.GetGoStringFromObject(params[0].(*object.Object)), " ")
 	obj := object.NewPoolStringFromGoString(str)
 	return obj
 }

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -442,7 +442,7 @@ func StringFormatter(params []interface{}) interface{} {
 	}
 
 	valuesOut := []any{}
-	fmt.Printf("DEBUG StringFormatter params[1]=%T\n", params[1])
+	//fmt.Printf("DEBUG StringFormatter params[1]=%T\n", params[1])
 	fld := params[1].(*object.Object).FieldTable["value"]
 	//fmt.Printf("DEBUG StringFormatter fld.Ftype=%s, fld.Fvalue=%v\n", fld.Ftype, fld.Fvalue)
 	if !strings.HasPrefix(fld.Ftype, types.RefArray) {

--- a/src/jvm/arrays_test.go
+++ b/src/jvm/arrays_test.go
@@ -1109,7 +1109,7 @@ func TestDaloadNilArray(t *testing.T) {
 
 	errMsg := string(out[:])
 
-	if !strings.Contains(errMsg, "Invalid (null) reference to an array") {
+	if !strings.Contains(errMsg, "Invalid object pointer") {
 		t.Errorf("DALOAD: Did not get expected err msg for nil array, got: %s",
 			errMsg)
 	}
@@ -1276,7 +1276,7 @@ func TestDastoreInvalid2(t *testing.T) {
 	_ = wout.Close()
 	os.Stdout = normalStdout
 
-	if !strings.Contains(errMsg, "Attempt to access array of incorrect type") {
+	if !strings.Contains(errMsg, "field type expected") {
 		t.Errorf("DASTORE: Did not get expected error msg, got: %s", errMsg)
 	}
 }
@@ -1315,7 +1315,7 @@ func TestDastoreInvalid3(t *testing.T) {
 	_ = wout.Close()
 	os.Stdout = normalStdout
 
-	if !strings.Contains(errMsg, "Invalid array subscript") {
+	if !strings.Contains(errMsg, " but index=") {
 		t.Errorf("DASTORE: Did not get expected error msg, got: %s", errMsg)
 	}
 }
@@ -1392,7 +1392,7 @@ func TestFaloadNilArray(t *testing.T) {
 
 	errMsg := string(out[:])
 
-	if !strings.Contains(errMsg, "Invalid (null) reference to an array") {
+	if !strings.Contains(errMsg, "Invalid object pointer") {
 		t.Errorf("FALOAD: Did not get expected err msg for nil array, got: %s",
 			errMsg)
 	}
@@ -1553,7 +1553,7 @@ func TestFastoreInvalid2(t *testing.T) {
 	_ = wout.Close()
 	os.Stdout = normalStdout
 
-	if !strings.Contains(errMsg, "Attempt to access array of incorrect type") {
+	if !strings.Contains(errMsg, "field type expected") {
 		t.Errorf("FASTORE: Did not get expected error msg, got: %s", errMsg)
 	}
 }
@@ -1591,7 +1591,7 @@ func TestFastoreInvalid3(t *testing.T) {
 	_ = wout.Close()
 	os.Stdout = normalStdout
 
-	if !strings.Contains(errMsg, "Invalid array subscript") {
+	if !strings.Contains(errMsg, " but index=") {
 		t.Errorf("FASTORE: Did not get expected error msg, got: %s", errMsg)
 	}
 }
@@ -1845,7 +1845,7 @@ func TestIastoreInvalid2(t *testing.T) {
 	_ = wout.Close()
 	os.Stdout = normalStdout
 
-	if !strings.Contains(errMsg, "IA/CA/SASTORE: field type expected=[I, observed=[F") {
+	if !strings.Contains(errMsg, "field type expected") {
 		t.Errorf("IASTORE: Did not get expected error msg, got: %s", errMsg)
 	}
 }
@@ -1883,7 +1883,7 @@ func TestIastoreInvalid3(t *testing.T) {
 	_ = wout.Close()
 	os.Stdout = normalStdout
 
-	if !strings.Contains(errMsg, "IA/CA/SASTORE: array size= 10 but array index= 30 (too large)") {
+	if !strings.Contains(errMsg, " but array index=") {
 		t.Errorf("IASTORE: Did not get expected error msg, got: %s", errMsg)
 	}
 }
@@ -2129,7 +2129,7 @@ func TestLastoreInvalid2(t *testing.T) {
 	_ = wout.Close()
 	os.Stdout = normalStdout
 
-	if !strings.Contains(errMsg, "Attempt to access array of incorrect type") {
+	if !strings.Contains(errMsg, "field type expected") {
 		t.Errorf("LASTORE: Did not get expected error msg, got: %s", errMsg)
 	}
 }
@@ -2168,7 +2168,7 @@ func TestLastoreInvalid3(t *testing.T) {
 	_ = wout.Close()
 	os.Stdout = normalStdout
 
-	if !strings.Contains(errMsg, "Invalid array subscript") {
+	if !strings.Contains(errMsg, " but array index=") {
 		t.Errorf("LASTORE: Did not get expected error msg, got: %s", errMsg)
 	}
 }

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -191,7 +191,8 @@ frameInterpreter:
 			_ = log.Log(traceInfo, log.TRACE_INST)
 		}
 
-		switch f.Meth[f.PC] { // cases listed in numerical value of opcode
+		opcode := f.Meth[f.PC]
+		switch opcode { // cases listed in numerical value of opcode
 		case opcodes.NOP:
 			break
 		case opcodes.ACONST_NULL: // 0x01   (push null onto opStack)
@@ -253,7 +254,7 @@ frameInterpreter:
 			push(f, wint64)
 		case opcodes.LDC, opcodes.LDC_W: // 	0x12, 0x13 	(get const from CP and push it onto stack)
 			var idx int
-			if f.Meth[f.PC] == opcodes.LDC { // LDC uses a 1-byte index into the CP, LDC_W uses a 2-byte index
+			if opcode == opcodes.LDC { // LDC uses a 1-byte index into the CP, LDC_W uses a 2-byte index
 				idx = int(f.Meth[f.PC+1])
 				f.PC += 1
 			} else {
@@ -373,18 +374,24 @@ frameInterpreter:
 			push(f, f.Locals[3])
 		case opcodes.IALOAD, //		0x2E	(push contents of an int array element)
 			opcodes.CALOAD, //		0x34	(push contents of a (two-byte) char array element)
-			opcodes.SALOAD: //		0x35    (push contents of a short array element)
+			opcodes.SALOAD, //		0x35    (push contents of a short array element)
+			opcodes.LALOAD: //		0x2F	(push contents of a long array element)
+			var array []int64
 			index := pop(f).(int64)
-			iAref := pop(f).(*object.Object) // ptr to array object
-			if iAref == object.Null {
-				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := "I/C/SALOAD: Invalid (null) reference to an array"
-				exceptions.Throw(exceptions.NullPointerException, errMsg)
-				return errors.New(errMsg)
+			ref := pop(f)
+			switch ref.(type) {
+			case *object.Object:
+				obj := ref.(*object.Object)
+				if obj == object.Null {
+					glob.ErrorGoStack = string(debug.Stack())
+					errMsg := "I/C/SALOAD: Invalid (null) reference to an array"
+					exceptions.Throw(exceptions.NullPointerException, errMsg)
+					return errors.New(errMsg)
+				}
+				array = obj.FieldTable["value"].Fvalue.([]int64)
+			case []int64:
+				array = ref.([]int64)
 			}
-
-			ao := iAref.FieldTable["value"].Fvalue
-			array := ao.([]int64)
 
 			if index >= int64(len(array)) {
 				glob.ErrorGoStack = string(debug.Stack())
@@ -394,64 +401,28 @@ frameInterpreter:
 			}
 			var value = array[index]
 			push(f, value)
+			if opcode == opcodes.LALOAD {
+				push(f, value)
+			}
 
-		case opcodes.LALOAD: //		0x2F	(push contents of a long array element)
+		case opcodes.DALOAD, //		0x31	(push contents of a double array element)
+			opcodes.FALOAD: //		0x30	(push contents of a float array element):
+			var array []float64
 			index := pop(f).(int64)
-			iAref := pop(f).(*object.Object) // ptr to array object
-			if iAref == nil {
-				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := "LALOAD: Invalid (null) reference to an array"
-				exceptions.Throw(exceptions.NullPointerException, errMsg)
-				return errors.New(errMsg)
+			ref := pop(f) // type is TBD
+			switch ref.(type) {
+			case []float64:
+				array = ref.([]float64)
+			case *object.Object:
+				obj := ref.(*object.Object)
+				if obj == object.Null {
+					glob.ErrorGoStack = string(debug.Stack())
+					errMsg := "DALOAD: Invalid object pointer (nil)"
+					exceptions.Throw(exceptions.NullPointerException, errMsg)
+					return errors.New(errMsg)
+				}
+				array = (*obj).FieldTable["value"].Fvalue.([]float64)
 			}
-
-			oa := iAref.FieldTable["value"]
-			array := oa.Fvalue.([]int64)
-			if index >= int64(len(array)) {
-				glob.ErrorGoStack = string(debug.Stack())
-				exceptions.Throw(exceptions.ArrayIndexOutOfBoundsException,
-					"LALOAD: Invalid array subscript")
-				return errors.New("LALOAD error")
-			}
-			var value = array[index]
-			push(f, value)
-			push(f, value) // pushed twice due to JDK longs being 64 bits wide
-
-		case opcodes.FALOAD: //		0x30	(push contents of an float array element)
-			index := pop(f).(int64)
-			ref := pop(f) // ptr to array object
-			if ref == nil || ref == object.Null {
-				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := "FALOAD: Invalid (null) reference to an array"
-				exceptions.Throw(exceptions.NullPointerException, errMsg)
-				return errors.New(errMsg)
-			}
-
-			fAref := ref.(*object.Object)
-			oa := fAref.FieldTable["value"]
-			array := oa.Fvalue.([]float64)
-			if index >= int64(len(array)) {
-				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := "FALOAD: Invalid array subscript"
-				exceptions.Throw(exceptions.ArrayIndexOutOfBoundsException, errMsg)
-				return errors.New(errMsg)
-			}
-			var value = array[index]
-			push(f, value)
-
-		case opcodes.DALOAD: //		0x31	(push contents of a double array element)
-			index := pop(f).(int64)
-			fAref := pop(f).(*object.Object) // ptr to array object
-			if fAref == nil {
-				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := "DALOAD: Invalid (null) reference to an array"
-				exceptions.Throw(exceptions.NullPointerException, errMsg)
-				return errors.New(errMsg)
-			}
-
-			oa := fAref.FieldTable["value"]
-			array := oa.Fvalue.([]float64)
-
 			if index >= int64(len(array)) {
 				glob.ErrorGoStack = string(debug.Stack())
 				errMsg := "DALOAD: Invalid array subscript"
@@ -460,7 +431,9 @@ frameInterpreter:
 			}
 			var value = array[index]
 			push(f, value)
-			push(f, value)
+			if opcode == opcodes.DALOAD {
+				push(f, value)
+			}
 
 		case opcodes.AALOAD: // 0x32    (push contents of a reference array element)
 			index := pop(f).(int64)
@@ -524,12 +497,11 @@ frameInterpreter:
 
 		case opcodes.ISTORE, //  0x36 	(store popped top of stack int into local[index])
 			opcodes.LSTORE: //  0x37 (store popped top of stack long into local[index])
-			bytecode := f.Meth[f.PC]
 			index := int(f.Meth[f.PC+1])
 			f.PC += 1
 			f.Locals[index] = pop(f).(int64)
 			// longs and doubles are stored in localvar[x] and again in localvar[x+1]
-			if bytecode == opcodes.LSTORE {
+			if opcode == opcodes.LSTORE {
 				f.Locals[index+1] = pop(f).(int64)
 			}
 		case opcodes.FSTORE: //  0x38 (store popped top of stack float into local[index])
@@ -604,137 +576,91 @@ frameInterpreter:
 			f.Locals[3] = pop(f)
 		case opcodes.IASTORE, //	0x4F	(store int in an array)
 			opcodes.CASTORE, //		0x55 	(store char (2 bytes) in an array)
-			opcodes.SASTORE: //    	0x56	(store a short in an array)
+			opcodes.SASTORE, //    	0x56	(store a short in an array)
+			opcodes.LASTORE: //     0x50	(store a long in a long array)
+			var array []int64
 			value := pop(f).(int64)
-			index := pop(f).(int64)
-			arrObj := pop(f).(*object.Object) // the array object
-			if arrObj == nil {
-				glob.ErrorGoStack = string(debug.Stack())
-				exceptions.Throw(exceptions.NullPointerException,
-					"IA/CA/SASTORE: Invalid (null) reference to an array")
-				return errors.New("IA/CA/SASTORE: Invalid array address")
+			if opcode == opcodes.LASTORE {
+				pop(f) // second pop b/c longs use two slots
 			}
-
-			ao := arrObj.FieldTable["value"]
-			if ao.Ftype != "[I" {
+			index := pop(f).(int64)
+			ref := pop(f)
+			switch ref.(type) {
+			case *object.Object:
+				obj := ref.(*object.Object)
+				if obj == object.Null {
+					glob.ErrorGoStack = string(debug.Stack())
+					errMsg := "IA/CA/SA/LASTORE: Invalid (null) reference to an array"
+					exceptions.Throw(exceptions.NullPointerException, errMsg)
+					return errors.New(errMsg)
+				}
+				fld := obj.FieldTable["value"]
+				if fld.Ftype != types.IntArray {
+					glob.ErrorGoStack = string(debug.Stack())
+					errMsg := fmt.Sprintf("IA/CA/SA/LASTORE: field type expected=[I, observed=%s", fld.Ftype)
+					exceptions.Throw(exceptions.ArrayStoreException, errMsg)
+					return errors.New(errMsg)
+				}
+				array = fld.Fvalue.([]int64)
+			case []float64:
+				array = ref.([]int64)
+			default:
 				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := fmt.Sprintf("IA/CA/SASTORE: field type expected=[I, observed=%s", ao.Ftype)
-				_ = log.Log(errMsg, log.SEVERE)
+				errMsg := fmt.Sprintf("IA/CA/SA/LASTORE: unexpected reference type: %T", ref)
 				exceptions.Throw(exceptions.ArrayStoreException, errMsg)
 				return errors.New(errMsg)
 			}
 
-			array := ao.Fvalue.([]int64)
 			size := int64(len(array))
 			if index >= size {
 				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := fmt.Sprintf("IA/CA/SASTORE: array size= %d but array index= %d (too large)", size, index)
-				_ = log.Log(errMsg, log.SEVERE)
+				errMsg := fmt.Sprintf("IA/CA/SA/LASTORE: array size= %d but array index= %d (too large)", size, index)
 				exceptions.Throw(exceptions.ArrayIndexOutOfBoundsException, errMsg)
 				return errors.New(errMsg)
 			}
 			array[index] = value
 
-		case opcodes.LASTORE: // 0x50	(store a long in a long array)
-			value := pop(f).(int64)
-			pop(f) // second pop b/c longs use two slots
+		case opcodes.DASTORE, // 0x52	(store a double in a doubles array)
+			opcodes.FASTORE: // 0x51	(store a float in a float array)
+			var array []float64
+			value := pop(f).(float64)
+			if opcode == opcodes.DASTORE {
+				pop(f) // second pop b/c doubles take two slots on the operand stack
+			}
 			index := pop(f).(int64)
-			lAref := pop(f).(*object.Object) // ptr to array object
-			if lAref == nil {
+			ref := pop(f)
+			switch ref.(type) {
+			case *object.Object:
+				obj := ref.(*object.Object)
+				if obj == object.Null {
+					glob.ErrorGoStack = string(debug.Stack())
+					errMsg := "DASTORE: Invalid (null) reference to an array"
+					exceptions.Throw(exceptions.NullPointerException, errMsg)
+					return errors.New("DASTORE/FASTORE: Invalid array reference")
+				}
+				fld := obj.FieldTable["value"]
+				if fld.Ftype != types.FloatArray {
+					glob.ErrorGoStack = string(debug.Stack())
+					errMsg := fmt.Sprintf("DASTORE/FASTORE: field type expected=[F, observed=%s", fld.Ftype)
+					exceptions.Throw(exceptions.ArrayStoreException, errMsg)
+					return errors.New(errMsg)
+				}
+				array = fld.Fvalue.([]float64)
+			case []float64:
+				array = ref.([]float64)
+			default:
 				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := fmt.Sprintf("LASTORE: Invalid (null) reference to an array")
-				exceptions.Throw(exceptions.NullPointerException, errMsg)
+				errMsg := fmt.Sprintf("DASTORE/FASTORE: unexpected reference type: %T", ref)
+				exceptions.Throw(exceptions.ArrayStoreException, errMsg)
 				return errors.New(errMsg)
 			}
 
-			oa := lAref.FieldTable["value"]
-			arrType := oa.Ftype
-
-			if arrType != "[I" {
-				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := fmt.Sprintf("LASTORE: field type expected=[I, observed=%s", arrType)
-				_ = log.Log(errMsg, log.SEVERE)
-				exceptions.Throw(exceptions.ArrayStoreException,
-					"LASTORE: Attempt to access array of incorrect type")
-				return errors.New("LASTORE: Invalid array type")
-			}
-
-			array := oa.Fvalue.([]int64)
-			size := int64(len(array))
-			if index >= size {
-				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := fmt.Sprintf("LASTORE: array size=%d but index=%d (too large)", size, index)
-				_ = log.Log(errMsg, log.SEVERE)
-				exceptions.Throw(exceptions.ArrayIndexOutOfBoundsException,
-					"LASTORE: Invalid array subscript")
-				return errors.New("LASTORE: Invalid array index")
-			}
-			array[index] = value
-
-		case opcodes.FASTORE: // 0x51	(store a float in a float array)
-			value := pop(f).(float64)
-			index := pop(f).(int64)
-			fAref := pop(f).(*object.Object) // ptr to array object
-			if fAref == nil {
-				glob.ErrorGoStack = string(debug.Stack())
-				exceptions.Throw(exceptions.NullPointerException,
-					"FASTORE: Invalid (null) reference to an array")
-				return errors.New("FASTORE: Invalid array address")
-			}
-
-			oa := fAref.FieldTable["value"]
-			if oa.Ftype != "[F" {
-				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := fmt.Sprintf("FASTORE: field type expected=[F, observed=%s", oa.Ftype)
-				_ = log.Log(errMsg, log.SEVERE)
-				exceptions.Throw(exceptions.ArrayStoreException,
-					"FASTORE: Attempt to access array of incorrect type")
-				return errors.New("FASTORE: Invalid array type")
-			}
-
-			array := oa.Fvalue.([]float64)
-			size := int64(len(array))
-			if index >= size {
-				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := fmt.Sprintf("FASTORE: array size=%d but index=%d (too large)", size, index)
-				_ = log.Log(errMsg, log.SEVERE)
-				exceptions.Throw(exceptions.ArrayIndexOutOfBoundsException,
-					"FASTORE: Invalid array subscript")
-				return errors.New("FASTORE: Invalid array index")
-			}
-			array[index] = value
-
-		case opcodes.DASTORE: // 0x52	(store a double in a doubles array)
-			value := pop(f).(float64)
-			pop(f) // second pop b/c doubles take two slots on the operand stack
-			index := pop(f).(int64)
-			dAref := pop(f).(*object.Object)
-			if dAref == nil {
-				glob.ErrorGoStack = string(debug.Stack())
-				exceptions.Throw(exceptions.NullPointerException,
-					"DASTORE: Invalid (null) reference to an array")
-				return errors.New("DASTORE: Invalid array reference")
-			}
-
-			oa := dAref.FieldTable["value"]
-			if oa.Ftype != "[F" {
-				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := fmt.Sprintf("DASTORE: field type expected=[F, observed=%s", oa.Ftype)
-				_ = log.Log(errMsg, log.SEVERE)
-				exceptions.Throw(exceptions.ArrayStoreException,
-					"DASTORE: Attempt to access array of incorrect type")
-				return errors.New("DASTORE: Invalid array type")
-			}
-
-			array := oa.Fvalue.([]float64)
 			size := int64(len(array))
 			if index >= size {
 				glob.ErrorGoStack = string(debug.Stack())
 				errMsg := fmt.Sprintf("DASTORE: array size=%d but index=%d (too large)", size, index)
-				_ = log.Log(errMsg, log.SEVERE)
-				exceptions.Throw(exceptions.ArrayIndexOutOfBoundsException,
-					"DASTORE: Invalid array subscript")
-				return errors.New("DASTORE: Invalid array index")
+				exceptions.Throw(exceptions.ArrayIndexOutOfBoundsException, errMsg)
+				return errors.New(errMsg)
 			}
 
 			array[index] = value
@@ -1246,7 +1172,7 @@ frameInterpreter:
 			value2 := pop(f).(float64)
 			value1 := pop(f).(float64)
 			if math.IsNaN(value1) || math.IsNaN(value2) {
-				if f.Meth[f.PC] == opcodes.FCMPG {
+				if opcode == opcodes.FCMPG {
 					push(f, int64(1))
 				} else {
 					push(f, int64(-1))
@@ -1265,7 +1191,7 @@ frameInterpreter:
 			pop(f)
 
 			if math.IsNaN(value1) || math.IsNaN(value2) {
-				if f.Meth[f.PC] == opcodes.DCMPG {
+				if opcode == opcodes.DCMPG {
 					push(f, int64(1))
 				} else {
 					push(f, int64(-1))
@@ -2699,10 +2625,10 @@ frameInterpreter:
 			}
 
 		default:
-			missingOpCode := fmt.Sprintf("%d (0x%X)", f.Meth[f.PC], f.Meth[f.PC])
+			missingOpCode := fmt.Sprintf("%d (0x%X)", opcode, opcode)
 
-			if int(f.Meth[f.PC]) < len(opcodes.BytecodeNames) && int(f.Meth[f.PC]) > 0 {
-				missingOpCode += fmt.Sprintf("(%s)", opcodes.BytecodeNames[f.Meth[f.PC]])
+			if int(opcode) < len(opcodes.BytecodeNames) && int(opcode) > 0 {
+				missingOpCode += fmt.Sprintf("(%s)", opcodes.BytecodeNames[opcode])
 			}
 
 			glob.ErrorGoStack = string(debug.Stack())

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -384,7 +384,7 @@ frameInterpreter:
 				obj := ref.(*object.Object)
 				if obj == object.Null {
 					glob.ErrorGoStack = string(debug.Stack())
-					errMsg := "I/C/SALOAD: Invalid (null) reference to an array"
+					errMsg := "I/C/S/LALOAD: Invalid (null) reference to an array"
 					exceptions.Throw(exceptions.NullPointerException, errMsg)
 					return errors.New(errMsg)
 				}
@@ -395,7 +395,7 @@ frameInterpreter:
 
 			if index >= int64(len(array)) {
 				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := "IALOAD: Invalid array subscript"
+				errMsg := "I/C/S/LALOAD: Invalid array subscript"
 				exceptions.Throw(exceptions.ArrayIndexOutOfBoundsException, errMsg)
 				return errors.New(errMsg)
 			}
@@ -417,7 +417,7 @@ frameInterpreter:
 				obj := ref.(*object.Object)
 				if obj == object.Null {
 					glob.ErrorGoStack = string(debug.Stack())
-					errMsg := "DALOAD: Invalid object pointer (nil)"
+					errMsg := "D/FALOAD: Invalid object pointer (nil)"
 					exceptions.Throw(exceptions.NullPointerException, errMsg)
 					return errors.New(errMsg)
 				}
@@ -425,7 +425,7 @@ frameInterpreter:
 			}
 			if index >= int64(len(array)) {
 				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := "DALOAD: Invalid array subscript"
+				errMsg := "D/FALOAD: Invalid array subscript"
 				exceptions.Throw(exceptions.ArrayIndexOutOfBoundsException, errMsg)
 				return errors.New(errMsg)
 			}
@@ -590,14 +590,14 @@ frameInterpreter:
 				obj := ref.(*object.Object)
 				if obj == object.Null {
 					glob.ErrorGoStack = string(debug.Stack())
-					errMsg := "IA/CA/SA/LASTORE: Invalid (null) reference to an array"
+					errMsg := "I/C/S/LASTORE: Invalid (null) reference to an array"
 					exceptions.Throw(exceptions.NullPointerException, errMsg)
 					return errors.New(errMsg)
 				}
 				fld := obj.FieldTable["value"]
 				if fld.Ftype != types.IntArray {
 					glob.ErrorGoStack = string(debug.Stack())
-					errMsg := fmt.Sprintf("IA/CA/SA/LASTORE: field type expected=[I, observed=%s", fld.Ftype)
+					errMsg := fmt.Sprintf("I/C/S/LASTORE: field type expected=[I, observed=%s", fld.Ftype)
 					exceptions.Throw(exceptions.ArrayStoreException, errMsg)
 					return errors.New(errMsg)
 				}
@@ -606,7 +606,7 @@ frameInterpreter:
 				array = ref.([]int64)
 			default:
 				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := fmt.Sprintf("IA/CA/SA/LASTORE: unexpected reference type: %T", ref)
+				errMsg := fmt.Sprintf("I/C/S/LASTORE: unexpected reference type: %T", ref)
 				exceptions.Throw(exceptions.ArrayStoreException, errMsg)
 				return errors.New(errMsg)
 			}
@@ -614,7 +614,7 @@ frameInterpreter:
 			size := int64(len(array))
 			if index >= size {
 				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := fmt.Sprintf("IA/CA/SA/LASTORE: array size= %d but array index= %d (too large)", size, index)
+				errMsg := fmt.Sprintf("I/C/S/LASTORE: array size= %d but array index= %d (too large)", size, index)
 				exceptions.Throw(exceptions.ArrayIndexOutOfBoundsException, errMsg)
 				return errors.New(errMsg)
 			}
@@ -634,14 +634,14 @@ frameInterpreter:
 				obj := ref.(*object.Object)
 				if obj == object.Null {
 					glob.ErrorGoStack = string(debug.Stack())
-					errMsg := "DASTORE: Invalid (null) reference to an array"
+					errMsg := "D/FASTORE: Invalid (null) reference to an array"
 					exceptions.Throw(exceptions.NullPointerException, errMsg)
 					return errors.New("DASTORE/FASTORE: Invalid array reference")
 				}
 				fld := obj.FieldTable["value"]
 				if fld.Ftype != types.FloatArray {
 					glob.ErrorGoStack = string(debug.Stack())
-					errMsg := fmt.Sprintf("DASTORE/FASTORE: field type expected=[F, observed=%s", fld.Ftype)
+					errMsg := fmt.Sprintf("D/FASTORE: field type expected=[F, observed=%s", fld.Ftype)
 					exceptions.Throw(exceptions.ArrayStoreException, errMsg)
 					return errors.New(errMsg)
 				}
@@ -650,7 +650,7 @@ frameInterpreter:
 				array = ref.([]float64)
 			default:
 				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := fmt.Sprintf("DASTORE/FASTORE: unexpected reference type: %T", ref)
+				errMsg := fmt.Sprintf("D/FASTORE: unexpected reference type: %T", ref)
 				exceptions.Throw(exceptions.ArrayStoreException, errMsg)
 				return errors.New(errMsg)
 			}
@@ -658,7 +658,7 @@ frameInterpreter:
 			size := int64(len(array))
 			if index >= size {
 				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := fmt.Sprintf("DASTORE: array size=%d but index=%d (too large)", size, index)
+				errMsg := fmt.Sprintf("D/FASTORE: array size=%d but index=%d (too large)", size, index)
 				exceptions.Throw(exceptions.ArrayIndexOutOfBoundsException, errMsg)
 				return errors.New(errMsg)
 			}

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -602,7 +602,7 @@ frameInterpreter:
 					return errors.New(errMsg)
 				}
 				array = fld.Fvalue.([]int64)
-			case []float64:
+			case []int64:
 				array = ref.([]int64)
 			default:
 				glob.ErrorGoStack = string(debug.Stack())

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -391,6 +391,11 @@ frameInterpreter:
 				array = obj.FieldTable["value"].Fvalue.([]int64)
 			case []int64:
 				array = ref.([]int64)
+			default:
+				glob.ErrorGoStack = string(debug.Stack())
+				errMsg := fmt.Sprintf("I/C/S/LALOAD: Invalid reference type of an array: %T", ref)
+				exceptions.Throw(exceptions.NullPointerException, errMsg)
+				return errors.New(errMsg)
 			}
 
 			if index >= int64(len(array)) {
@@ -422,6 +427,11 @@ frameInterpreter:
 					return errors.New(errMsg)
 				}
 				array = (*obj).FieldTable["value"].Fvalue.([]float64)
+			default:
+				glob.ErrorGoStack = string(debug.Stack())
+				errMsg := fmt.Sprintf("D/FALOAD: Invalid reference type of an array: %T", ref)
+				exceptions.Throw(exceptions.NullPointerException, errMsg)
+				return errors.New(errMsg)
 			}
 			if index >= int64(len(array)) {
 				glob.ErrorGoStack = string(debug.Stack())

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -1696,9 +1696,9 @@ frameInterpreter:
 			objField := obj.FieldTable[fieldName]
 			fieldType = objField.Ftype
 			if fieldType == types.StringIndex {
-				fieldValue = stringPool.GetStringPointer(fieldValue.(uint32))
+				fieldValue = stringPool.GetStringPointer(objField.Fvalue.(uint32))
 			} else {
-				fieldValue = objField.Fvalue // <<<< test for string and return pointer to String object
+				fieldValue = objField.Fvalue
 			}
 			push(f, fieldValue)
 


### PR DESCRIPTION
See discussion in JACOBIN-475.
Files impacted:
* jvm/arrays_test.go
* jvm/run.go

Opcodes impacted: I/C/S/L/F/D -ALOAD and -ASTORE. In a nutshell, do not assume that the stack input is of type *object.Object. It could also be an array ([]int64 or []float64) per GETFIELD.

AALOAD and AASTORE seem okay but need to be verified.