### PR TITLE
JACOBIN-500 temporary error msg in INVOKEINTERFACE

### DIFF
--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -2341,11 +2341,11 @@ frameInterpreter:
 			}
 
 			CPentry := CP.CpIndex[CPslot]
-			// if CPentry.Type != classloader.Interface {
 			if CPentry.Type != classloader.Dummy { // intended to force an error, for the nonce
 				glob.ErrorGoStack = string(debug.Stack())
 				errMsg := fmt.Sprintf("INVOKEINTERFACE: CP entry type (%d) did not point to an interface method type (%d)",
 					CPentry.Type, classloader.Interface)
+				errMsg = "INVOKEINTERFACE: WIP, forcing an error, for the nonce" /* TODO Remove this temporary error message */
 				err := exceptions.ThrowEx(excNames.WrongMethodTypeException, errMsg, f)
 				if err == exceptions.NotCaught {
 					goto frameInterpreter


### PR DESCRIPTION
Misleading error message in INVOKEINTERFACE:
```INVOKEINTERFACE: CP entry type (%d) did not point to an interface method type (%d)```

Overridden in a subsequent assignment statement to:
```INVOKEINTERFACE: WIP, forcing an error, for the nonce /* TODO Remove this temporary error message */```

When INVOKEINTERFACE is ready for testing, we should yank this message along with the other indicated changes.