### PR TITLE
JACOBIN-499 Always show the ThrowEx caught and uncaught messages

### DIFF
--- a/src/exceptions/exception.go
+++ b/src/exceptions/exception.go
@@ -7,6 +7,7 @@
 package exceptions
 
 import (
+	"fmt"
 	"jacobin/globals"
 	"jacobin/log"
 	"jacobin/shutdown"
@@ -419,7 +420,8 @@ func Throw(exceptionType int, msg string) {
 	   	msg := fmt.Sprintf(
 	   		"%s%sin %s, in%s, at bytecode[]: %d", JacobinRuntimeErrLiterals[excType], ": ", clName, methName, cp)
 	*/
-	_ = log.Log(msg, log.SEVERE)
+	helloMsg := fmt.Sprintf("[Throw] Arrived, which: %d, msg: %s", exceptionType, msg)
+	log.Log(helloMsg, log.SEVERE)
 
 	// TODO: Temporary until error/exception processing is complete.
 	glob := globals.GetGlobalRef()

--- a/src/exceptions/throw.go
+++ b/src/exceptions/throw.go
@@ -33,7 +33,8 @@ func ThrowEx(which int, msg string, f *frames.Frame) {
 
 	// If tracing, announce.
 	helloMsg := fmt.Sprintf("[ThrowEx] Arrived, which: %d, msg: %s", which, msg)
-	log.Log(helloMsg, log.TRACE_INST)
+	//log.Log(helloMsg, log.TRACE_INST)
+	log.Log(helloMsg, log.SEVERE)
 
 	// If in a unit test, log a severe message and return.
 	glob := globals.GetGlobalRef()

--- a/src/exceptions/throw.go
+++ b/src/exceptions/throw.go
@@ -73,7 +73,7 @@ func ThrowEx(which int, msg string, f *frames.Frame) {
 		// 1. creating a new objRef for the exception
 		// 2. pushing the objRef on the stack of the frame
 		// 3. setting the PC to point to the catch code (which expects the objRef at TOS)
-		caughtMsg := fmt.Sprintf("[ThrowEx] Caught exception, which: %d, msg: %s", which, msg)
+		caughtMsg := fmt.Sprintf("[ThrowEx] caught %s, msg: %s", exceptionCPname, msg)
 		log.Log(caughtMsg, log.TRACE_INST)
 		th = glob.Threads[f.Thread].(*thread.ExecThread)
 		fs = th.Stack
@@ -85,7 +85,7 @@ func ThrowEx(which int, msg string, f *frames.Frame) {
 	}
 
 	// if the exception was not caught...
-	errMsg := fmt.Sprintf("[ThrowEx] Uncaught exception, which: %d, msg: %s", which, msg)
+	errMsg := fmt.Sprintf("[ThrowEx] uncaught %s, msg: %s", exceptionCPname, msg)
 	log.Log(errMsg, log.SEVERE)
 
 	genCode := generateThrowBytecodes(f, exceptionCPname, msg)

--- a/src/exceptions/throw.go
+++ b/src/exceptions/throw.go
@@ -32,7 +32,7 @@ import (
 func ThrowEx(which int, msg string, f *frames.Frame) {
 
 	helloMsg := fmt.Sprintf("[ThrowEx] Arrived, which: %d, msg: %s", which, msg)
-	log.Log(helloMsg, log.SEVERE)
+	log.Log(helloMsg, log.TRACE_INST)
 
 	// If in a unit test, log a severe message and return.
 	glob := globals.GetGlobalRef()
@@ -73,6 +73,8 @@ func ThrowEx(which int, msg string, f *frames.Frame) {
 		// 1. creating a new objRef for the exception
 		// 2. pushing the objRef on the stack of the frame
 		// 3. setting the PC to point to the catch code (which expects the objRef at TOS)
+		caughtMsg := fmt.Sprintf("[ThrowEx] Caught exception, which: %d, msg: %s", which, msg)
+		log.Log(caughtMsg, log.TRACE_INST)
 		th = glob.Threads[f.Thread].(*thread.ExecThread)
 		fs = th.Stack
 		objRef, _ := glob.FuncInstantiateClass(exceptionCPname, fs)
@@ -83,6 +85,9 @@ func ThrowEx(which int, msg string, f *frames.Frame) {
 	}
 
 	// if the exception was not caught...
+	errMsg := fmt.Sprintf("[ThrowEx] Uncaught exception, which: %d, msg: %s", which, msg)
+	log.Log(errMsg, log.SEVERE)
+
 	genCode := generateThrowBytecodes(f, exceptionCPname, msg)
 
 	// append the genCode to the bytecode of the current method in the frame

--- a/src/exceptions/throw.go
+++ b/src/exceptions/throw.go
@@ -31,9 +31,7 @@ import (
 // the current thread.
 func ThrowEx(which int, msg string, f *frames.Frame) {
 
-	// If tracing, announce.
 	helloMsg := fmt.Sprintf("[ThrowEx] Arrived, which: %d, msg: %s", which, msg)
-	//log.Log(helloMsg, log.TRACE_INST)
 	log.Log(helloMsg, log.SEVERE)
 
 	// If in a unit test, log a severe message and return.

--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -201,68 +201,68 @@ func Load_Traps() map[string]GMeth {
 func trapCharset([]interface{}) interface{} {
 	errMsg := "Class java/nio/charset/Charset is not yet supported"
 	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
-	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
+	return nil
 }
 
 // Trap for deprecated functions
 func trapDeprecated([]interface{}) interface{} {
 	errMsg := "The class or function requested is deprecated and is not supported by jacobin"
 	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
-	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
+	return nil
 }
 
 // Trap for FileChannel references
 func trapFileChannel([]interface{}) interface{} {
 	errMsg := "Class java.nio.channels.FileChannel is not yet supported"
 	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
-	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
+	return nil
 }
 
 // Trap for FileDescriptor references
 func trapFileDescriptor([]interface{}) interface{} {
 	errMsg := "Class java/io/FileDescriptor is not yet supported"
 	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
-	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
+	return nil
 }
 
 // Trap for FileSystem references
 func trapFileSystem([]interface{}) interface{} {
 	errMsg := "Class java.io.FileSystem is not yet supported"
 	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
-	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
+	return nil
 }
 
 // "java/io/DefaultFileSystem.getFileSystem()Ljava/io/FileSystem;"
 func trapGetDefaultFileSystem([]interface{}) interface{} {
 	errMsg := "DefaultFileSystem.getFileSystem() is not yet supported"
 	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
-	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
+	return nil
 }
 
 // Trap for unsupported readers
 func trapReader([]interface{}) interface{} {
 	errMsg := "The requested reader is not yet supported"
 	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
-	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
+	return nil
 }
 
 // Trap for unsupported writers
 func trapWriter([]interface{}) interface{} {
 	errMsg := "The requested writer is not yet supported"
 	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
-	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
+	return nil
 }
 
 // Trap for StringBuilder
 func trapStringBuilder([]interface{}) interface{} {
 	errMsg := "Class StringBuilder is not yet supported"
 	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
-	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
+	return nil
 }
 
-// Trap for StringBuilder
+// Trap for StringBuffer
 func trapStringBuffer([]interface{}) interface{} {
 	errMsg := "Class StringBuffer is not yet supported"
 	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
-	return getGErrBlk(exceptions.UnsupportedOperationException, errMsg)
+	return nil
 }


### PR DESCRIPTION
The ThrowEx hello message contains the original detailed error message. That is ok for tracing.

It would be very helpful in debugging if we also log in the caught and uncaught sections as SEVERE. Then, even if the original detailed error message gets lost or some other mishap occurs, we will at least have:
* captured the original detailed message as evidence
* note that we have come through ThrowEx and the mode (caught or uncaught)