### PR TITLE
JACOBIN-495 Reinstated frame push/pop debug (currently, turned off)

### DIFF
--- a/src/frames/frames.go
+++ b/src/frames/frames.go
@@ -18,10 +18,16 @@ type StackValue interface {
 	int64 | float64 | unsafe.Pointer
 }
 
-//var debugging bool = true
+var debugging bool = false
 
 type Number interface {
 	int64 | float64
+}
+
+func ftag(f *Frame) string {
+	pp := fmt.Sprintf("%p\n", f)
+	jj := len(pp) - 5 // show last 4 hex digits
+	return pp[jj:]
 }
 
 // Frame is the fundamental execution environment for a single function/method call.
@@ -75,9 +81,9 @@ func CreateFrame(opStackSize int) *Frame {
 
 // PushFrame pushes a frame. This simply adds a frame to the head of the list.
 func PushFrame(fs *list.List, f *Frame) error {
-	/*if debugging {
-		fmt.Printf("DEBUG PushFrame ClName=%s, MethName=%s TOS=%d, PC=%d\n", f.ClName, f.MethName, f.TOS, f.PC)
-	}*/
+	if debugging {
+		fmt.Printf("DEBUG PushFrame %s ClName=%s, MethName=%s TOS=%d, PC=%d\n", ftag(f), f.ClName, f.MethName, f.TOS, f.PC)
+	}
 	fs.PushFront(f)
 	// TODO: move this to instrumentation system
 	if log.Level == log.FINEST {
@@ -97,10 +103,10 @@ func PopFrame(fs *list.List) error {
 		return fmt.Errorf("invalid PopFrame of empty JVM frame stack")
 	}
 
-	/*if debugging {
+	if debugging {
 		f := PeekFrame(fs, 0)
-		fmt.Printf("DEBUG PopFrame ClName=%s, MethName=%s TOS=%d, PC=%d\n", f.ClName, f.MethName, f.TOS, f.PC)
-	}*/
+		fmt.Printf("DEBUG PopFrame %s ClName=%s, MethName=%s TOS=%d, PC=%d\n", ftag(f), f.ClName, f.MethName, f.TOS, f.PC)
+	}
 
 	fs.Remove(fs.Front())
 	return nil

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -2936,8 +2936,10 @@ frameInterpreter:
 				errMsg := fmt.Sprintf("Method: %-40s PC: %03d", methName, location)
 				_ = log.Log(errMsg, log.SEVERE)
 
-				fs.Remove(fs.Front()) // having reported on this frame's error, pop the frame off
-				// return errors.New(rootCause)
+				err := frames.PopFrame(fs) // having reported on this frame's error, pop the frame off
+				if err != nil {
+					_ = log.Log(err.Error(), log.SEVERE)
+				}
 				return errors.New(string(debug.Stack()))
 
 			case 0x02: // stack underflow
@@ -2950,8 +2952,10 @@ frameInterpreter:
 				exceptions.ShowPanicCause(rootCause)
 				errMsg := fmt.Sprintf("Method: %-40s PC: %03d", methName, location)
 				_ = log.Log(errMsg, log.SEVERE)
-
-				fs.Remove(fs.Front()) // having reported on this frame's error, pop the frame off
+				err := frames.PopFrame(fs) // having reported on this frame's error, pop the frame off
+				if err != nil {
+					_ = log.Log(err.Error(), log.SEVERE)
+				}
 				return errors.New(string(debug.Stack()))
 
 			default:


### PR DESCRIPTION
I was trying figure out why stack underflow was occuring. I suspected that it might be due to ThrowEx appending the wrong ```frame.meth``` in the case that the exception occured in a called local function. Now, I don't think so. Are we getting confused somehow with the runGmethod-runFrame-runGframe stuff? I cannot see it but maybe I overlooked something.

The following works as expected, correctly reporting a symptom of ByteArrayInputStream not yet supported:

```
import java.io.ByteArrayInputStream;
import java.io.InputStreamReader;
 
public class main {
 
    public static void main(String args[]) { 
        byte[] byte_array = { 'w' };
        ByteArrayInputStream bais = new ByteArrayInputStream(byte_array);
        InputStreamReader streamreader = new InputStreamReader(bais);
        String str = streamreader.getEncoding();
        System.out.println(str);
    }
    
}
```

The following has stack underflow during/after the exception processing:

```
import java.io.ByteArrayInputStream;
import java.io.InputStreamReader;
 
public class main {
 
    public static String getCharacterEncoding() {
        byte[] byte_array = { 'w' };
        ByteArrayInputStream bais = new ByteArrayInputStream(byte_array);
        InputStreamReader streamreader = new InputStreamReader(bais);
        String str = streamreader.getEncoding();
        return str;
    }
 
    public static void main(String args[]) { 
        String str = getCharacterEncoding();
    }
    
}
```