### PR TITLE
JACOBIN-510 Consolidate Go constants to types/constants.go

### DIFF
--- a/src/classloader/TestLoadClass_test.go
+++ b/src/classloader/TestLoadClass_test.go
@@ -8,6 +8,7 @@ package classloader
 import (
 	"jacobin/globals"
 	"jacobin/log"
+	"jacobin/types"
 	"testing"
 )
 
@@ -68,6 +69,6 @@ func TestJmodToClass(t *testing.T) {
 	t.Logf("classloader.Init ok\n")
 
 	_ = checkClass(t, "com/sun/accessibility/internal/resources/accessibility", "java.desktop.jmod")
-	_ = checkClass(t, "java/lang/String", "java.base.jmod")
+	_ = checkClass(t, types.StringClassName, "java.base.jmod")
 
 }

--- a/src/classloader/classes.go
+++ b/src/classloader/classes.go
@@ -12,6 +12,7 @@ import (
 	"jacobin/log"
 	"jacobin/shutdown"
 	"jacobin/stringPool"
+	"jacobin/types"
 )
 
 // the definition of the class as it's stored in the method area
@@ -352,7 +353,7 @@ func FetchMethodAndCP(className, methName, methType string) (MTentry, error) {
 			AddEntry(&MTable, methFQN, methodEntry)
 			return methodEntry, nil
 		} else {
-			if className != "java/lang/Object" { // if we've ascended to Object and don't have the method, it ain't here
+			if className != types.ObjectClassName { // if we've ascended to Object and don't have the method, it ain't here
 				goto superclassLoop
 			} else {
 				errMsg := fmt.Sprintf("FetchMethodAndCP: Neither %s nor its superclasses contain method %s",

--- a/src/classloader/classes_test.go
+++ b/src/classloader/classes_test.go
@@ -146,14 +146,14 @@ func TestInvalidLookupOfMethod_Test1(t *testing.T) {
 		Data:   &ClData{},
 	}
 	k.Data.Name = "testClass"
-	k.Data.Superclass = "java/lang/Object"
+	k.Data.Superclass = types.ObjectClassName
 	k.Loader = "testloader"
 	k.Status = 'F'
 	MethAreaInsert("TestEntry", &k)
 
 	// we need a java/lang/Object instance, so just duplicate the entry
 	// in the MethArea. It's only a placeholder
-	MethAreaInsert("java/lang/Object", &k)
+	MethAreaInsert(types.ObjectClassName, &k)
 
 	_, err := FetchMethodAndCP("TestEntry", "main", "([L)V")
 	if err == nil {
@@ -198,14 +198,14 @@ func TestInvalidLookupOfMethod_Test2(t *testing.T) {
 		Data:   &ClData{},
 	}
 	k.Data.Name = "testClass"
-	k.Data.SuperclassIndex = stringPool.GetStringIndex(&types.JavaLangObjectString)
+	k.Data.SuperclassIndex = stringPool.GetStringIndex(&types.ObjectClassName)
 	k.Loader = "testloader"
 	k.Status = 'F'
 	MethAreaInsert("TestEntry", &k)
 
 	// we need a java/lang/Object instance, so just duplicate the entry
 	// in the MethArea. It's only a placeholder
-	MethAreaInsert("java/lang/Object", &k)
+	MethAreaInsert(types.ObjectClassName, &k)
 
 	newLen := MethAreaSize()
 	if newLen != currLen+2 {
@@ -298,14 +298,14 @@ func TestInvalidMainMethod(t *testing.T) {
 		Data:   &ClData{},
 	}
 	k.Data.Name = "testClass"
-	k.Data.Superclass = "java/lang/Object"
+	k.Data.Superclass = types.ObjectClassName
 	k.Loader = "testloader"
 	k.Status = 'F'
 	MethAreaInsert("TestEntry", &k)
 
 	// we need a java/lang/Object instance, so just duplicate the entry
 	// in the MethArea. It's only a placeholder
-	MethAreaInsert("java/lang/Object", &k)
+	MethAreaInsert(types.ObjectClassName, &k)
 
 	// fetch a non-existent main() method
 	_, err := FetchMethodAndCP("java/lan/Object", "main", "([LString;)V")

--- a/src/classloader/classloader.go
+++ b/src/classloader/classloader.go
@@ -795,7 +795,7 @@ func Init() error {
 
 	// Load the base jmod
 	GetBaseJmodBytes()
-	_, err := GetClassBytes("java.base.jmod", "java/lang/String")
+	_, err := GetClassBytes("java.base.jmod", types.StringClassName)
 	if err != nil {
 		msg := fmt.Sprintf("classloader.Init: GetClassBytes failed for java/lang/String in java.base.jmod")
 		_ = log.Log(msg, log.SEVERE)

--- a/src/classloader/classloader_test.go
+++ b/src/classloader/classloader_test.go
@@ -130,8 +130,8 @@ func TestNormalizingClassReference(t *testing.T) {
 		t.Error("Unexpected normalized class reference: " + s)
 	}
 
-	s = normalizeClassReference("java/lang/Object")
-	if s != "java/lang/Object" {
+	s = normalizeClassReference(types.ObjectClassName)
+	if s != types.ObjectClassName {
 		t.Error("Unexpected normalized class reference: " + s)
 	}
 }

--- a/src/classloader/jmodMap_test.go
+++ b/src/classloader/jmodMap_test.go
@@ -8,6 +8,7 @@ package classloader
 import (
 	"jacobin/globals"
 	"jacobin/log"
+	"jacobin/types"
 	"os"
 	"testing"
 	"time"
@@ -62,7 +63,7 @@ func TestJmodMapHomeTempdir(t *testing.T) {
 		t.Logf("Gob not found as expected")
 	}
 
-	checkMap(t, "java/lang/String", "java.base.jmod")
+	checkMap(t, types.StringClassName, "java.base.jmod")
 	checkMap(t, "com/sun/accessibility/internal/resources/accessibility", "java.desktop.jmod")
 
 }
@@ -96,7 +97,7 @@ func TestJmodMapHomeDefault(t *testing.T) {
 	}
 	t.Logf("Map size is %d\n", mapSize)
 
-	checkMap(t, "java/lang/String", "java.base.jmod")
+	checkMap(t, types.StringClassName, "java.base.jmod")
 	checkMap(t, "com/sun/accessibility/internal/resources/accessibility", "java.desktop.jmod")
 
 }

--- a/src/classloader/methArea.go
+++ b/src/classloader/methArea.go
@@ -42,8 +42,8 @@ func MethAreaPreload() {
 	emptyKlass := Klass{
 		Status: 'N', // N = instantiated
 		Loader: "bootstrap",
-		Data: &ClData{Superclass: "java/lang/Object",
-			SuperclassIndex: stringPool.GetStringIndex(types.PtrToJavaLangObjecct)}, // empty class info
+		Data: &ClData{Superclass: types.ObjectClassName,
+			SuperclassIndex: stringPool.GetStringIndex(types.PtrToJavaLangObject)}, // empty class info
 	}
 
 	classesToPreload := []string{

--- a/src/classloader/methArea_test.go
+++ b/src/classloader/methArea_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"jacobin/globals"
 	"jacobin/log"
+	"jacobin/types"
 	"os"
 	"strings"
 	"sync"
@@ -33,7 +34,7 @@ func TestMethAreadDelete(t *testing.T) {
 		Data:   &ClData{},
 	}
 	k.Data.Name = "testClass1"
-	k.Data.Superclass = "java/lang/Object"
+	k.Data.Superclass = types.ObjectClassName
 	k.Loader = "testloader"
 	k.Status = 'F'
 	MethAreaInsert("TestEntry1", &k)
@@ -65,7 +66,7 @@ func TestMethAreadDeleteNonExistentEntry(t *testing.T) {
 		Data:   &ClData{},
 	}
 	k.Data.Name = "testClass1"
-	k.Data.Superclass = "java/lang/Object"
+	k.Data.Superclass = types.ObjectClassName
 	k.Loader = "testloader"
 	k.Status = 'F'
 	MethAreaInsert("TestEntry", &k)
@@ -107,7 +108,7 @@ func TestMethAreadFetchNonExistentEntry(t *testing.T) {
 		Data:   &ClData{},
 	}
 	k.Data.Name = "testClass1"
-	k.Data.Superclass = "java/lang/Object"
+	k.Data.Superclass = types.ObjectClassName
 	k.Loader = "testloader"
 	k.Status = 'F'
 	MethAreaInsert("TestEntry", &k)
@@ -147,7 +148,7 @@ func TestWaitFornNonExistentClass(t *testing.T) {
 		Data:   &ClData{},
 	}
 	k.Data.Name = "testClass1"
-	k.Data.Superclass = "java/lang/Object"
+	k.Data.Superclass = types.ObjectClassName
 	k.Loader = "testloader"
 	k.Status = 'F'
 	MethAreaInsert("TestEntry", &k)
@@ -193,7 +194,7 @@ func TestWaitFornUnresolvedClassStatus(t *testing.T) {
 		Data:   &ClData{},
 	}
 	k.Data.Name = "testClass1"
-	k.Data.Superclass = "java/lang/Object"
+	k.Data.Superclass = types.ObjectClassName
 	k.Loader = "testloader"
 	k.Status = 'I'
 	MethAreaInsert("TestEntry", &k)

--- a/src/classloader/parser.go
+++ b/src/classloader/parser.go
@@ -295,7 +295,7 @@ func parseSuperClassName(bytes []byte, loc int, klass *ParsedClass) (int, error)
 	}
 
 	if index == 0 {
-		if klass.className != "java/lang/Object" {
+		if klass.className != types.ObjectClassName {
 			return pos, cfe("invaild index for superclass name. Got: 0," +
 				" but class is not java/lang/Object")
 		} else {

--- a/src/classloader/parser_test.go
+++ b/src/classloader/parser_test.go
@@ -11,6 +11,7 @@ import (
 	"jacobin/globals"
 	"jacobin/log"
 	"jacobin/stringPool"
+	"jacobin/types"
 	"os"
 	"strconv"
 	"strings"
@@ -618,7 +619,7 @@ func TestSuperclassNameValidEmptyDueToItBeingObjectClass(t *testing.T) {
 		entryType: 1,
 		slot:      1,
 	})
-	pc.className = "java/lang/Object"
+	pc.className = types.ObjectClassName
 	pc.superClassIndex = stringPool.GetStringIndex(nil)
 
 	_, err := parseSuperClassName(testBytes, 0, &pc)

--- a/src/classloader/parsingFullClass_test.go
+++ b/src/classloader/parsingFullClass_test.go
@@ -11,6 +11,7 @@ import (
 	"jacobin/globals"
 	"jacobin/log"
 	"jacobin/stringPool"
+	"jacobin/types"
 	"strconv"
 	"testing"
 )
@@ -147,7 +148,7 @@ func TestASimpleValidClass(t *testing.T) {
 	}
 
 	superClass := stringPool.GetStringPointer(klass.superClassIndex)
-	if *superClass != "java/lang/Object" {
+	if *superClass != types.ObjectClassName {
 		t.Error("Expected superclass to be 'java/lang/Object'. Got: " + *superClass)
 	}
 

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -338,9 +338,9 @@ func Load_Lang_String() map[string]GMeth {
 
 // "java/lang/String.<clinit>()V" -- String class initialisation
 func stringClinit([]interface{}) interface{} {
-	klass := classloader.MethAreaFetch(object.StringClassName)
+	klass := classloader.MethAreaFetch(types.StringClassName)
 	if klass == nil {
-		errMsg := fmt.Sprintf("stringClinit: Could not find class %s in the MethodArea", object.StringClassName)
+		errMsg := fmt.Sprintf("stringClinit: Could not find class %s in the MethodArea", types.StringClassName)
 		return getGErrBlk(excNames.ClassNotLoadedException, errMsg)
 	}
 	klass.Data.ClInit = types.ClInitRun // just mark that String.<clinit>() has been run
@@ -349,7 +349,7 @@ func stringClinit([]interface{}) interface{} {
 
 // No support YET for references to Charset objects nor for Unicode code point arrays
 func noSupportYetInString([]interface{}) interface{} {
-	errMsg := fmt.Sprintf("%s: No support yet for user-specified character sets and Unicode code point arrays", object.StringClassName)
+	errMsg := fmt.Sprintf("%s: No support yet for user-specified character sets and Unicode code point arrays", types.StringClassName)
 	return getGErrBlk(excNames.UnsupportedEncodingException, errMsg)
 }
 

--- a/src/globals/globals.go
+++ b/src/globals/globals.go
@@ -11,6 +11,7 @@ import (
 	"container/list"
 	"errors"
 	"fmt"
+	"jacobin/types"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -294,16 +295,15 @@ func InitStringPool() {
 
 	// Add empty string (for when an index field has not been use, and so = 0
 	StringPoolTable[""] = 0
-	StringPoolList = append(StringPoolList, "")
+	StringPoolList = append(StringPoolList, types.EmptyString)
 
 	// Add "java/lang/String"
-	StringIndexString = 1
-	StringPoolTable["java/lang/String"] = StringIndexString
-	StringPoolList = append(StringPoolList, "java/lang/String")
+	StringPoolTable[types.StringClassName] = types.StringPoolStringIndex
+	StringPoolList = append(StringPoolList, types.StringClassName)
 
 	// Add "java/lang/Object"
-	StringPoolTable["java/lang/Object"] = 2
-	StringPoolList = append(StringPoolList, "java/lang/Object")
+	StringPoolTable[types.ObjectClassName] = types.ObjectPoolStringIndex
+	StringPoolList = append(StringPoolList, types.ObjectClassName)
 
 	// Set up next available index
 	StringPoolNext = uint32(3)

--- a/src/jvm/arrayBytecodes_test.go
+++ b/src/jvm/arrayBytecodes_test.go
@@ -64,7 +64,7 @@ func TestAaload(t *testing.T) {
 	CP.CpIndex = make([]classloader.CpEntry, 10, 10)
 	CP.CpIndex[0] = classloader.CpEntry{Type: 0, Slot: 0}
 	CP.CpIndex[1] = classloader.CpEntry{Type: classloader.ClassRef, Slot: 0}
-	CP.ClassRefs = append(CP.ClassRefs, object.StringPoolStringIndex) // use string pool
+	CP.ClassRefs = append(CP.ClassRefs, types.StringPoolStringIndex) // use string pool
 	f.CP = &CP
 
 	globals.InitGlobals("test")
@@ -153,7 +153,7 @@ func TestAastore(t *testing.T) {
 	CP.CpIndex = make([]classloader.CpEntry, 10, 10)
 	CP.CpIndex[0] = classloader.CpEntry{Type: 0, Slot: 0}
 	CP.CpIndex[1] = classloader.CpEntry{Type: classloader.ClassRef, Slot: 0}
-	CP.ClassRefs = append(CP.ClassRefs, object.StringPoolStringIndex) // point to string pool
+	CP.ClassRefs = append(CP.ClassRefs, types.StringPoolStringIndex) // point to string pool
 	f.CP = &CP
 
 	globals.InitGlobals("test")
@@ -271,7 +271,7 @@ func TestAastoreInvalid2(t *testing.T) {
 
 // AASTORE: Test error conditions: index out of range
 func TestAastoreInvalid3(t *testing.T) {
-	objType := "java/lang/Object"
+	objType := types.ObjectClassName
 	o := object.Make1DimRefArray(&objType, 10)
 	f := newFrame(opcodes.AASTORE)
 	push(&f, o)         // an array of 10 ints, not floats
@@ -321,7 +321,7 @@ func TestAnewrray(t *testing.T) {
 	CP.CpIndex = make([]classloader.CpEntry, 10, 10)
 	CP.CpIndex[0] = classloader.CpEntry{Type: 0, Slot: 0}
 	CP.CpIndex[1] = classloader.CpEntry{Type: classloader.ClassRef, Slot: 0}
-	CP.ClassRefs = append(CP.ClassRefs, object.StringPoolStringIndex) // point to string pool entry
+	CP.ClassRefs = append(CP.ClassRefs, types.StringPoolStringIndex) // point to string pool entry
 	f.CP = &CP
 
 	globals.InitGlobals("test")
@@ -365,8 +365,8 @@ func TestAnewrrayKlassField(t *testing.T) {
 	CP.CpIndex[0] = classloader.CpEntry{Type: 0, Slot: 0}
 	CP.CpIndex[1] = classloader.CpEntry{Type: classloader.UTF8, Slot: 0}
 	CP.CpIndex[2] = classloader.CpEntry{Type: classloader.ClassRef, Slot: 0}
-	CP.ClassRefs = append(CP.ClassRefs, object.StringPoolStringIndex) // point to string pool entry
-	CP.Utf8Refs = append(CP.Utf8Refs, "java/lang/String")
+	CP.ClassRefs = append(CP.ClassRefs, types.StringPoolStringIndex) // point to string pool entry
+	CP.Utf8Refs = append(CP.Utf8Refs, types.StringClassName)
 	f.CP = &CP
 
 	globals.InitGlobals("test")
@@ -393,7 +393,7 @@ func TestAnewrrayKlassField(t *testing.T) {
 		t.Errorf("ANEWARRAY: Expecting class to start with '[L', got %s", *klassString)
 	}
 
-	if !strings.HasSuffix(*klassString, "java/lang/String") {
+	if !strings.HasSuffix(*klassString, types.StringClassName) {
 		t.Errorf("ANEWARRAY: Expecting class to end with 'java/lang/String', got %s", *klassString)
 	}
 }

--- a/src/jvm/initializerBlock.go
+++ b/src/jvm/initializerBlock.go
@@ -38,7 +38,7 @@ func runInitializationBlock(k *classloader.Klass, superClasses []string, fs *lis
 
 		superclass := *stringPool.GetStringPointer(k.Data.SuperclassIndex)
 		for {
-			if superclass == "java/lang/Object" {
+			if superclass == types.ObjectClassName {
 				break
 			}
 

--- a/src/jvm/instantiate.go
+++ b/src/jvm/instantiate.go
@@ -42,7 +42,7 @@ func InstantiateClass(classname string, frameStack *list.List) (any, error) {
 	}
 
 	// strings are handled separately
-	if classname == object.StringClassName {
+	if classname == types.StringClassName {
 		return object.NewStringObject(), nil
 	}
 
@@ -71,7 +71,7 @@ func InstantiateClass(classname string, frameStack *list.List) (any, error) {
 		// if the present class is Object, it has no superclass. If the present
 		// class's superclass is Object, we've reached the top of the superclass
 		// hierarchy. Otherwise, keep looping up the superclasses.
-		if classname == "java/lang/Object" || *superclassNamePtr == "java/lang/Object" {
+		if classname == types.ObjectClassName || *superclassNamePtr == types.ObjectClassName {
 			break
 		}
 

--- a/src/jvm/instantiate_test.go
+++ b/src/jvm/instantiate_test.go
@@ -54,14 +54,14 @@ func TestInstantiateString1(t *testing.T) {
 	}
 	classloader.LoadBaseClasses()
 
-	myobj, err := InstantiateClass("java/lang/String", nil)
+	myobj, err := InstantiateClass(types.StringClassName, nil)
 	if err != nil {
 		t.Errorf("Got unexpected error from instantiating string: %s", err.Error())
 	}
 
 	obj := myobj.(*object.Object)
 	klassType := stringPool.GetStringPointer(obj.KlassName)
-	if *klassType != "java/lang/String" {
+	if *klassType != types.StringClassName {
 		t.Errorf("Expected 'java/lang/String', got %s", *klassType)
 	}
 
@@ -221,7 +221,7 @@ func TestLoadClassJavaLangObject(t *testing.T) {
 	}
 	classloader.LoadBaseClasses()
 
-	err = loadThisClass("java/lang/Object")
+	err = loadThisClass(types.ObjectClassName)
 
 	// this should always work. java/lang/Object contains no instance or static fields,
 	// so this is about as simple a class instantiation as possible

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -1933,7 +1933,7 @@ frameInterpreter:
 			fieldType = objField.Ftype
 			if fieldType == types.StringIndex {
 				fieldValue = stringPool.GetStringPointer(objField.Fvalue.(uint32))
-			} else if fieldType == object.StringClassRef {
+			} else if fieldType == types.StringClassRef {
 				// if the field type is String pointer and value is a byte array, convert it to a string
 				valueType, ok := objField.Fvalue.([]byte)
 				if ok {

--- a/src/jvm/runUtils.go
+++ b/src/jvm/runUtils.go
@@ -16,6 +16,7 @@ import (
 	"jacobin/log"
 	"jacobin/object"
 	"jacobin/opcodes"
+	"jacobin/types"
 	"math"
 	"runtime/debug"
 	"unsafe"
@@ -222,7 +223,7 @@ func traceObject(f *frames.Frame, opStr string, obj *object.Object) {
 	if len(obj.FieldTable) > 0 {
 		for fieldName := range obj.FieldTable {
 			fld := obj.FieldTable[fieldName]
-			if klass == "java/lang/String" && fieldName == "value" {
+			if klass == types.StringClassName && fieldName == "value" {
 				str := string(fld.Fvalue.([]byte))
 				traceInfo = fmt.Sprintf("%74s", prefix) + fmt.Sprintf("field: %s %s %v \"%s\"", fieldName, fld.Ftype, fld.Fvalue, str)
 			} else {

--- a/src/jvm/run_A-E_test.go
+++ b/src/jvm/run_A-E_test.go
@@ -13,6 +13,7 @@ import (
 	"jacobin/log"
 	"jacobin/object"
 	"jacobin/opcodes"
+	"jacobin/types"
 	"math"
 	"os"
 	"strings"
@@ -333,7 +334,7 @@ func TestCheckcastOfString(t *testing.T) {
 
 	classloader.Init()
 	// classloader.LoadBaseClasses()
-	classloader.MethAreaInsert("java/lang/String",
+	classloader.MethAreaInsert(types.StringClassName,
 		&(classloader.Klass{
 			Status: 'X', // use a status that's not subsequently tested for.
 			Loader: "bootstrap",
@@ -352,7 +353,7 @@ func TestCheckcastOfString(t *testing.T) {
 	CP.CpIndex = make([]classloader.CpEntry, 10, 10)
 	CP.CpIndex[0] = classloader.CpEntry{Type: 0, Slot: 0}
 	CP.CpIndex[1] = classloader.CpEntry{Type: classloader.ClassRef, Slot: 0}
-	CP.ClassRefs = append(CP.ClassRefs, object.StringPoolStringIndex) // point to string pool entry
+	CP.ClassRefs = append(CP.ClassRefs, types.StringPoolStringIndex) // point to string pool entry
 	f.CP = &CP
 
 	push(&f, s)
@@ -376,7 +377,7 @@ func TestCheckcastOfNil(t *testing.T) {
 
 	classloader.Init()
 	// classloader.LoadBaseClasses()
-	classloader.MethAreaInsert("java/lang/String",
+	classloader.MethAreaInsert(types.StringClassName,
 		&(classloader.Klass{
 			Status: 'X', // use a status that's not subsequently tested for.
 			Loader: "bootstrap",

--- a/src/jvm/run_F-IF_test.go
+++ b/src/jvm/run_F-IF_test.go
@@ -741,7 +741,7 @@ func TestGetStaticBoolean(t *testing.T) {
 
 	CP.Utf8Refs = make([]string, 5, 5)
 	// class = "java/lang/String" in string pool
-	classNameIndex := stringPool.GetStringIndex(&object.StringClassName)
+	classNameIndex := stringPool.GetStringIndex(&types.StringClassName)
 	CP.Utf8Refs[0] = "COMPACT_STRINGS"
 
 	CP.ClassRefs = make([]uint32, 5, 5)

--- a/src/jvm/run_II-LD_test.go
+++ b/src/jvm/run_II-LD_test.go
@@ -15,6 +15,7 @@ import (
 	"jacobin/object"
 	"jacobin/opcodes"
 	"jacobin/stringPool"
+	"jacobin/types"
 	"os"
 	"strings"
 	"testing"
@@ -330,7 +331,7 @@ func TestInstanceofString(t *testing.T) {
 
 	_ = classloader.Init()
 	// classloader.LoadBaseClasses()
-	classloader.MethAreaInsert("java/lang/String",
+	classloader.MethAreaInsert(types.StringClassName,
 		&(classloader.Klass{
 			Status: 'X', // use a status that's not subsequently tested for.
 			Loader: "bootstrap",
@@ -349,7 +350,7 @@ func TestInstanceofString(t *testing.T) {
 	CP.CpIndex = make([]classloader.CpEntry, 10, 10)
 	CP.CpIndex[0] = classloader.CpEntry{Type: 0, Slot: 0}
 	CP.CpIndex[1] = classloader.CpEntry{Type: classloader.ClassRef, Slot: 0}
-	CP.ClassRefs = append(CP.ClassRefs, object.StringPoolStringIndex) // point to string pool entry for java/lang/String
+	CP.ClassRefs = append(CP.ClassRefs, types.StringPoolStringIndex) // point to string pool entry for java/lang/String
 	f.CP = &CP
 
 	push(&f, s)

--- a/src/object/format.go
+++ b/src/object/format.go
@@ -37,7 +37,7 @@ func fmtHelper(field Field, className string, fieldName string) string {
 	flagStatic := strings.HasPrefix(ftype, types.Static)
 
 	// Process Java String class reference.
-	if ftype == StringClassRef {
+	if ftype == types.StringClassRef {
 		// Special handling for String.
 		if flagStatic {
 			return fmt.Sprintf("%v", statics.GetStaticValue(className, fieldName))

--- a/src/object/string.go
+++ b/src/object/string.go
@@ -23,16 +23,11 @@ import (
 	"jacobin/types"
 )
 
-var StringClassName = "java/lang/String"
-var StringClassRef = "Ljava/lang/String;"
-var StringPoolStringIndex = uint32(1) // points to the string pool slice for "java/lang/String"
-var EmptyString = ""
-
 // NewStringObject creates an empty string object (aka Java String)
 func NewStringObject() *Object {
 	s := new(Object)
 	s.Mark.Hash = 0
-	s.KlassName = StringPoolStringIndex // =  java/lang/String
+	s.KlassName = types.StringPoolStringIndex // =  java/lang/String
 	s.FieldTable = make(map[string]Field)
 
 	// ==== now the fields ====
@@ -79,7 +74,7 @@ func StringObjectFromGoString(str string) *Object {
 
 // GoStringFromStringObject: convenience method to extract a Go string from a String object (Java string)
 func GoStringFromStringObject(obj *Object) string {
-	if obj != nil && obj.KlassName == StringPoolStringIndex {
+	if obj != nil && obj.KlassName == types.StringPoolStringIndex {
 		if obj.FieldTable["value"].Fvalue != nil {
 			return string(obj.FieldTable["value"].Fvalue.([]byte))
 		}
@@ -89,7 +84,7 @@ func GoStringFromStringObject(obj *Object) string {
 
 // ByteArrayFromStringObject: convenience method to extract a byte array from a String object (Java string)
 func ByteArrayFromStringObject(obj *Object) []byte {
-	if obj != nil && obj.KlassName == StringPoolStringIndex {
+	if obj != nil && obj.KlassName == types.StringPoolStringIndex {
 		return obj.FieldTable["value"].Fvalue.([]byte)
 	} else {
 		return nil
@@ -105,7 +100,7 @@ func StringObjectFromByteArray(bytes []byte) *Object {
 
 // StringPoolIndexFromStringObject: convenience method to extract a string pool index from a String object
 func StringPoolIndexFromStringObject(obj *Object) uint32 {
-	if obj != nil && obj.KlassName == StringPoolStringIndex {
+	if obj != nil && obj.KlassName == types.StringPoolStringIndex {
 		str := string(obj.FieldTable["value"].Fvalue.([]byte))
 		index := stringPool.GetStringIndex(&str)
 		return index
@@ -154,7 +149,7 @@ func IsStringObject(unknown any) bool {
 		return false
 	}
 
-	if o.KlassName == StringPoolStringIndex {
+	if o.KlassName == types.StringPoolStringIndex {
 		return true
 	}
 	return false

--- a/src/object/string_test.go
+++ b/src/object/string_test.go
@@ -20,7 +20,7 @@ func TestNewStringObject(t *testing.T) {
 
 	str := *NewStringObject()
 	klassStr := *(stringPool.GetStringPointer(str.KlassName))
-	if klassStr != "java/lang/String" {
+	if klassStr != types.StringClassName {
 		t.Errorf("Klass should be java/lang/String, observed: %s", klassStr)
 	}
 
@@ -114,7 +114,7 @@ func TestStringPoolStringOperations(t *testing.T) {
 	}
 
 	strValue := GoStringFromStringPoolIndex(index)
-	if strValue == EmptyString { // if ""
+	if strValue == types.EmptyString { // if ""
 		t.Errorf("strValue from string pool index %d is an empty string", index)
 	}
 
@@ -172,8 +172,8 @@ func TestIsStringObjectWithGoString(t *testing.T) {
 
 func TestGetStringFromStringPoolIndex(t *testing.T) {
 	globals.InitGlobals("test")
-	goStr := GoStringFromStringPoolIndex(StringPoolStringIndex)
-	if goStr != "java/lang/String" {
+	goStr := GoStringFromStringPoolIndex(types.StringPoolStringIndex)
+	if goStr != types.StringClassName {
 		t.Errorf("Got unexpected string value: %s", goStr)
 	}
 
@@ -185,9 +185,9 @@ func TestGetStringFromStringPoolIndex(t *testing.T) {
 
 func TestGetStringObjectFromStringPoolIndex(t *testing.T) {
 	globals.InitGlobals("test")
-	stObj := StringObjectFromPoolIndex(StringPoolStringIndex)
+	stObj := StringObjectFromPoolIndex(types.StringPoolStringIndex)
 	goStr := GoStringFromStringObject(stObj)
-	if goStr != "java/lang/String" {
+	if goStr != types.StringClassName {
 		t.Errorf("Got unexpected string value: %s", goStr)
 	}
 

--- a/src/statics/statics_test.go
+++ b/src/statics/statics_test.go
@@ -92,7 +92,7 @@ func TestStatics1(t *testing.T) {
 	Check statics values.
 	*/
 	tCheckStatic(t, "main", "$assertionsDisabled", int64(1))
-	tCheckStatic(t, "java/lang/String", "COMPACT_STRINGS", true)
+	tCheckStatic(t, types.StringClassName, "COMPACT_STRINGS", true)
 	tCheckStatic(t, "AlphaBetaGamma", "ONE", int64(0x31))
 	tCheckStatic(t, "AlphaBetaGamma", "QM", int64('?'))
 	tCheckStatic(t, "AlphaBetaGamma", "PI", float64(3.14159265))
@@ -196,7 +196,7 @@ func TestStaticsPreload(t *testing.T) {
 	Statics = make(map[string]Static)
 
 	PreloadStatics()
-	s1 := GetStaticValue("java/lang/String", "COMPACT_STRINGS")
+	s1 := GetStaticValue(types.StringClassName, "COMPACT_STRINGS")
 	switch s1.(type) {
 	case int64:
 		if s1.(int64) != types.JavaBoolTrue {

--- a/src/types/constants.go
+++ b/src/types/constants.go
@@ -18,5 +18,12 @@ const ClInitRun byte = 0x03
 const InvalidStringIndex uint32 = 0xffffffff
 
 // ---- default superclass ----
-var JavaLangObjectString string = "java/lang/Object"
-var PtrToJavaLangObjecct = &JavaLangObjectString
+var ObjectClassName = "java/lang/Object"
+var PtrToJavaLangObject = &ObjectClassName
+var ObjectPoolStringIndex = uint32(2) // points to the string pool slice for "java/lang/Object"
+
+// Constants related to "java/lang/String":
+var StringClassName = "java/lang/String"
+var StringClassRef = "Ljava/lang/String;"
+var StringPoolStringIndex = uint32(1) // points to the string pool slice for "java/lang/String"
+var EmptyString = ""


### PR DESCRIPTION
In the first go-around,
- Move some java/lang/String related constants from objects.string.go to types/constants.go, joining the java/lang/Object constants. Now, they are all in one place.
- In several Go source files, change references to literals such as "java/lang/String" and "java/lang/Object" to use constants defined in types.constants.go.

Deferred:
- "value"
- empty string ("") --> types.EmptyString
- others, TBD