### PR TITLE
JACOBIN-495 Correct split character on error message, add gfunctions

### DIFF
--- a/src/gfunction/javaLangLong.go
+++ b/src/gfunction/javaLangLong.go
@@ -7,6 +7,7 @@
 package gfunction
 
 import (
+	"fmt"
 	"jacobin/object"
 	"jacobin/types"
 )
@@ -23,6 +24,12 @@ func Load_Lang_Long() {
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  longDoubleValue,
+		}
+
+	MethodSignatures["java/lang/Long.toHexString(J)Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  longToHexString,
 		}
 
 	MethodSignatures["java/lang/Long.valueOf(J)Ljava/lang/Long;"] =
@@ -45,4 +52,13 @@ func longDoubleValue(params []interface{}) interface{} {
 func longValueOf(params []interface{}) interface{} {
 	int64Value := params[0].(int64)
 	return populator("java/lang/Long", types.Long, int64Value)
+}
+
+// "java/lang/Long.toHexString(J)Ljava/lang/String;"
+func longToHexString(params []interface{}) interface{} {
+	int64Value := params[0].(int64)
+	uint64Value := uint64(int64Value)
+	str := fmt.Sprintf("%016x", uint64Value)
+	obj := object.StringObjectFromGoString(str)
+	return obj
 }

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -213,6 +213,13 @@ func Load_Lang_String() {
 		}
 
 	// Return the length of a String.
+	MethodSignatures["java/lang/String.isLatin1()Z"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  stringIsLatin1,
+		}
+
+	// Return the length of a String.
 	MethodSignatures["java/lang/String.length()I"] =
 		GMeth{
 			ParamSlots: 0,
@@ -557,6 +564,12 @@ func StringFormatter(params []interface{}) interface{} {
 
 	// Return a pointer to an object.Object that wraps the string byte array.
 	return object.StringObjectFromGoString(str)
+}
+
+// "java/lang/String.isLatin1()Z"
+func stringIsLatin1(params []interface{}) interface{} {
+	// TODO: Someday, the answer might be false.
+	return int64(1) // true
 }
 
 // "java/lang/String.length()I"

--- a/src/gfunction/justReturn.go
+++ b/src/gfunction/justReturn.go
@@ -31,6 +31,12 @@ func Load_Just_Return() {
 			GFunction:  justReturn,
 		}
 
+	MethodSignatures["java/lang/CharacterDataLatin1.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
 	MethodSignatures["java/math/BigDecimal.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -181,7 +181,7 @@ frameInterpreter:
 			case *gfunction.GErrBlk:
 				var funcName, errorDetails string
 				errBlk := *err.(*gfunction.GErrBlk)
-				parts := strings.SplitN(errBlk.ErrMsg, ",", 2)
+				parts := strings.SplitN(errBlk.ErrMsg, ":", 2)
 				if len(parts) > 0 {
 					funcName = parts[0]
 					errorDetails = parts[1]

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -182,9 +182,12 @@ frameInterpreter:
 				var funcName, errorDetails string
 				errBlk := *err.(*gfunction.GErrBlk)
 				parts := strings.SplitN(errBlk.ErrMsg, ":", 2)
-				if len(parts) > 0 {
+				if len(parts) == 2 {
 					funcName = parts[0]
 					errorDetails = parts[1]
+				} else {
+					funcName = "{MISSINGCOLON}"
+					errorDetails = errBlk.ErrMsg
 				}
 
 				var threadName string


### PR DESCRIPTION
* run.go line 184 - The separator is a colon. Also, added a check that a colon was found.
* String.isLatin1 - always return true.
* Long.toHexString - needed in one jacotest case.