### PR TITLE
JACOBIN-491 Github Actions workflow fix for golang projects

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,6 +23,8 @@ jobs:
       uses: actions/setup-go@main
       with:
         go-version: '1.21.x'
+          cache: true
+          cache-dependency-path: "**/go.sum"
       
     - name: Setup JDK
       uses: actions/setup-java@main


### PR DESCRIPTION
Github Actions workflow succeeds but there is the same warning for each O/S:

![image](https://github.com/platypusguy/jacobin/assets/11318756/e662dd40-d5e0-4b8b-b0cb-308914fc2601)


The fix in the commit is based on a discussion at https://github.com/actions/setup-go/issues/427