### PR TITLE
JACOBIN-518 fix caught G exceptions in run.go runFrame

### DIFF
--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -12,6 +12,18 @@ import (
 
 func Load_Traps() {
 
+	MethodSignatures["java/io/BufferedInputStream.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapBufferedInputStream,
+		}
+
+	MethodSignatures["java/io/BufferedOutputStream.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapBufferedOutputStream,
+		}
+
 	MethodSignatures["java/io/BufferedWriter.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
@@ -228,6 +240,30 @@ func Load_Traps() {
 			GFunction:  trapDeprecated,
 		}
 
+	MethodSignatures["java/security/SecureRandom.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapSecureRandom,
+		}
+
+	MethodSignatures["java/security/SecureRandom.<init>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapSecureRandom,
+		}
+
+	MethodSignatures["java/security/SecureRandom.<init>([B)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapSecureRandom,
+		}
+
+	MethodSignatures["java/security/SecureRandom.<init>(Ljava.security.SecureRandomSpi;Ljava.security.Provider;)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapSecureRandom,
+		}
+
 	MethodSignatures["java/util/Random.next(I)V"] =
 		GMeth{
 			ParamSlots: 1,
@@ -240,6 +276,18 @@ func Load_Traps() {
 			GFunction:  trapSharedSecrets,
 		}
 
+}
+
+// Trap for BufferedInputStream references
+func trapBufferedInputStream([]interface{}) interface{} {
+	errMsg := "trapBufferedInputStream: Class java/io/BufferedInputStream is not yet supported"
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
+}
+
+// Trap for BufferedOutputStream references
+func trapBufferedOutputStream([]interface{}) interface{} {
+	errMsg := "trapBufferedOutputStream: Class java/io/BufferedOutputStream is not yet supported"
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
 // Trap for Charset references
@@ -323,5 +371,11 @@ func trapRandomNext([]interface{}) interface{} {
 // Trap for Random.next()
 func trapSharedSecrets([]interface{}) interface{} {
 	errMsg := "trapSharedSecrets: Class jdk/internal/access/SharedSecrets is not yet supported"
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
+}
+
+// Trap for SecureRandom
+func trapSecureRandom([]interface{}) interface{} {
+	errMsg := "trapSecureRandom: Class java.security.SecureRandom is not yet supported"
 	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }

--- a/src/gfunction/javaLangInteger.go
+++ b/src/gfunction/javaLangInteger.go
@@ -188,7 +188,7 @@ func integerParseInt(params []interface{}) interface{} {
 	rdx := params[1].(int64)
 	if rdx < MinRadix || rdx > MaxRadix {
 		errMsg := fmt.Sprintf("integerParseInt: invalid radix value (%d)", rdx)
-		return getGErrBlk(excNames.NumberFormatException, errMsg)
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
 	// Compute output.
@@ -263,7 +263,7 @@ func integerToUnsignedStringRadix(params []interface{}) interface{} {
 	rdx := params[1].(int64)
 	if rdx < MinRadix || rdx > MaxRadix {
 		errMsg := fmt.Sprintf("integerToUnsignedStringRadix: invalid radix value (%d)", rdx)
-		return getGErrBlk(excNames.NumberFormatException, errMsg)
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
 	str := strconv.FormatInt(argInt64, int(rdx))

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -200,19 +200,19 @@ frameInterpreter:
 				errMsg = errMsg + errorDetails
 				status := exceptions.ThrowEx(errBlk.ExceptionType, errorDetails, f)
 				if status == exceptions.Caught {
-					// runGmethod needs a non-nil return unconditionally when an exception is caught.
+					// Unit test or not, runGmethod needs a non-nil return when an exception is caught.
 					return errors.New(errMsg)
 				}
-				// Uncaught exception for testing only
+				// Unit testing only: Arrive here for uncaught exception.
 
 			case error:
 				errMsg := (err.(error)).Error()
 				status := exceptions.ThrowEx(excNames.NativeMethodException, errMsg, f)
 				if status == exceptions.Caught {
-					// runGmethod needs a non-nil return unconditionally when an exception is caught.
+					// Unit test or not, runGmethod needs a non-nil return when an exception is caught.
 					return err.(error)
 				}
-				// Uncaught exception for testing only
+				// Unit testing only: Arrive here for uncaught exception.
 			}
 		}
 

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -199,16 +199,20 @@ frameInterpreter:
 					threadName, funcName)
 				errMsg = errMsg + errorDetails
 				status := exceptions.ThrowEx(errBlk.ExceptionType, errorDetails, f)
-				if status != exceptions.Caught {
-					return errors.New(errMsg) // applies only if in test
+				if status == exceptions.Caught {
+					// runGmethod needs a non-nil return unconditionally when an exception is caught.
+					return errors.New(errMsg)
 				}
+				// Uncaught exception for testing only
 
 			case error:
 				errMsg := (err.(error)).Error()
 				status := exceptions.ThrowEx(excNames.NativeMethodException, errMsg, f)
-				if status != exceptions.Caught {
-					return err.(error) // applies only if in test
+				if status == exceptions.Caught {
+					// runGmethod needs a non-nil return unconditionally when an exception is caught.
+					return err.(error)
 				}
+				// Uncaught exception for testing only
 			}
 		}
 

--- a/src/jvm/runUtils.go
+++ b/src/jvm/runUtils.go
@@ -94,7 +94,6 @@ func convertInterfaceToUint64(val interface{}) uint64 {
 // Appears primarily in the runFrame{} IF* bytecodes.
 func convertIntegralValueToInt64(arg interface{}) int64 {
 	var value int64
-	// fmt.Printf("convertIntegralValueToInt64 *TRAP*: argument type: %T\n", arg)
 	switch arg.(type) {
 	case int64:
 		value = arg.(int64)
@@ -111,7 +110,7 @@ func convertIntegralValueToInt64(arg interface{}) int64 {
 			value = int64(0)
 		}
 	default:
-		errMsg := fmt.Sprintf("convertIntegralValueToInt64 *TRAP*: Invalid argument type: %T", arg)
+		errMsg := fmt.Sprintf("convertIntegralValueToInt64: Invalid argument type: %T", arg)
 		exceptions.ThrowEx(excNames.InvalidTypeException, errMsg, nil)
 	}
 


### PR DESCRIPTION
Modified: run.go - Fix error handling in runFrame after calling runGframe.