### PR TITLE
JACOBIN-477 and more

### DIFF
--- a/src/classloader/mTable.go
+++ b/src/classloader/mTable.go
@@ -64,6 +64,7 @@ var MTmutex sync.Mutex
 func AddEntry(tbl *MT, key string, mte MTentry) {
 	mt := *tbl
 
+	//fmt.Printf("DEBUG mTable.go AddEntry key=%s, MType=%s\n", key, string(mte.MType))
 	MTmutex.Lock()
 	mt[key] = mte
 	MTmutex.Unlock()

--- a/src/classloader/methArea_test.go
+++ b/src/classloader/methArea_test.go
@@ -198,7 +198,7 @@ func TestWaitFornUnresolvedClassStatus(t *testing.T) {
 	k.Status = 'I'
 	MethAreaInsert("TestEntry", &k)
 
-	// fetching a non-entry should not cause an error, shiuld return nil
+	// fetching a non-entry should not cause an error, should return nil
 	me := WaitForClassStatus("testClass1")
 	if me == nil {
 		t.Errorf("Expected error return from methArea.WaitForClassStatus(), got none")
@@ -217,4 +217,41 @@ func TestWaitFornUnresolvedClassStatus(t *testing.T) {
 	if !strings.Contains(msg, "--> nil") {
 		t.Errorf("Expected different log message, got: %s", msg)
 	}
+}
+
+func tryMethod(t *testing.T, class string, methodName string, methodType string) {
+	t.Logf("tryMethod: Input class=%s, methodName=%s, methodType=%s\n", class, methodName, methodType)
+	mte, err := FetchMethodAndCP(class, methodName, methodType)
+	if err != nil {
+		t.Errorf("tryMethod: FetchMethodAndCP failed: %s\n", err.Error())
+		return
+	}
+	t.Logf("tryMethod: FetchMethodAndCP returned MType: %s\n", string(mte.MType))
+}
+func TestMethArea42(t *testing.T) {
+	globals.InitGlobals("test")
+	_ = log.SetLogLevel(log.WARNING)
+
+	// Initialise JMODMAP
+	JmodMapInit()
+	t.Logf("JmodMapInit ok\n")
+	mapSize := JmodMapSize()
+	if mapSize < 1 {
+		t.Errorf("TestMethArea42: JMODMAP size < 1\n")
+		return
+	}
+	t.Logf("JMODMAP size is %d\n", mapSize)
+
+	// Initialise classloader
+	Init()
+	t.Logf("classloader.Init ok\n")
+
+	// Load base classes.
+	LoadBaseClasses()
+
+	// Find some specific class-methods.
+	tryMethod(t, "java/io/PrintStream", "println", "(Ljava/lang/String;)V")
+	tryMethod(t, "java/io/BufferedOutputStream", "<init>", "(Ljava/io/OutputStream;)V")
+	tryMethod(t, "java/io/BufferedOutputStream", "<init>", "(Ljava/io/OutputStream;I)V")
+	tryMethod(t, "java/io/InputStream", "<init>", "()V")
 }

--- a/src/gfunction/javaIoPrintStream.go
+++ b/src/gfunction/javaIoPrintStream.go
@@ -227,6 +227,10 @@ func PrintlnDouble(params []interface{}) interface{} {
 
 // Println an Object's contents
 func PrintlnObject(params []interface{}) interface{} {
+	if params[1] == nil {
+		errMsg := fmt.Sprintf("PrintlnObject: expected params[1] of type *object.Object but observed type %T\n", params[1])
+		exceptions.Throw(exceptions.IllegalArgumentException, errMsg)
+	}
 	objPtr := params[1].(*object.Object)
 	fld := objPtr.FieldTable["value"]
 	if fld.Ftype == types.ByteArray {
@@ -310,6 +314,10 @@ func PrintString(params []interface{}) interface{} {
 
 // Print an Object's contents
 func PrintObject(params []interface{}) interface{} {
+	if params[1] == nil {
+		errMsg := fmt.Sprintf("PrintObject: expected params[1] of type *object.Object but observed type %T\n", params[1])
+		exceptions.Throw(exceptions.IllegalArgumentException, errMsg)
+	}
 	objPtr := params[1].(*object.Object)
 	fld := objPtr.FieldTable["value"]
 	switch fld.Ftype {

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -314,6 +314,7 @@ func Load_Lang_String() map[string]GMeth {
 
 }
 
+// "java/lang/String.<clinit>()V" -- String class initialisation
 func stringClinit([]interface{}) interface{} {
 	klass := classloader.MethAreaFetch(object.StringClassName)
 	if klass == nil {
@@ -331,6 +332,7 @@ func noSupportYetInString([]interface{}) interface{} {
 }
 
 // Get character at the given index.
+// "java/lang/String.charAt(I)C"
 func stringCharAt(params []interface{}) interface{} {
 	// Unpack the reference string and convert it to a rune array.
 	ptrObj := params[0].(*object.Object)
@@ -351,6 +353,7 @@ func stringCharAt(params []interface{}) interface{} {
 }
 
 // Are 2 strings equal?
+// "java/lang/String.equals(Ljava/lang/Object;)Z"
 func stringEquals(params []interface{}) interface{} {
 	// params[0]: reference string object
 	// params[1]: compare-to string Object
@@ -361,7 +364,7 @@ func stringEquals(params []interface{}) interface{} {
 		obj := params[0].(*object.Object)
 		fld := obj.FieldTable["value"]
 		if fld.Ftype != types.StringIndex {
-			errMsg := "stringLength: 1st reference object must hold an interned String"
+			errMsg := "stringEquals: 1st reference object must hold an interned String"
 			return getGErrBlk(exceptions.VirtualMachineError, errMsg)
 		}
 		str1 = object.GetGoStringFromObject(obj)
@@ -374,7 +377,7 @@ func stringEquals(params []interface{}) interface{} {
 		obj := params[1].(*object.Object)
 		fld := obj.FieldTable["value"]
 		if fld.Ftype != types.StringIndex {
-			errMsg := "stringLength: 2nd reference object must hold an interned String"
+			errMsg := "stringEquals: 2nd reference object must hold an interned String"
 			return getGErrBlk(exceptions.VirtualMachineError, errMsg)
 		}
 		str2 = object.GetGoStringFromObject(obj)
@@ -587,6 +590,7 @@ func StringFormatter(params []interface{}) interface{} {
 	return object.NewPoolStringFromGoString(str)
 }
 
+// "java/lang/String.length()I"
 func stringLength(params []interface{}) interface{} {
 	switch params[0].(type) {
 	case *object.Object:
@@ -666,6 +670,7 @@ func substringStartEnd(params []interface{}) interface{} {
 	return obj
 }
 
+// "java/lang/String.toLowerCase()Ljava/lang/String;"
 func toLowerCase(params []interface{}) interface{} {
 	// params[0]: input string
 	str := strings.ToLower(object.GetGoStringFromObject(params[0].(*object.Object)))
@@ -673,6 +678,7 @@ func toLowerCase(params []interface{}) interface{} {
 	return obj
 }
 
+// "java/lang/String.toUpperCase()Ljava/lang/String;"
 func toUpperCase(params []interface{}) interface{} {
 	// params[0]: input string
 	str := strings.ToUpper(object.GetGoStringFromObject(params[0].(*object.Object)))
@@ -680,6 +686,7 @@ func toUpperCase(params []interface{}) interface{} {
 	return obj
 }
 
+// "java/lang/String.trim()Ljava/lang/String;"
 func trimString(params []interface{}) interface{} {
 	// params[0]: input string
 	str := strings.Trim(object.GetGoStringFromObject(params[0].(*object.Object)), " ")
@@ -687,6 +694,7 @@ func trimString(params []interface{}) interface{} {
 	return obj
 }
 
+// "java/lang/String.valueOf(Z)Ljava/lang/String;"
 func valueOfBoolean(params []interface{}) interface{} {
 	// params[0]: input boolean
 	value := params[0].(int64)
@@ -700,6 +708,7 @@ func valueOfBoolean(params []interface{}) interface{} {
 	return obj
 }
 
+// "java/lang/String.valueOf(C)Ljava/lang/String;"
 func valueOfChar(params []interface{}) interface{} {
 	// params[0]: input char
 	value := params[0].(int64)
@@ -708,6 +717,7 @@ func valueOfChar(params []interface{}) interface{} {
 	return obj
 }
 
+// "java/lang/String.valueOf([C)Ljava/lang/String;"
 func valueOfCharArray(params []interface{}) interface{} {
 	// params[0]: input char array
 	propObj := params[0].(*object.Object)
@@ -720,6 +730,7 @@ func valueOfCharArray(params []interface{}) interface{} {
 	return obj
 }
 
+// "java/lang/String.valueOf([CII)Ljava/lang/String;"
 func valueOfCharSubarray(params []interface{}) interface{} {
 	// params[0]: input char array
 	// params[1]: input offset
@@ -748,6 +759,7 @@ func valueOfCharSubarray(params []interface{}) interface{} {
 	return obj
 }
 
+// "java/lang/String.valueOf(D)Ljava/lang/String;"
 func valueOfDouble(params []interface{}) interface{} {
 	// params[0]: input double
 	value := params[0].(float64)
@@ -759,6 +771,7 @@ func valueOfDouble(params []interface{}) interface{} {
 	return obj
 }
 
+// "java/lang/String.valueOf(F)Ljava/lang/String;"
 func valueOfFloat(params []interface{}) interface{} {
 	// params[0]: input double
 	value := params[0].(float64)
@@ -771,6 +784,7 @@ func valueOfFloat(params []interface{}) interface{} {
 	return obj
 }
 
+// "java/lang/String.valueOf(I)Ljava/lang/String;"
 func valueOfInt(params []interface{}) interface{} {
 	// params[0]: input int
 	value := params[0].(int64)
@@ -779,6 +793,7 @@ func valueOfInt(params []interface{}) interface{} {
 	return obj
 }
 
+// "java/lang/String.valueOf(J)Ljava/lang/String;"
 func valueOfLong(params []interface{}) interface{} {
 	// params[0]: input long
 	value := params[0].(int64)
@@ -787,6 +802,7 @@ func valueOfLong(params []interface{}) interface{} {
 	return obj
 }
 
+// "java/lang/String.valueOf(Ljava/lang/Object;)Ljava/lang/String;"
 func valueOfObject(params []interface{}) interface{} {
 	// params[0]: input Object
 	ptrObj := params[0].(*object.Object)
@@ -795,6 +811,7 @@ func valueOfObject(params []interface{}) interface{} {
 	return obj
 }
 
+// "java/lang/String.compareTo(Ljava/lang/String;)I"
 func compareToCaseSensitive(params []interface{}) interface{} {
 	obj := params[0].(*object.Object)
 	str1 := object.GetGoStringFromObject(obj)
@@ -809,6 +826,7 @@ func compareToCaseSensitive(params []interface{}) interface{} {
 	return int64(1)
 }
 
+// "java/lang/String.compareToIgnoreCase(Ljava/lang/String;)I"
 func compareToIgnoreCase(params []interface{}) interface{} {
 	obj := params[0].(*object.Object)
 	str1 := strings.ToLower(object.GetGoStringFromObject(obj))
@@ -823,12 +841,49 @@ func compareToIgnoreCase(params []interface{}) interface{} {
 	return int64(1)
 }
 
+// "java/lang/String.concat(Ljava/lang/String;)Ljava/lang/String;"
 func stringConcat(params []interface{}) interface{} {
-	obj := params[0].(*object.Object)
-	strRef := object.GetGoStringFromObject(obj)
-	obj = params[1].(*object.Object)
-	strArg := object.GetGoStringFromObject(obj)
-	str := strRef + strArg
-	obj = object.NewPoolStringFromGoString(str)
+	var str1, str2 string
+
+	switch params[0].(type) {
+	case *object.Object:
+		fld := params[0].(*object.Object).FieldTable["value"]
+		switch fld.Ftype {
+		case types.ByteArray:
+			str1 = string(fld.Fvalue.([]byte))
+		case types.StringIndex:
+			str1 = object.GetGoStringFromObject(params[0].(*object.Object))
+		default:
+			errMsg := fmt.Sprintf("stringConcat: Object 1 has invalid field type: %s", fld.Ftype)
+			return getGErrBlk(exceptions.InvalidTypeException, errMsg)
+		}
+	case []byte:
+		str1 = string(params[0].([]byte))
+	default:
+		errMsg := fmt.Sprintf("stringConcat: Object 1 parameter type is invalid: %T", params[0])
+		return getGErrBlk(exceptions.InvalidTypeException, errMsg)
+	}
+
+	switch params[1].(type) {
+	case *object.Object:
+		fld := params[1].(*object.Object).FieldTable["value"]
+		switch fld.Ftype {
+		case types.ByteArray:
+			str2 = string(fld.Fvalue.([]byte))
+		case types.StringIndex:
+			str2 = object.GetGoStringFromObject(params[1].(*object.Object))
+		default:
+			errMsg := fmt.Sprintf("stringConcat: Object 2 has invalid field type: %s", fld.Ftype)
+			return getGErrBlk(exceptions.InvalidTypeException, errMsg)
+		}
+	case []byte:
+		str2 = string(params[0].([]byte))
+	default:
+		errMsg := fmt.Sprintf("stringConcat: Object 2 parameter type is invalid: %T", params[0])
+		return getGErrBlk(exceptions.InvalidTypeException, errMsg)
+	}
+
+	str := str1 + str2
+	obj := object.NewPoolStringFromGoString(str)
 	return obj
 }

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -1917,7 +1917,7 @@ frameInterpreter:
 			if err != nil || mtEntry.Meth == nil {
 				// TODO: search the classpath and retry
 				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := "INVOKESPECIAL: Class method not found: " + className + "." + methName
+				errMsg := "INVOKESPECIAL: Class method not found: " + className + "." + methName + methSig
 				_ = log.Log(errMsg, log.SEVERE)
 				return errors.New(errMsg)
 			}
@@ -1950,7 +1950,7 @@ frameInterpreter:
 				fram, err := createAndInitNewFrame(className, methName, methSig, &m, true, f)
 				if err != nil {
 					glob.ErrorGoStack = string(debug.Stack())
-					errMsg := "INVOKESPECIAL: Error creating frame in: " + className + "." + methName
+					errMsg := "INVOKESPECIAL: Error creating frame in: " + className + "." + methName + methSig
 					return errors.New(errMsg)
 				}
 


### PR DESCRIPTION
* Added nil pointer protection to print and println of objects.
* Added comments to java/lang/String functions.
* Added method signature to error messages in run.go.
* Added a unit test to demonstrate that we can find class/method/signature with FetchMethodAndCP after those classes are loaded.
* stringConcat is more flexible BUT ........................

Somewhere, in jacobin, a Field is being set with Ftype="T" but Fvalue is a byte array. Ftype=[B is correct for an external string to/from a Hotspot library routine. See JACOBIN-479. Once we have set the new string strategy in motion, this symptom might disappear.