### PR TITLE
JACOBIN-476 trap SecurityManager, enable java/lang/arraycopy

### DIFF
--- a/src/classloader/classes.go
+++ b/src/classloader/classes.go
@@ -238,9 +238,16 @@ func FetchMethodAndCP(className, methName, methType string) (MTentry, error) {
 	if methEntry.Meth != nil { // we found the entry in the MTable
 		if methEntry.MType == 'J' {
 			return MTentry{Meth: methEntry.Meth, MType: 'J'}, nil
-		} else if methEntry.MType == 'G' {
+		}
+		if methEntry.MType == 'G' {
+
 			return MTentry{Meth: methEntry.Meth, MType: 'G'}, nil
 		}
+		errMsg := fmt.Sprintf("FetchMethodAndCP: methEntry.Meth != nil BUT methEntry.MType is neither J nor G for %s", methFQN)
+		_ = log.Log(errMsg, log.SEVERE)
+		shutdown.Exit(shutdown.JVM_EXCEPTION)
+		return MTentry{}, errors.New(errMsg) // dummy return needed for tests
+
 	}
 
 	// --- at this point, the method is not in the MTable ---

--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -18,25 +18,25 @@ func Load_Traps() map[string]GMeth {
 			GFunction:  trapGetDefaultFileSystem,
 		}
 
-	MethodSignatures["java/io/FileDescriptor.<clinit>()"] =
+	MethodSignatures["java/io/FileDescriptor.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapFileDescriptor,
 		}
 
-	MethodSignatures["java/io/FileSystem.<clinit>()"] =
+	MethodSignatures["java/io/FileSystem.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapFileSystem,
 		}
 
-	MethodSignatures["java/nio/charset/Charset.<clinit>()"] =
+	MethodSignatures["java/nio/charset/Charset.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapCharset,
 		}
 
-	MethodSignatures["java/nio/channels/FileChannel.<clinit>()"] =
+	MethodSignatures["java/nio/channels/FileChannel.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapFileChannel,
@@ -44,31 +44,31 @@ func Load_Traps() map[string]GMeth {
 
 	// Unsupported readers
 
-	MethodSignatures["java/io/BufferedReader.<clinit>()"] =
+	MethodSignatures["java/io/BufferedReader.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapReader,
 		}
 
-	MethodSignatures["java/io/CharArrayReader.<clinit>()"] =
+	MethodSignatures["java/io/CharArrayReader.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapReader,
 		}
 
-	MethodSignatures["java/io/FilterReader.<clinit>()"] =
+	MethodSignatures["java/io/FilterReader.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapReader,
 		}
 
-	MethodSignatures["java/io/PipedReader.<clinit>()"] =
+	MethodSignatures["java/io/PipedReader.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapReader,
 		}
 
-	MethodSignatures["java/io/StringReader.<clinit>()"] =
+	MethodSignatures["java/io/StringReader.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapReader,
@@ -76,52 +76,72 @@ func Load_Traps() map[string]GMeth {
 
 	// Unsupported writers
 
-	MethodSignatures["java/io/BufferedWriter.<clinit>()"] =
+	MethodSignatures["java/io/BufferedWriter.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapWriter,
 		}
 
-	MethodSignatures["java/io/CharArrayWriter.<clinit>()"] =
+	MethodSignatures["java/io/CharArrayWriter.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapWriter,
 		}
 
-	MethodSignatures["java/io/FileSystem.<clinit>()"] =
+	MethodSignatures["java/io/FileSystem.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapFileSystem,
 		}
 
-	MethodSignatures["java/io/FilterWriter.<clinit>()"] =
+	MethodSignatures["java/io/FilterWriter.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapWriter,
 		}
 
-	MethodSignatures["java/io/PipedWriter.<clinit>()"] =
+	MethodSignatures["java/io/PipedWriter.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapWriter,
 		}
 
-	MethodSignatures["java/io/PrintWriter.<clinit>()"] =
+	MethodSignatures["java/io/PrintWriter.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapWriter,
 		}
 
-	MethodSignatures["java/io/StringWriter.<clinit>()"] =
+	MethodSignatures["java/io/StringWriter.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapWriter,
 		}
 
-	MethodSignatures["java/lang/SecurityManager.<clinit>()"] =
+	MethodSignatures["java/lang/SecurityManager.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.<init>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
+		}
+
+	// String Builder
+
+	MethodSignatures["java/lang/StringBuilder.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapStringBuilder,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.<init>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapStringBuilder,
 		}
 
 	return MethodSignatures
@@ -172,5 +192,11 @@ func trapReader([]interface{}) interface{} {
 // Trap for unsupported writers
 func trapWriter([]interface{}) interface{} {
 	errMsg := "The requested writer is not yet supported"
+	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
+}
+
+// Trap for StringBuilder
+func trapStringBuilder([]interface{}) interface{} {
+	errMsg := "Class StringBuilder is not yet supported"
 	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
 }

--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -118,6 +118,12 @@ func Load_Traps() map[string]GMeth {
 			GFunction:  trapWriter,
 		}
 
+	MethodSignatures["java/lang/SecurityManager.<clinit>()"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
+		}
+
 	return MethodSignatures
 }
 
@@ -129,7 +135,7 @@ func trapCharset([]interface{}) interface{} {
 
 // Trap for deprecated functions
 func trapDeprecated([]interface{}) interface{} {
-	errMsg := "The function requested is deprecated and is not supported by jacobin"
+	errMsg := "The class or function requested is deprecated and is not supported by jacobin"
 	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
 }
 

--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -144,59 +144,125 @@ func Load_Traps() map[string]GMeth {
 			GFunction:  trapStringBuilder,
 		}
 
+	MethodSignatures["java/lang/StringBuilder.<init>(I)V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapStringBuilder,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.<init>(Ljava/lang/CharSequence;)V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapStringBuilder,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.<init>(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapStringBuilder,
+		}
+
+	// String Buffer
+
+	MethodSignatures["java/lang/StringBuffer.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapStringBuffer,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.<init>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapStringBuffer,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.<init>(I)V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapStringBuffer,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.<init>(Ljava/lang/CharSequence;)V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapStringBuffer,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.<init>(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapStringBuffer,
+		}
+
 	return MethodSignatures
 }
 
 // Trap for Charset references
 func trapCharset([]interface{}) interface{} {
 	errMsg := "Class java/nio/charset/Charset is not yet supported"
+	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
 	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
 }
 
 // Trap for deprecated functions
 func trapDeprecated([]interface{}) interface{} {
 	errMsg := "The class or function requested is deprecated and is not supported by jacobin"
+	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
 	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
 }
 
 // Trap for FileChannel references
 func trapFileChannel([]interface{}) interface{} {
 	errMsg := "Class java.nio.channels.FileChannel is not yet supported"
+	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
 	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
 }
 
 // Trap for FileDescriptor references
 func trapFileDescriptor([]interface{}) interface{} {
 	errMsg := "Class java/io/FileDescriptor is not yet supported"
+	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
 	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
 }
 
 // Trap for FileSystem references
 func trapFileSystem([]interface{}) interface{} {
 	errMsg := "Class java.io.FileSystem is not yet supported"
+	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
 	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
 }
 
 // "java/io/DefaultFileSystem.getFileSystem()Ljava/io/FileSystem;"
 func trapGetDefaultFileSystem([]interface{}) interface{} {
 	errMsg := "DefaultFileSystem.getFileSystem() is not yet supported"
+	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
 	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
 }
 
 // Trap for unsupported readers
 func trapReader([]interface{}) interface{} {
 	errMsg := "The requested reader is not yet supported"
+	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
 	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
 }
 
 // Trap for unsupported writers
 func trapWriter([]interface{}) interface{} {
 	errMsg := "The requested writer is not yet supported"
+	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
 	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
 }
 
 // Trap for StringBuilder
 func trapStringBuilder([]interface{}) interface{} {
 	errMsg := "Class StringBuilder is not yet supported"
+	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
+	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
+}
+
+// Trap for StringBuilder
+func trapStringBuffer([]interface{}) interface{} {
+	errMsg := "Class StringBuffer is not yet supported"
+	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
 	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
 }

--- a/src/gfunction/javaIoPrintStream.go
+++ b/src/gfunction/javaIoPrintStream.go
@@ -310,8 +310,11 @@ func PrintString(params []interface{}) interface{} {
 	switch params[1].(type) {
 	case []byte:
 		str = string(params[1].([]byte))
+	case *object.Object:
+		str = object.GoStringFromStringObject(params[1].(*object.Object))
 	default:
-		str = string(params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte))
+		errMsg := fmt.Sprintf("PrintString: expected params[1] of type *object.Object but observed type %T\n", params[1])
+		exceptions.Throw(exceptions.IllegalArgumentException, errMsg)
 	}
 
 	fmt.Fprint(params[0].(*os.File), str)

--- a/src/gfunction/javaIoPrintStream.go
+++ b/src/gfunction/javaIoPrintStream.go
@@ -308,8 +308,6 @@ func PrintDouble(params []interface{}) interface{} {
 func PrintString(params []interface{}) interface{} {
 	var str string
 	switch params[1].(type) {
-	case []byte:
-		str = string(params[1].([]byte))
 	case *object.Object:
 		str = object.GoStringFromStringObject(params[1].(*object.Object))
 	default:

--- a/src/gfunction/javaLangSystem.go
+++ b/src/gfunction/javaLangSystem.go
@@ -97,6 +97,12 @@ func Load_Lang_System() map[string]GMeth {
 			GFunction:  clinit,
 		}
 
+	MethodSignatures["java/lang/System.arraycopy.(Ljava/lang/Object;ILjava/lang/Object;II)V"] =
+		GMeth{
+			ParamSlots: 5,
+			GFunction:  arrayCopy,
+		}
+
 	return MethodSignatures
 }
 

--- a/src/gfunction/javaLangSystem.go
+++ b/src/gfunction/javaLangSystem.go
@@ -43,7 +43,7 @@ import (
 
 func Load_Lang_System() map[string]GMeth {
 
-	MethodSignatures["java/lang/System.arrayCopy(Ljava.lang.Object;ILjava.lang.Object;II)V"] = // copy array (full or partial)
+	MethodSignatures["java/lang/System.arraycopy(Ljava.lang.Object;ILjava.lang.Object;II)V"] = // copy array (full or partial)
 		GMeth{
 			ParamSlots: 5,
 			GFunction:  arrayCopy,
@@ -101,12 +101,6 @@ func Load_Lang_System() map[string]GMeth {
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  clinit,
-		}
-
-	MethodSignatures["java/lang/System.arraycopy.(Ljava/lang/Object;ILjava/lang/Object;II)V"] =
-		GMeth{
-			ParamSlots: 5,
-			GFunction:  arrayCopy,
 		}
 
 	return MethodSignatures

--- a/src/gfunction/javaLangSystem.go
+++ b/src/gfunction/javaLangSystem.go
@@ -43,7 +43,7 @@ import (
 
 func Load_Lang_System() map[string]GMeth {
 
-	MethodSignatures["java/lang/System.arraycopy(Ljava.lang.Object;ILjava.lang.Object;II)V"] = // copy array (full or partial)
+	MethodSignatures["java/lang/System.arraycopy(Ljava/lang/Object;ILjava/lang/Object;II)V"] = // copy array (full or partial)
 		GMeth{
 			ParamSlots: 5,
 			GFunction:  arrayCopy,

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -1970,7 +1970,7 @@ frameInterpreter:
 				if err != nil || mtEntry.Meth == nil {
 					// TODO: search the superclasses, then the classpath and retry
 					glob.ErrorGoStack = string(debug.Stack())
-					errMsg := "INVOKEVIRTUAL: Class method not found: " + className + "." + methodName
+					errMsg := "INVOKEVIRTUAL: Class method not found: " + className + "." + methodName + methodType
 					_ = log.Log(errMsg, log.SEVERE)
 					return errors.New(errMsg)
 				}
@@ -1998,7 +1998,7 @@ frameInterpreter:
 					// any exception message will already have been displayed to the user
 					glob.ErrorGoStack = string(debug.Stack())
 					errMsg := fmt.Sprintf("INVOKEVIRTUAL: Error encountered in: %s.%s"+
-						className, methodName)
+						className, methodName+methodType)
 					return errors.New(errMsg)
 				}
 				break
@@ -2009,7 +2009,7 @@ frameInterpreter:
 				if m.AccessFlags&0x0100 > 0 {
 					// Native code
 					glob.ErrorGoStack = string(debug.Stack())
-					errMsg := "INVOKEVIRTUAL: Native method requested: " + className + "." + methodName + "." + methodType
+					errMsg := "INVOKEVIRTUAL: Native method requested: " + className + "." + methodName + methodType
 					_ = log.Log(errMsg, log.SEVERE)
 					return errors.New(errMsg)
 				}
@@ -2017,7 +2017,7 @@ frameInterpreter:
 					className, methodName, methodType, &m, true, f)
 				if err != nil {
 					glob.ErrorGoStack = string(debug.Stack())
-					errMsg := "INVOKEVIRTUAL: Error creating frame in: " + className + "." + methodName
+					errMsg := "INVOKEVIRTUAL: Error creating frame in: " + className + "." + methodName + methodType
 					return errors.New(errMsg)
 				}
 				f.PC += 1                            // move to next bytecode before exiting
@@ -2075,7 +2075,7 @@ frameInterpreter:
 				if m.AccessFlags&0x0100 > 0 {
 					// Native code
 					glob.ErrorGoStack = string(debug.Stack())
-					errMsg := "INVOKESPECIAL: Native method requested: " + className + "." + methodName + "." + methSig
+					errMsg := "INVOKESPECIAL: Native method requested: " + className + "." + methodName + methSig
 					_ = log.Log(errMsg, log.SEVERE)
 					return errors.New(errMsg)
 				}
@@ -2172,7 +2172,7 @@ frameInterpreter:
 				if err != nil {
 					glob.ErrorGoStack = string(debug.Stack())
 					return errors.New("INVOKESTATIC: Error creating frame in: " +
-						className + "." + methodName)
+						className + "." + methodName + methodType)
 				}
 
 				f.PC += 1                            // point to the next bytecode before exiting

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -2122,7 +2122,7 @@ frameInterpreter:
 			if err != nil || mtEntry.Meth == nil {
 				// TODO: search the classpath and retry
 				glob.ErrorGoStack = string(debug.Stack())
-				errMsg := "INVOKESTATIC: Class method not found: " + className + "." + methodName
+				errMsg := "INVOKESTATIC: Class method not found: " + className + "." + methodName + methodType
 				_ = log.Log(errMsg, log.SEVERE)
 				return errors.New(errMsg)
 			}
@@ -2163,7 +2163,7 @@ frameInterpreter:
 				if m.AccessFlags&0x0100 > 0 {
 					// Native code
 					glob.ErrorGoStack = string(debug.Stack())
-					errMsg := "INVOKESTATIC: Native method requested: " + className + "." + methodName + "." + methodType
+					errMsg := "INVOKESTATIC: Native method requested: " + className + "." + methodName + methodType
 					_ = log.Log(errMsg, log.SEVERE)
 					return errors.New(errMsg)
 				}


### PR DESCRIPTION
* The SecurityManager is deprecated so trapping it as such.

* Added MethodSignatures entry for arraycopy to ```javaLangSystem.go```:
```
	MethodSignatures["java/lang/System.arraycopy.(Ljava/lang/Object;ILjava/lang/Object;II)V"] =
		GMeth{
			ParamSlots: 5,
			GFunction:  arrayCopy,
		}

```