### PR TITLE
JACOBIN-511 Three AWT functions are blocking jacotest case emission-line-spectra

### DIFF
--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -67,7 +67,7 @@ func getGErrBlk(exceptionType int, errMsg string) *GErrBlk {
 // they make available.
 func MTableLoadGFunctions(MTable *classloader.MT) {
 
-	// java/lang/*
+	// java/awt/*
 	Load_Awt_Graphics_Environment()
 
 	// java/io/*

--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -67,9 +67,12 @@ func getGErrBlk(exceptionType int, errMsg string) *GErrBlk {
 // they make available.
 func MTableLoadGFunctions(MTable *classloader.MT) {
 
-	Load_Io_Console() // load the java.io.Console golang functions
+	// java/lang/*
+	Load_Awt_Graphics_Environment()
 
+	// java/io/*
 	Load_Io_BufferedReader()
+	Load_Io_Console()
 	Load_Io_File()
 	Load_Io_FileInputStream()
 	Load_Io_FileOutputStream()
@@ -80,27 +83,30 @@ func MTableLoadGFunctions(MTable *classloader.MT) {
 	Load_Io_PrintStream()
 	Load_Io_RandomAccessFile()
 
+	// java/lang/*
 	Load_Lang_Boolean()
 	Load_Lang_Byte()
 	Load_Lang_Character()
-	Load_Lang_Class() // load the java.lang.Class golang functions
+	Load_Lang_Class()
 	Load_Lang_Double()
 	Load_Lang_Float()
 	Load_Lang_Integer()
 	Load_Lang_Long()
-	Load_Lang_Math()   // load the java.lang.Math & StrictMath golang functions
-	Load_Lang_Object() // load the java.lang.Class golang functions
+	Load_Lang_Math()
+	Load_Lang_Object()
 	Load_Lang_Short()
-	Load_Lang_String()            // load the java.lang.String golang functions
-	Load_Lang_StringBuilder()     // load the java.lang.StringBuilder golang functions
-	Load_Lang_System()            // load the java.lang.System golang functions
-	Load_Lang_StackTraceELement() //  java.lang.StackTraceElement golang functions
-	Load_Lang_Thread()            // load the java.lang.Thread golang functions
-	Load_Lang_Throwable()         // load the java.lang.Throwable golang functions (errors & exceptions)
-	Load_Lang_UTF16()             // load the java.lang.UTF16 golang functions
+	Load_Lang_String()
+	Load_Lang_StringBuilder()
+	Load_Lang_System()
+	Load_Lang_StackTraceELement()
+	Load_Lang_Thread()
+	Load_Lang_Throwable()
+	Load_Lang_UTF16()
 
-	Load_Nio_Charset_Charset() // Zero Charset support
+	// java/nio/*
+	Load_Nio_Charset_Charset()
 
+	// java/util/*
 	Load_Util_Concurrent_Atomic_AtomicInteger()
 	Load_Util_Concurrent_Atomic_Atomic_Long()
 	Load_Util_HashMap()
@@ -108,11 +114,15 @@ func MTableLoadGFunctions(MTable *classloader.MT) {
 	Load_Util_Locale()
 	Load_Util_Random()
 
+	// jdk/internal/misc/*
 	Load_Jdk_Internal_Misc_Unsafe()
 	Load_Jdk_Internal_Misc_ScopedMemoryAccess()
 
-	Load_Nil_Clinit() // Load <clinit> functions that invoke justReturn()
-	Load_Traps()      // Load traps that lead to unconditional error returns
+	// Load functions that invoke justReturn() and do nothing else.
+	Load_Just_Return()
+
+	// Load traps that lead to unconditional error returns.
+	Load_Traps()
 
 	/*
 		With the accumulated MethodSignatures maps, load MTable.
@@ -154,11 +164,6 @@ func loadlib(tbl *classloader.MT, libMeths map[string]GMeth) {
 	if !ok {
 		exceptions.ThrowExNil(excNames.InternalException, "loadlib: at least one key was invalid")
 	}
-}
-
-// do-nothing Go function shared by several source files
-func justReturn([]interface{}) interface{} {
-	return nil
 }
 
 // Populate an object for a primitive type (Byte, Character, Double, Float, Integer, Long, Short, String).

--- a/src/gfunction/javaAwtGraphicsEnvironment.go
+++ b/src/gfunction/javaAwtGraphicsEnvironment.go
@@ -1,0 +1,39 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2023 by  the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package gfunction
+
+import (
+	"jacobin/globals"
+)
+
+func Load_Awt_Graphics_Environment() {
+
+	MethodSignatures["java/awt/GraphicsEnvironment.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/awt/GraphicsEnvironment.isHeadless()Z"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  awtgeIsHeadless,
+		}
+
+	MethodSignatures["java/awt/GraphicsEnvironment.isHeadlessInstance()Z"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  awtgeIsHeadless,
+		}
+
+}
+
+// "java/awt/GraphicsEnvironment.isHeadless()Z"
+func awtgeIsHeadless(params []interface{}) interface{} {
+	glob := globals.GetGlobalRef()
+	return glob.Headless
+}

--- a/src/gfunction/justReturn.go
+++ b/src/gfunction/justReturn.go
@@ -6,7 +6,30 @@
 
 package gfunction
 
-func Load_Nil_Clinit() {
+// do-nothing Go function shared by several source files
+func justReturn([]interface{}) interface{} {
+	return nil
+}
+
+func Load_Just_Return() {
+
+	MethodSignatures["java/awt/Color.initIDs()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/awt/Toolkit.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/awt/Toolkit.loadLibraries()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
 
 	MethodSignatures["java/math/BigDecimal.<clinit>()V"] =
 		GMeth{

--- a/src/globals/globals.go
+++ b/src/globals/globals.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 )
 
+var StringEnvVarHeadless = "java.awt.headless"
+
 // Globals contains variables that need to be globally accessible,
 // such as VM and program args, etc.
 // Note: globals cannot depend on exec package to avoid circularity.
@@ -88,6 +90,7 @@ type Globals struct {
 
 	// ---- misc properties
 	FileEncoding string // what file encoding are we using?
+	Headless     bool   // Headless?
 
 	// Get around the golang circular dependency. To be set up in jvmStart.go
 	// Enables gfunctions to call these functions through a global variable.
@@ -156,7 +159,17 @@ func InitGlobals(progName string) Globals {
 		global.FileEncoding = "UTF-8"
 	}
 
+	// Set up headlass boolean.
+	strHeadless := os.Getenv(StringEnvVarHeadless)
+	global.Headless = false
+	if strHeadless != "" {
+		if strHeadless == "true" {
+			global.Headless = true
+		}
+	}
+
 	global.Threads = make(map[int]interface{})
+
 	return global
 }
 


### PR DESCRIPTION
Three of the AWT functions are preventing jacotest case emission-line-spectra from showing a true result.

Source files modified:
* gfunction/gfunction.go -- load javaAwtGraphicsEnvironment entries
* gfunction/nilClinit.go --renamed--> gfunction/justReturn.go
* gfunction/justReturn.go -- added more justReturns.
* globals/globals.go  -------------------------------------------- isHeadless(), isHeadlessInstance()

New: gfunction/javaAwtGraphicsEnvironment.go   ------- support isHeadless(), isHeadlessInstance()