### PR TITLE
JACOBIN-514 G functions should return the standard G error block

### DIFF
--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -8,7 +8,6 @@ package gfunction
 
 import (
 	"jacobin/excNames"
-	"jacobin/exceptions"
 )
 
 func Load_Traps() {
@@ -246,97 +245,83 @@ func Load_Traps() {
 // Trap for Charset references
 func trapCharset([]interface{}) interface{} {
 	errMsg := "Class java/nio/charset/Charset is not yet supported"
-	exceptions.ThrowExNil(excNames.UnsupportedOperationException, errMsg)
-	return nil
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
 // Trap for deprecated functions
 func trapDeprecated([]interface{}) interface{} {
 	errMsg := "The class or function requested is deprecated and is not supported by jacobin"
-	exceptions.ThrowExNil(excNames.UnsupportedOperationException, errMsg)
-	return nil
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
 // Trap for FileChannel references
 func trapFileChannel([]interface{}) interface{} {
 	errMsg := "File Channels are not yet supported"
-	exceptions.ThrowExNil(excNames.UnsupportedOperationException, errMsg)
-	return nil
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
 // Trap for FileDescriptor references
 func trapFileDescriptor([]interface{}) interface{} {
 	errMsg := "Class java/io/FileDescriptor is not yet supported"
-	exceptions.ThrowExNil(excNames.UnsupportedOperationException, errMsg)
-	return nil
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
 // Trap for FileSystem references
 func trapFileSystem([]interface{}) interface{} {
 	errMsg := "Class java.io.FileSystem is not yet supported"
-	exceptions.ThrowExNil(excNames.UnsupportedOperationException, errMsg)
-	return nil
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
 // "java/io/DefaultFileSystem.getFileSystem()Ljava/io/FileSystem;"
 func trapGetDefaultFileSystem([]interface{}) interface{} {
 	errMsg := "DefaultFileSystem.getFileSystem() is not yet supported"
-	exceptions.ThrowExNil(excNames.UnsupportedOperationException, errMsg)
-	return nil
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
 // Trap for unsupported readers
 func trapReader([]interface{}) interface{} {
 	errMsg := "The requested reader is not yet supported"
-	exceptions.ThrowExNil(excNames.UnsupportedOperationException, errMsg)
-	return nil
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
 // Trap for unsupported writers
 func trapWriter([]interface{}) interface{} {
 	errMsg := "The requested writer is not yet supported"
-	exceptions.ThrowExNil(excNames.UnsupportedOperationException, errMsg)
-	return nil
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
 // Trap for StringBuilder
 func trapStringBuilder([]interface{}) interface{} {
 	errMsg := "Class StringBuilder is not yet supported"
-	exceptions.ThrowExNil(excNames.UnsupportedOperationException, errMsg)
-	return nil
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
 // Trap for StringBuffer
 func trapStringBuffer([]interface{}) interface{} {
 	errMsg := "Class StringBuffer is not yet supported"
-	exceptions.ThrowExNil(excNames.UnsupportedOperationException, errMsg)
-	return nil
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
 // Trap for FilterInputStream
 func trapFilterInputStream([]interface{}) interface{} {
 	errMsg := "Class FilterInputStream is not yet supported"
-	exceptions.ThrowExNil(excNames.UnsupportedOperationException, errMsg)
-	return nil
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
 // Trap for FilterOutputStream
 func trapFilterOutputStream([]interface{}) interface{} {
 	errMsg := "Class FilterOutputStream is not yet supported"
-	exceptions.ThrowExNil(excNames.UnsupportedOperationException, errMsg)
-	return nil
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
 // Trap for Random.next()
 func trapRandomNext([]interface{}) interface{} {
 	errMsg := "Protected method Random.next should never be reached unless done by reflection"
-	exceptions.ThrowExNil(excNames.UnsupportedOperationException, errMsg)
-	return nil
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
 // Trap for Random.next()
 func trapSharedSecrets([]interface{}) interface{} {
 	errMsg := "Class jdk/internal/access/SharedSecrets is not supported"
-	exceptions.ThrowExNil(excNames.UnsupportedOperationException, errMsg)
-	return nil
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }

--- a/src/gfunction/javaIoBufferedReader.go
+++ b/src/gfunction/javaIoBufferedReader.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"jacobin/excNames"
-	"jacobin/exceptions"
 	"jacobin/object"
 	"jacobin/types"
 	"os"
@@ -119,20 +118,17 @@ func bufferedReaderInit(params []interface{}) interface{} {
 
 func bufferedReaderInitSz(params []interface{}) interface{} {
 	errMsg := "Instantiating BufferedReader with a size is not yet supported by jacobin"
-	exceptions.ThrowExNil(excNames.UnsupportedOperationException, errMsg)
-	return nil
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
 func bufferedReaderLines(params []interface{}) interface{} {
 	errMsg := "Instantiating BufferedReader with a size is not yet supported by jacobin"
-	exceptions.ThrowExNil(excNames.UnsupportedOperationException, errMsg)
-	return nil
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
 func bufferedReaderMarkAndReset(params []interface{}) interface{} {
 	errMsg := "BufferedReader mark() & reset() are not yet supported by jacobin"
-	exceptions.ThrowExNil(excNames.UnsupportedOperationException, errMsg)
-	return nil
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
 func bufferedReaderMarkSupported(params []interface{}) interface{} {

--- a/src/gfunction/javaIoPrintStream.go
+++ b/src/gfunction/javaIoPrintStream.go
@@ -9,7 +9,6 @@ package gfunction
 import (
 	"fmt"
 	"jacobin/excNames"
-	"jacobin/exceptions"
 	"jacobin/object"
 	"jacobin/types"
 	"math"
@@ -160,7 +159,7 @@ func PrintlnString(params []interface{}) interface{} {
 	param1, ok := params[1].(*object.Object)
 	if !ok {
 		errMsg := fmt.Sprintf("PrintlnString: expected params[1] of type *object.Object but observed type %T\n", params[1])
-		exceptions.ThrowExNil(excNames.IllegalArgumentException, errMsg)
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
 	// Handle null strings as well as []byte.
@@ -232,7 +231,7 @@ func PrintlnDoubleFloat(params []interface{}) interface{} {
 func PrintlnObject(params []interface{}) interface{} {
 	if params[1] == nil {
 		errMsg := fmt.Sprintf("PrintlnObject: expected params[1] of type *object.Object but observed type %T\n", params[1])
-		exceptions.ThrowExNil(excNames.IllegalArgumentException, errMsg)
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	objPtr := params[1].(*object.Object)
 	fld := objPtr.FieldTable["value"]
@@ -310,7 +309,7 @@ func PrintString(params []interface{}) interface{} {
 		str = object.GoStringFromStringObject(params[1].(*object.Object))
 	default:
 		errMsg := fmt.Sprintf("PrintString: expected params[1] of type *object.Object but observed type %T\n", params[1])
-		exceptions.ThrowExNil(excNames.IllegalArgumentException, errMsg)
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
 	fmt.Fprint(params[0].(*os.File), str)
@@ -322,7 +321,7 @@ func PrintString(params []interface{}) interface{} {
 func PrintObject(params []interface{}) interface{} {
 	if params[1] == nil {
 		errMsg := fmt.Sprintf("PrintObject: expected params[1] of type *object.Object but observed type %T\n", params[1])
-		exceptions.ThrowExNil(excNames.IllegalArgumentException, errMsg)
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	objPtr := params[1].(*object.Object)
 	fld := objPtr.FieldTable["value"]

--- a/src/gfunction/javaLangMath.go
+++ b/src/gfunction/javaLangMath.go
@@ -9,7 +9,6 @@ package gfunction
 import (
 	"jacobin/classloader"
 	"jacobin/excNames"
-	"jacobin/exceptions"
 	"jacobin/log"
 	"math"
 	"math/big"
@@ -222,7 +221,7 @@ func mathClinit([]interface{}) interface{} {
 	if klass == nil {
 		errMsg := "mathClinit, expected java/lang/Math to be in the MethodArea, but it was not"
 		_ = log.Log(errMsg, log.SEVERE)
-		exceptions.ThrowEx(excNames.VirtualMachineError, errMsg, nil)
+		return getGErrBlk(excNames.VirtualMachineError, errMsg)
 	}
 	return nil
 }

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"jacobin/classloader"
 	"jacobin/excNames"
-	"jacobin/exceptions"
 	"jacobin/object"
 	"jacobin/types"
 	"strconv"
@@ -548,7 +547,7 @@ func StringFormatter(params []interface{}) interface{} {
 				valuesOut = append(valuesOut, fld.Fvalue.(int64))
 			default:
 				errMsg := fmt.Sprintf("StringFormatter: Invalid parameter %d type %s", ii+1, fld.Ftype)
-				exceptions.ThrowExNil(excNames.IllegalArgumentException, errMsg)
+				return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 			}
 		}
 	}

--- a/src/gfunction/javaLangSystem.go
+++ b/src/gfunction/javaLangSystem.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"jacobin/classloader"
 	"jacobin/excNames"
-	"jacobin/exceptions"
 	"jacobin/globals"
 	"jacobin/log"
 	"jacobin/object"
@@ -124,7 +123,7 @@ func clinit([]interface{}) interface{} {
 	if klass == nil {
 		errMsg := "System <clinit>: Expected java/lang/System to be in the MethodArea, but it was not"
 		_ = log.Log(errMsg, log.SEVERE)
-		exceptions.ThrowEx(excNames.ClassNotLoadedException, errMsg, nil)
+		return getGErrBlk(excNames.ClassNotLoadedException, errMsg)
 	}
 	if klass.Data.ClInit != types.ClInitRun {
 		_ = statics.AddStatic("java/lang/System.in", statics.Static{Type: "GS", Value: os.Stdin})


### PR DESCRIPTION
Updated source files:
* gfunction/Traps.go
* gfunction/javaIoBufferedReader.go
* gfunction/javaIoPrintStream.go
* gfunction/javaLangMath.go
* gfunction/javaLangString.go
* gfunction/javaLangSystem.go

Note that 
* gfunction/gfunction.go calls ThrowExNil if an error is encountered during MethodSignature loading.
* gfunction/javaLangThrowable_test.go calls to ThrowEx as part of testing logic.