### PR TITLE
JACOBIN-491 Update go.yml Windows section to resolve caching issue

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -59,6 +59,8 @@ jobs:
       uses: actions/setup-go@main
       with:
         go-version: '1.21.x'
+        cache: true
+        cache-dependency-path: "**/go.sum"
       
     - name: Setup JDK
       uses: actions/setup-java@main


### PR DESCRIPTION
I forgot that Windows was a separate build from MacOS and Linux.