### PR TITLE
JACOBIN-469 Miscellaneous native work-arounds, AtomicInteger

### DIFF
--- a/src/frames/frames.go
+++ b/src/frames/frames.go
@@ -18,6 +18,8 @@ type StackValue interface {
 	int64 | float64 | unsafe.Pointer
 }
 
+//var debugging bool = true
+
 type Number interface {
 	int64 | float64
 }
@@ -73,6 +75,9 @@ func CreateFrame(opStackSize int) *Frame {
 
 // PushFrame pushes a frame. This simply adds a frame to the head of the list.
 func PushFrame(fs *list.List, f *Frame) error {
+	/*if debugging {
+		fmt.Printf("DEBUG PushFrame ClName=%s, MethName=%s TOS=%d, PC=%d\n", f.ClName, f.MethName, f.TOS, f.PC)
+	}*/
 	fs.PushFront(f)
 	// TODO: move this to instrumentation system
 	if log.Level == log.FINEST {
@@ -91,6 +96,11 @@ func PopFrame(fs *list.List) error {
 	if fs.Len() == 0 {
 		return fmt.Errorf("invalid PopFrame of empty JVM frame stack")
 	}
+
+	/*if debugging {
+		f := PeekFrame(fs, 0)
+		fmt.Printf("DEBUG PopFrame ClName=%s, MethName=%s TOS=%d, PC=%d\n", f.ClName, f.MethName, f.TOS, f.PC)
+	}*/
 
 	fs.Remove(fs.Front())
 	return nil

--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -242,6 +242,12 @@ func Load_Traps() map[string]GMeth {
 			GFunction:  trapRandomNext,
 		}
 
+	MethodSignatures["jdk/internal/access/SharedSecrets.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapSharedSecrets,
+		}
+
 	return MethodSignatures
 }
 
@@ -332,6 +338,13 @@ func trapFilterOutputStream([]interface{}) interface{} {
 // Trap for Random.next()
 func trapRandomNext([]interface{}) interface{} {
 	errMsg := "Protected method Random.next should never be reached unless done by reflection"
+	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
+	return nil
+}
+
+// Trap for Random.next()
+func trapSharedSecrets([]interface{}) interface{} {
+	errMsg := "Class jdk/internal/access/SharedSecrets is not supported"
 	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
 	return nil
 }

--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -130,7 +130,19 @@ func Load_Traps() map[string]GMeth {
 			GFunction:  trapDeprecated,
 		}
 
-	// String Builder
+	MethodSignatures["java/security/AccessController.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures["java/security/AccessController.<init>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
+		}
+
+	// StringBuilder
 
 	MethodSignatures["java/lang/StringBuilder.<clinit>()V"] =
 		GMeth{
@@ -162,7 +174,7 @@ func Load_Traps() map[string]GMeth {
 			GFunction:  trapStringBuilder,
 		}
 
-	// String Buffer
+	// StringBuffer
 
 	MethodSignatures["java/lang/StringBuffer.<clinit>()V"] =
 		GMeth{
@@ -193,6 +205,36 @@ func Load_Traps() map[string]GMeth {
 			ParamSlots: 0,
 			GFunction:  trapStringBuffer,
 		}
+
+	// FilterInputStream
+
+	MethodSignatures["java/lang/FilterInputStream.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFilterInputStream,
+		}
+
+	MethodSignatures["java/lang/FilterInputStream.<init>(Ljava/io/InputStream;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFilterInputStream,
+		}
+
+	// FilterOutputStream
+
+	MethodSignatures["java/lang/FilterOutputStream.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFilterOutputStream,
+		}
+
+	MethodSignatures["java/lang/FilterOutputStream.<init>(Ljava/io/OutputStream;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFilterOutputStream,
+		}
+
+	// Miscellaneous
 
 	MethodSignatures["java/util/Random.next(I)V"] =
 		GMeth{
@@ -273,7 +315,21 @@ func trapStringBuffer([]interface{}) interface{} {
 	return nil
 }
 
-// Trap for StringBuffer
+// Trap for FilterInputStream
+func trapFilterInputStream([]interface{}) interface{} {
+	errMsg := "Class FilterInputStream is not yet supported"
+	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
+	return nil
+}
+
+// Trap for FilterOutputStream
+func trapFilterOutputStream([]interface{}) interface{} {
+	errMsg := "Class FilterOutputStream is not yet supported"
+	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)
+	return nil
+}
+
+// Trap for Random.next()
 func trapRandomNext([]interface{}) interface{} {
 	errMsg := "Protected method Random.next should never be reached unless done by reflection"
 	exceptions.Throw(exceptions.UnsupportedOperationException, errMsg)

--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -113,6 +113,9 @@ func checkKey(key string) bool {
 	if strings.Index(key, ".") == -1 || strings.Index(key, "(") == -1 || strings.Index(key, ")") == -1 {
 		return false
 	}
+	if strings.HasSuffix(key, ")") {
+		return false
+	}
 	return true
 }
 

--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -93,6 +93,7 @@ func MTableLoadNatives(MTable *classloader.MT) {
 	loadlib(MTable, Load_Nio_Charset_Charset()) // Zero Charset support
 
 	loadlib(MTable, Load_Util_HashMap())
+	loadlib(MTable, Load_Util_HexFormat())
 	loadlib(MTable, Load_Util_Locale())
 	loadlib(MTable, Load_Util_Concurrent_Atomic_Atomic_Long())
 	loadlib(MTable, Load_Util_Random())

--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -92,6 +92,7 @@ func MTableLoadNatives(MTable *classloader.MT) {
 
 	loadlib(MTable, Load_Nio_Charset_Charset()) // Zero Charset support
 
+	loadlib(MTable, Load_Util_Concurrent_Atomic_AtomicInteger())
 	loadlib(MTable, Load_Util_HashMap())
 	loadlib(MTable, Load_Util_HexFormat())
 	loadlib(MTable, Load_Util_Locale())

--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -93,10 +93,10 @@ func MTableLoadNatives(MTable *classloader.MT) {
 	loadlib(MTable, Load_Nio_Charset_Charset()) // Zero Charset support
 
 	loadlib(MTable, Load_Util_Concurrent_Atomic_AtomicInteger())
+	loadlib(MTable, Load_Util_Concurrent_Atomic_Atomic_Long())
 	loadlib(MTable, Load_Util_HashMap())
 	loadlib(MTable, Load_Util_HexFormat())
 	loadlib(MTable, Load_Util_Locale())
-	loadlib(MTable, Load_Util_Concurrent_Atomic_Atomic_Long())
 	loadlib(MTable, Load_Util_Random())
 
 	loadlib(MTable, Load_Jdk_Internal_Misc_Unsafe())

--- a/src/gfunction/gfunction_test.go
+++ b/src/gfunction/gfunction_test.go
@@ -8,27 +8,45 @@ package gfunction
 
 import (
 	"jacobin/classloader"
+	"jacobin/globals"
+	"jacobin/log"
 	"testing"
 )
 
+func f1([]interface{}) interface{} { return nil }
+func f2([]interface{}) interface{} { return nil }
+func f3([]interface{}) interface{} { return nil }
+
 func TestMTableLoadLib(t *testing.T) {
+	globals.InitGlobals("test")
+	log.Init()
 	libMeths := make(map[string]GMeth)
-	libMeths["testG1"] = GMeth{ParamSlots: 1, GFunction: nil}
-	libMeths["testG2"] = GMeth{ParamSlots: 2, GFunction: nil}
-	libMeths["testG3"] = GMeth{ParamSlots: 3, GFunction: nil}
+	libMeths["test.f1()V"] = GMeth{ParamSlots: 0, GFunction: f1}
+	libMeths["test.f2(I)V"] = GMeth{ParamSlots: 1, GFunction: f2}
+	libMeths["test.f3(Ljava/lang/String;JZ)D"] = GMeth{ParamSlots: 3, GFunction: f3}
 	mtbl := make(classloader.MT)
 	loadlib(&mtbl, libMeths)
 	if len(mtbl) != 3 {
-		t.Errorf("Expecting MTable with 3 entries, got: %d", len(mtbl))
+		t.Errorf("ERROR, Expecting MTable with 3 entries, got: %d\n", len(mtbl))
 	}
-	mte := libMeths["testG2"]
-	if mte.ParamSlots != 2 {
-		t.Errorf("Expecting MTable entry to have 2 param slots, got: %d",
+	mte := libMeths["test.f1()V"]
+	if mte.ParamSlots != 0 {
+		t.Errorf("ERROR, Expecting f1 MTable entry to have 0 param slots, got: %d\n",
+			mte.ParamSlots)
+	}
+	mte = libMeths["test.f2(I)V"]
+	if mte.ParamSlots != 1 {
+		t.Errorf("ERROR, Expecting f2 MTable entry to have 1 param slots, got: %d\n",
+			mte.ParamSlots)
+	}
+	mte = libMeths["test.f3(Ljava/lang/String;JZ)D"]
+	if mte.ParamSlots != 3 {
+		t.Errorf("ERROR, Expecting f3 MTable entry to have 3 param slots, got: %d\n",
 			mte.ParamSlots)
 	}
 
-	if mte.NeedsContext != false {
-		t.Errorf("Expecting MTable entry's NeedContext to be false")
+	if mte.NeedsContext {
+		t.Errorf("ERROR, Expecting MTable entry's NeedContext to be false\n")
 	}
 }
 

--- a/src/gfunction/javaUtilConcurrentAtomicAtomicInteger.go
+++ b/src/gfunction/javaUtilConcurrentAtomicAtomicInteger.go
@@ -10,7 +10,7 @@ var atomicIntegerClassName = "java/util/concurrent/atomic/AtomicInteger"
 
 func Load_Util_Concurrent_Atomic_AtomicInteger() map[string]GMeth {
 
-	MethodSignatures["java/util/concurrent/atomic/AtomicInteger.<clinit>V"] =
+	MethodSignatures["java/util/concurrent/atomic/AtomicInteger.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  justReturn,

--- a/src/gfunction/javaUtilConcurrentAtomicAtomicInteger.go
+++ b/src/gfunction/javaUtilConcurrentAtomicAtomicInteger.go
@@ -1,0 +1,237 @@
+package gfunction
+
+import (
+	"jacobin/globals"
+	"jacobin/object"
+	"jacobin/types"
+)
+
+var atomicIntegerClassName = "java/util/concurrent/atomic/AtomicInteger"
+
+func Load_Util_Concurrent_Atomic_AtomicInteger() map[string]GMeth {
+
+	MethodSignatures["java/util/concurrent/atomic/AtomicInteger.<clinit>V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/util/concurrent/atomic/AtomicInteger.<init>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  atomicIntegerInitVoid,
+		}
+
+	MethodSignatures["java/util/concurrent/atomic/AtomicInteger.<init>(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  atomicIntegerInitInt,
+		}
+
+	MethodSignatures["java/util/concurrent/atomic/AtomicInteger.get()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  atomicIntegerGet,
+		}
+
+	MethodSignatures["java/util/concurrent/atomic/AtomicInteger.set(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  atomicIntegerInitInt,
+		}
+
+	MethodSignatures["java/util/concurrent/atomic/AtomicInteger.lazySet(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  atomicIntegerInitInt,
+		}
+
+	MethodSignatures["java/util/concurrent/atomic/AtomicInteger.getAndSet(I)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  atomicIntegerInitInt,
+		}
+
+	MethodSignatures["java/util/concurrent/atomic/AtomicInteger.compareAndSet(II)I"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  atomicIntegerInitInt,
+		}
+
+	MethodSignatures["java/util/concurrent/atomic/AtomicInteger.weakCompareAndSet(II)I"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures["java/util/concurrent/atomic/AtomicInteger.getAndIncrement()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  atomicIntegerGetAndIncrement,
+		}
+
+	MethodSignatures["java/util/concurrent/atomic/AtomicInteger.getAndDecrement()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  atomicIntegerGetAndDecrement,
+		}
+
+	MethodSignatures["java/util/concurrent/atomic/AtomicInteger.getAndAdd(I)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  atomicIntegerGetAndDecrement,
+		}
+
+	MethodSignatures["java/util/concurrent/atomic/AtomicInteger.incrementAndGet()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  atomicIntegerGetAndIncrement,
+		}
+
+	MethodSignatures["java/util/concurrent/atomic/AtomicInteger.decrementAndGet()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  atomicIntegerGetAndDecrement,
+		}
+
+	MethodSignatures["java/util/concurrent/atomic/AtomicInteger.addAndGet(I)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  atomicIntegerGetAndDecrement,
+		}
+
+	return MethodSignatures
+}
+
+// "java/util/concurrent/atomic/AtomicInteger.<init>()V"
+func atomicIntegerInitVoid(params []interface{}) interface{} {
+	initialField := object.Field{Ftype: types.Int, Fvalue: int64(0)}
+	obj := params[0].(*object.Object)
+	obj.FieldTable["value"] = initialField
+	return nil
+}
+
+// "java/util/concurrent/atomic/AtomicInteger.<init>(I)V"
+func atomicIntegerInitInt(params []interface{}) interface{} {
+	initialValue := params[1].(int64)
+	initialField := object.Field{Ftype: types.Int, Fvalue: initialValue}
+	obj := params[0].(*object.Object)
+	obj.FieldTable["value"] = initialField
+	return nil
+}
+
+// "java/util/concurrent/atomic/AtomicInteger.get()I"
+func atomicIntegerGet(params []interface{}) interface{} {
+	obj := params[0].(*object.Object)
+	wint := obj.FieldTable["value"].Fvalue.(int64)
+	return wint
+}
+
+// func atomicIntegerSet = atomicIntegerInitInt
+
+// func atomicIntegerLazySet = atomicIntegerInitInt
+
+func atomicIntegerGetAndSet(params []interface{}) interface{} {
+	global := globals.GetGlobalRef()
+	global.AtomicIntegerLock.Lock() // <-------------------
+	obj := params[0].(*object.Object)
+	oldValue := obj.FieldTable["value"].Fvalue.(int64)
+	newValue := params[1].(int64)
+	newField := object.Field{Ftype: types.Int, Fvalue: newValue}
+	obj.FieldTable["value"] = newField
+	global.AtomicIntegerLock.Unlock() // <-------------------
+	return oldValue
+}
+
+func atomicIntegerCompareAndSet(params []interface{}) interface{} {
+	global := globals.GetGlobalRef()
+	global.AtomicIntegerLock.Lock() // <-------------------
+	obj := params[0].(*object.Object)
+	oldValue := obj.FieldTable["value"].Fvalue.(int64)
+	expectedValue := params[1].(int64)
+	if oldValue != expectedValue {
+		global.AtomicIntegerLock.Unlock() // <-------------------
+		return int64(0)
+	}
+	newValue := params[2].(int64)
+	newField := object.Field{Ftype: types.Int, Fvalue: newValue}
+	obj.FieldTable["value"] = newField
+	global.AtomicIntegerLock.Unlock() // <-------------------
+	return int64(1)
+}
+
+// func WeakCompareAndSet = trapDeprecated
+
+func atomicIntegerGetAndIncrement(params []interface{}) interface{} {
+	global := globals.GetGlobalRef()
+	global.AtomicIntegerLock.Lock() // <-------------------
+	obj := params[0].(*object.Object)
+	oldValue := obj.FieldTable["value"].Fvalue.(int64)
+	newValue := oldValue + 1
+	newField := object.Field{Ftype: types.Int, Fvalue: newValue}
+	obj.FieldTable["value"] = newField
+	global.AtomicIntegerLock.Unlock() // <-------------------
+	return oldValue                   // previous value
+}
+
+func atomicIntegerGetAndDecrement(params []interface{}) interface{} {
+	global := globals.GetGlobalRef()
+	global.AtomicIntegerLock.Lock() // <-------------------
+	obj := params[0].(*object.Object)
+	oldValue := obj.FieldTable["value"].Fvalue.(int64)
+	newValue := oldValue - 1
+	newField := object.Field{Ftype: types.Int, Fvalue: newValue}
+	obj.FieldTable["value"] = newField
+	global.AtomicIntegerLock.Unlock() // <-------------------
+	return oldValue                   // previous value
+}
+
+func atomicIntegerGetAndAdd(params []interface{}) interface{} {
+	global := globals.GetGlobalRef()
+	global.AtomicIntegerLock.Lock() // <-------------------
+	obj := params[0].(*object.Object)
+	delta := params[1].(int64)
+	oldValue := obj.FieldTable["value"].Fvalue.(int64)
+	newValue := oldValue + delta
+	newField := object.Field{Ftype: types.Int, Fvalue: newValue}
+	obj.FieldTable["value"] = newField
+	global.AtomicIntegerLock.Unlock() // <-------------------
+	return oldValue                   // previous value
+}
+
+func atomicIntegerIncrementAndGet(params []interface{}) interface{} {
+	global := globals.GetGlobalRef()
+	global.AtomicIntegerLock.Lock() // <-------------------
+	obj := params[0].(*object.Object)
+	oldValue := obj.FieldTable["value"].Fvalue.(int64)
+	newValue := oldValue + 1
+	newField := object.Field{Ftype: types.Int, Fvalue: newValue}
+	obj.FieldTable["value"] = newField
+	global.AtomicIntegerLock.Unlock() // <-------------------
+	return newValue                   // previous value
+}
+
+func atomicIntegerDecrementAndGet(params []interface{}) interface{} {
+	global := globals.GetGlobalRef()
+	global.AtomicIntegerLock.Lock() // <-------------------
+	obj := params[0].(*object.Object)
+	oldValue := obj.FieldTable["value"].Fvalue.(int64)
+	newValue := oldValue - 1
+	newField := object.Field{Ftype: types.Int, Fvalue: newValue}
+	obj.FieldTable["value"] = newField
+	global.AtomicIntegerLock.Unlock() // <-------------------
+	return newValue                   // previous value
+}
+
+func atomicIntegerAddAndGet(params []interface{}) interface{} {
+	global := globals.GetGlobalRef()
+	global.AtomicIntegerLock.Lock() // <-------------------
+	obj := params[0].(*object.Object)
+	delta := params[1].(int64)
+	oldValue := obj.FieldTable["value"].Fvalue.(int64)
+	newValue := oldValue + delta
+	newField := object.Field{Ftype: types.Int, Fvalue: newValue}
+	obj.FieldTable["value"] = newField
+	global.AtomicIntegerLock.Unlock() // <-------------------
+	return newValue                   // previous value
+}

--- a/src/gfunction/javaUtilHexFormat.go
+++ b/src/gfunction/javaUtilHexFormat.go
@@ -1,0 +1,22 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2023 by  the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package gfunction
+
+// Implementation of some of the functions in Java/util/HexFormat.
+
+var JavaUtilHexFormat string = "java/util/HexFormat"
+
+func Load_Util_HexFormat() map[string]GMeth {
+
+	MethodSignatures["java/util/HexFormat.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	return MethodSignatures
+}

--- a/src/gfunction/jdkMiscUnsafe.go
+++ b/src/gfunction/jdkMiscUnsafe.go
@@ -49,7 +49,7 @@ func Load_Jdk_Internal_Misc_Unsafe() map[string]GMeth {
 
 	MethodSignatures["jdk/internal/misc/Unsafe.compareAndSetInt(Ljava/lang/Object;JII)Z"] =
 		GMeth{
-			ParamSlots: 3,
+			ParamSlots: 5,
 			GFunction:  unsafeCompareAndSetInt,
 		}
 
@@ -59,8 +59,16 @@ func Load_Jdk_Internal_Misc_Unsafe() map[string]GMeth {
 			GFunction:  unsafeCompareAndSetInt,
 		}
 
+	MethodSignatures["jdk/internal/misc/Unsafe.getUnsafe()Ljdk/internal/misc/Unsafe;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  unsafeGetUnsafe,
+		}
+
 	return MethodSignatures
 }
+
+var classUnsafeName = "jdk/internal/misc/Unsafe"
 
 // Return the number of bytes between the beginning of the object and the first element.
 // This is used in computing the pointer to a given element
@@ -111,4 +119,9 @@ func unsafeGetAndAddInt(params []interface{}) interface{} {
 	delta := params[4].(int64)
 	wint := hash + offset + delta
 	return wint
+}
+
+func unsafeGetUnsafe([]interface{}) interface{} {
+	obj := object.MakeEmptyObjectWithClassName(&classUnsafeName)
+	return obj
 }

--- a/src/gfunction/jdkMiscUnsafe.go
+++ b/src/gfunction/jdkMiscUnsafe.go
@@ -41,17 +41,74 @@ func Load_Jdk_Internal_Misc_Unsafe() map[string]GMeth {
 			GFunction:  arrayBaseOffset,
 		}
 
+	MethodSignatures["jdk/internal/misc/Unsafe.getIntVolatile(Ljava/lang/Object;J)I"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  unsafeGetIntVolatile,
+		}
+
+	MethodSignatures["jdk/internal/misc/Unsafe.compareAndSetInt(Ljava/lang/Object;JII)Z"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  unsafeCompareAndSetInt,
+		}
+
+	MethodSignatures["jdk/internal/misc/Unsafe.getAndAddInt(Ljava/lang/Object;JI)I"] =
+		GMeth{
+			ParamSlots: 4,
+			GFunction:  unsafeCompareAndSetInt,
+		}
+
 	return MethodSignatures
 }
 
 // Return the number of bytes between the beginning of the object and the first element.
 // This is used in computing the pointer to a given element
 // "jdk/internal/misc/Unsafe.arrayBaseOffset(Ljava/lang/Class;)I"
-func arrayBaseOffset(param []interface{}) interface{} {
-	p := param[0]
+func arrayBaseOffset(params []interface{}) interface{} {
+	p := params[0]
 	if p == nil || p == object.Null {
 		errMsg := "jdk.internal.misc.Unsafe::arrayBaseOffset() was passed a null pointer"
 		return getGErrBlk(exceptions.NullPointerException, errMsg)
 	}
 	return int64(0) // this should work...
+}
+
+// SWAG
+// "jdk/internal/misc/Unsafe.getIntVolatile(Ljava/lang/Object;J)I"
+func unsafeGetIntVolatile(params []interface{}) interface{} {
+	var hash int64
+	switch params[1].(type) {
+	case nil:
+		hash = 0
+	case *object.Object:
+		obj := params[0].(*object.Object)
+		hash = int64(obj.Mark.Hash)
+	}
+	offset := params[2].(int64)
+	wint := hash + offset
+	return wint
+}
+
+// SWAG
+// "jdk/internal/misc/Unsafe.compareAndSetInt(Ljava/lang/Object;JII)Z"
+func unsafeCompareAndSetInt(params []interface{}) interface{} {
+	return int64(1) // SWAG
+}
+
+// SWAG
+// "jdk/internal/misc/Unsafe.getAndAddInt(Ljava/lang/Object;JI)I"
+func unsafeGetAndAddInt(params []interface{}) interface{} {
+	var hash int64
+	switch params[1].(type) {
+	case nil:
+		hash = 0
+	case *object.Object:
+		obj := params[0].(*object.Object)
+		hash = int64(obj.Mark.Hash)
+	}
+	offset := params[2].(int64)
+	delta := params[4].(int64)
+	wint := hash + offset + delta
+	return wint
 }

--- a/src/globals/globals.go
+++ b/src/globals/globals.go
@@ -82,6 +82,9 @@ type Globals struct {
 	// Random object mutex
 	RandomLock sync.Mutex
 
+	// AtomicInteger mutex
+	AtomicIntegerLock sync.Mutex
+
 	// ---- misc properties
 	FileEncoding string // what file encoding are we using?
 

--- a/src/jvm/goFunctionExec.go
+++ b/src/jvm/goFunctionExec.go
@@ -68,13 +68,16 @@ func runGframe(fs *list.List, fr *frames.Frame) (interface{}, int, error) {
 		// Get the G error block
 		ge := *ret.(*gfunction.GErrBlk)
 		// Pop the G frame off the frame stack.
-		fs.Remove(fs.Front())
+		err := frames.PopFrame(fs)
+		if err != nil {
+			return nil, 0, err
+		}
 		// Get a pointer to the previous frame.
 		fprev := fs.Front().Value.(*frames.Frame)
 		// Throw an exception in the previous frame.
 		exceptions.ThrowEx(ge.ExceptionType, ge.ErrMsg, fprev)
 		// Create an error object to return to caller.
-		var err = errors.New(ge.ErrMsg)
+		err = errors.New(ge.ErrMsg)
 		// Return to caller a nil G function result, 0 slots, and an error object.
 		return nil, 0, err
 	}

--- a/src/jvm/goFunctionExec.go
+++ b/src/jvm/goFunctionExec.go
@@ -21,13 +21,24 @@ import (
 // Similar to global tracing but just for this source file.
 var localDebugging bool = false
 
-// This function is called from run(). It executes a frame whose method is
+// runGframe is called from run(). It executes a frame whose method is
 // a native method implemented in golang. It copies the parameters from the
 // operand stack and passes them to the golang function, called GFunction,
 // as an array of interface{}, which can be nil if there are no arguments.
 // Any return value from the method is returned to run() as an interface{}
 // (which is nil in the case of a void function), where it is placed
 // by run() on the operand stack of the calling function.
+/*
+=========================================================
+Return values table
+			ret		slotCount	err
+---------------------------------------------------------
+Failure		nil		0			error
+Success		nil		0			nil		E.g. <clinit>
+Success		J/D		2			nil		long or double
+Success		~ J/D	1			nil		E.g. int
+=========================================================
+*/
 func runGframe(fs *list.List, fr *frames.Frame) (interface{}, int, error) {
 	if localDebugging || MainThread.Trace {
 		traceInfo := fmt.Sprintf("runGframe %s.%s, f.OpStack:", fr.ClName, fr.MethName)

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -176,7 +176,7 @@ frameInterpreter:
 		retval, slotCount, err := runGframe(fs, f)
 
 		if retval != nil {
-			f = fs.Front().Next().Value.(*frames.Frame)
+			f := fs.Front().Next().Value.(*frames.Frame)
 			push(f, retval) // if slotCount = 1
 
 			if slotCount == 2 {


### PR DESCRIPTION
* Added traps for more deprecated functions.
* Added traps for Filter{Input, Output}Stream classes.
* Created a ```<clinit>``` for java/util/HexFormat to avoid the SharedSecrets cascade of trouble:
```
GETFIELD: Invalid type of object ref: int64
error encountered running java/lang/invoke/MethodHandles$Lookup.<clinit>()
NEW: could not load class java/lang/invoke/MethodHandles$Lookup
INVOKESTATIC: error running initializer block in jdk/internal/access/SharedSecrets
INVOKESTATIC: error running initializer block in java/util/HexFormat
Method: java/lang/Class.getModule                PC: 003
Method: java/lang/invoke/MethodHandles$Lookup.<clinit> PC: 028
Method: java/lang/invoke/MethodHandles.lookup    PC: 002
Method: java/lang/invoke/MemberName.getFactory   PC: 003
Method: java/lang/invoke/MethodHandles.<clinit>  PC: 019
Method: jdk/internal/access/SharedSecrets.<clinit> PC: 003  // <----- just for hex formatting ?????
Method: java/util/HexFormat.<clinit>             PC: 018
Method: main.main                                PC: 007
```