### PR TITLE
JACOBIN-482 : gfunctions now use array objects for parameters and results

### DIFF
--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -7,7 +7,6 @@
 package gfunction
 
 import (
-	"fmt"
 	"jacobin/classloader"
 	"jacobin/exceptions"
 	"jacobin/object"
@@ -104,12 +103,6 @@ func deprecated([]interface{}) interface{} {
 
 // Populate an object for a primitive type (Byte, Character, Double, Float, Integer, Long, Short, String).
 func populator(classname string, fldtype string, fldvalue interface{}) interface{} {
-	klass := classloader.MethAreaFetch(classname)
-	if klass == nil {
-		errMsg := fmt.Sprintf("populator: Could not find %s in the MethodArea", classname)
-		return getGErrBlk(exceptions.VirtualMachineError, errMsg)
-	}
-	klass.Data.ClInit = types.ClInitRun // just mark that String.<clinit>() has been run
 	var objPtr *object.Object
 	if fldtype == types.StringIndex {
 		objPtr = object.StringObjectFromGoString(fldvalue.(string))

--- a/src/gfunction/javaIoConsole.go
+++ b/src/gfunction/javaIoConsole.go
@@ -194,7 +194,13 @@ func consoleReadPassword([]interface{}) interface{} {
 	}
 	stdout := statics.GetStaticValue("java/lang/System", "out").(*os.File)
 	_, _ = fmt.Fprint(stdout, "\n")
-	return password
+
+	// Convert password to int64 array, insert into an object, and return to caller
+	var iArray []int64
+	for _, bb := range password {
+		iArray = append(iArray, int64(bb))
+	}
+	return populator("[C", types.IntArray, iArray)
 }
 
 // Provides a formatted prompt, then reads a password or passphrase from the console.

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -398,14 +398,7 @@ func newEmptyString(params []interface{}) interface{} {
 func newStringFromBytes(params []interface{}) interface{} {
 	// params[0] = reference string (to be updated with byte array)
 	// params[1] = byte array object
-	// TRAP fmt.Printf("===========================DEBUG===newStringFromBytes params[1] type: %T\n", params[1])
-	var bytes []byte
-	switch params[1].(type) {
-	case []byte:
-		bytes = params[1].([]byte)
-	default:
-		bytes = params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
-	}
+	bytes := params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
 	object.UpdateStringObjectFromBytes(params[0].(*object.Object), bytes)
 	return nil
 }
@@ -417,14 +410,7 @@ func newStringFromBytesSubset(params []interface{}) interface{} {
 	// params[1] = byte array object
 	// params[2] = start offset
 	// params[3] = end offset
-	// TRAP fmt.Printf("===========================DEBUG===newStringFromBytesSubset params[1] type: %T\n", params[1])
-	var bytes []byte
-	switch params[1].(type) {
-	case []byte:
-		bytes = params[1].([]byte)
-	default:
-		bytes = params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
-	}
+	bytes := params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
 
 	// Get substring start and end offset
 	ssStart := params[2].(int64)
@@ -450,13 +436,7 @@ func newStringFromBytesSubset(params []interface{}) interface{} {
 func newStringFromChars(params []interface{}) interface{} {
 	// params[0] = reference string (to be updated with byte array)
 	// params[1] = byte array object
-	var ints []int64
-	switch params[1].(type) {
-	case []int64:
-		ints = params[1].([]int64)
-	default:
-		ints = params[1].(*object.Object).FieldTable["value"].Fvalue.([]int64)
-	}
+	ints := params[1].(*object.Object).FieldTable["value"].Fvalue.([]int64)
 
 	var bytes []byte
 	for _, ii := range ints {
@@ -470,7 +450,7 @@ func newStringFromChars(params []interface{}) interface{} {
 func getBytesFromString(params []interface{}) interface{} {
 	// params[0] = reference string with byte array to be returned
 	bytes := object.ByteArrayFromStringObject(params[0].(*object.Object))
-	return []byte(bytes)
+	return populator("[B", types.ByteArray, bytes)
 }
 
 // "java/lang/String.format(Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;"
@@ -669,7 +649,7 @@ func toCharArray(params []interface{}) interface{} {
 	for _, bb := range bytes {
 		iArray = append(iArray, int64(bb))
 	}
-	return iArray
+	return populator("[C", types.IntArray, iArray)
 }
 
 // "java/lang/String.toLowerCase()Ljava/lang/String;"

--- a/src/jvm/cli.go
+++ b/src/jvm/cli.go
@@ -210,6 +210,6 @@ func showCopyright(g *globals.Globals) {
 			strings.Contains(g.CommandLine, "-version") ||
 			strings.Contains(g.CommandLine, "--version")) {
 		fmt.Println("Jacobin VM, Copyright " +
-			"© 2021-3 by the Jacobin authors. MPL 2.0 License. www.jacobin.org")
+			"© 2021-4 by the Jacobin authors. MPL 2.0 License. www.jacobin.org")
 	}
 }


### PR DESCRIPTION
	modified:   gfunction/gfunction.go
	modified:   gfunction/javaIoConsole.go
	modified:   gfunction/javaLangString.go

All flexibilities were removed. 