### PR TITLE
JACOBIN-524 and small error text fixes

### DIFF
--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -87,7 +87,7 @@ func Load_Traps() {
 	MethodSignatures["java/io/FilterInputStream.<init>(Ljava/io/InputStream;)V"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  trapClass,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/io/FilterOutputStream.<clinit>()V"] =
@@ -99,7 +99,7 @@ func Load_Traps() {
 	MethodSignatures["java/io/FilterOutputStream.<init>(Ljava/io/OutputStream;)V"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  trapClass,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/io/FilterWriter.<clinit>()V"] =
@@ -159,25 +159,25 @@ func Load_Traps() {
 	MethodSignatures["java/lang/StringBuffer.<init>()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  trapClass,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.<init>(I)V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  trapClass,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.<init>(Ljava/lang/CharSequence;)V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  trapClass,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.<init>(Ljava/lang/String;)V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  trapClass,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/lang/StringBuilder.<clinit>()V"] =
@@ -195,19 +195,19 @@ func Load_Traps() {
 	MethodSignatures["java/lang/StringBuilder.<init>(I)V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  trapClass,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/lang/StringBuilder.<init>(Ljava/lang/CharSequence;)V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  trapClass,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/lang/StringBuilder.<init>(Ljava/lang/String;)V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  trapClass,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/nio/charset/Charset.<clinit>()V"] =
@@ -219,13 +219,13 @@ func Load_Traps() {
 	MethodSignatures["java/nio/channels/AsynchronousFileChannel.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  trapFileChannel,
+			GFunction:  trapClass,
 		}
 
 	MethodSignatures["java/nio/channels/FileChannel.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  trapFileChannel,
+			GFunction:  trapClass,
 		}
 
 	MethodSignatures["java/security/AccessController.<clinit>()V"] =
@@ -249,19 +249,19 @@ func Load_Traps() {
 	MethodSignatures["java/security/SecureRandom.<init>()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  trapClass,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/security/SecureRandom.<init>([B)V"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  trapClass,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/security/SecureRandom.<init>(Ljava.security.SecureRandomSpi;Ljava.security.Provider;)V"] =
 		GMeth{
 			ParamSlots: 2,
-			GFunction:  trapClass,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/util/Random.next(I)V"] =
@@ -278,38 +278,20 @@ func Load_Traps() {
 
 }
 
-// Generic trap for deprecated classes and functions
-func trapDeprecated([]interface{}) interface{} {
-	errMsg := "The requested class or function is deprecated and, therefore, not supported"
-	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
-}
-
 // Generic trap for classes
 func trapClass([]interface{}) interface{} {
 	errMsg := "The requested class is not yet supported"
 	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
+// Generic trap for deprecated classes and functions
+func trapDeprecated([]interface{}) interface{} {
+	errMsg := "The requested class or function is deprecated and, therefore, not supported"
+	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
+}
+
 // Generic trap for functions
 func trapFunction([]interface{}) interface{} {
 	errMsg := "The requested function is not yet supported"
-	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
-}
-
-// Trap for Charset references
-func trapCharset([]interface{}) interface{} {
-	errMsg := "Class java.nio.charset/Charset is not yet supported"
-	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
-}
-
-// Trap for FileDescriptor references
-func trapFileDescriptor([]interface{}) interface{} {
-	errMsg := "Class java.io.FileDescriptor is not yet supported"
-	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
-}
-
-// Trap for FileChannel references
-func trapFileChannel([]interface{}) interface{} {
-	errMsg := "Class java.nio.channels.FileChannel is not yet supported"
 	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }

--- a/src/gfunction/javaIoBufferedReader.go
+++ b/src/gfunction/javaIoBufferedReader.go
@@ -32,7 +32,7 @@ func Load_Io_BufferedReader() {
 	MethodSignatures["java/io/BufferedReader.<init>(Ljava/io/Reader;I)V"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  bufferedReaderInitSz,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/io/BufferedReader.close()V"] =
@@ -44,13 +44,13 @@ func Load_Io_BufferedReader() {
 	MethodSignatures["java/io/BufferedReader.lines()Ljava/util/stream/Stream;"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  bufferedReaderLines,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/io/BufferedReader.mark(I)V"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  bufferedReaderMarkAndReset,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/io/BufferedReader.markSupported()Z"] =
@@ -86,7 +86,7 @@ func Load_Io_BufferedReader() {
 	MethodSignatures["java/io/BufferedReader.reset()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  bufferedReaderMarkAndReset,
+			GFunction:  trapFunction,
 		}
 
 }
@@ -95,13 +95,13 @@ func Load_Io_BufferedReader() {
 func bufferedReaderInit(params []interface{}) interface{} {
 	fld1, ok := params[1].(*object.Object).FieldTable[FilePath]
 	if !ok {
-		errMsg := "bufferedReaderInit: File argument lacks a FilePath field"
+		errMsg := "Reader object lacks a FilePath field"
 		return getGErrBlk(excNames.InvalidTypeException, errMsg)
 	}
 	inPathStr := string(fld1.Fvalue.([]byte))
 	osFile, err := os.Open(inPathStr)
 	if err != nil {
-		errMsg := fmt.Sprintf("bufferedReaderInit: os.Open(%s) returned: %s", inPathStr, err.Error())
+		errMsg := fmt.Sprintf("os.Open(%s) failed, reason: %s", inPathStr, err.Error())
 		return getGErrBlk(excNames.FileNotFoundException, errMsg)
 	}
 
@@ -116,25 +116,12 @@ func bufferedReaderInit(params []interface{}) interface{} {
 	return nil
 }
 
-func bufferedReaderInitSz(params []interface{}) interface{} {
-	errMsg := "bufferedReaderInitSz: Instantiating BufferedReader with a size is not yet supported by jacobin"
-	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
-}
-
-func bufferedReaderLines(params []interface{}) interface{} {
-	errMsg := "bufferedReaderLines: Function lines() is not yet supported by jacobin"
-	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
-}
-
-func bufferedReaderMarkAndReset(params []interface{}) interface{} {
-	errMsg := "bufferedReaderMarkAndReset: BufferedReader mark() & reset() are not yet supported by jacobin"
-	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
-}
-
+// "java/io/BufferedReader.markSupported()Z"
 func bufferedReaderMarkSupported(params []interface{}) interface{} {
 	return int64(0) // false
 }
 
+// "java/io/BufferedReader.readLine()Ljava/lang/String;"
 func bufferedReaderReadLine(params []interface{}) interface{} {
 	// Get BufferedReader object.
 	obj := params[0].(*object.Object)
@@ -147,7 +134,7 @@ func bufferedReaderReadLine(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := obj.FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "bufferedReaderReadLine: BufferedReader object lacks a FileHandle field"
+		errMsg := "Reader object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -165,7 +152,7 @@ func bufferedReaderReadLine(params []interface{}) interface{} {
 			return object.Null
 		}
 		if err != nil {
-			errMsg := fmt.Sprintf("bufferedReaderReadLine: osFile.Read failed, reason: %s", err.Error())
+			errMsg := fmt.Sprintf("osFile.Read failed, reason: %s", err.Error())
 			return getGErrBlk(excNames.IOException, errMsg)
 		}
 		if byteBuf[0] == '\r' {

--- a/src/gfunction/javaIoFile.go
+++ b/src/gfunction/javaIoFile.go
@@ -66,14 +66,14 @@ func fileInit(params []interface{}) interface{} {
 	// Get the argument path string.
 	argPathStr := object.GoStringFromStringObject(params[1].(*object.Object))
 	if argPathStr == "" {
-		errMsg := "fileInit: String argument for path is null"
+		errMsg := "String argument for path is null"
 		return getGErrBlk(excNames.NullPointerException, errMsg)
 	}
 
 	// Create an absolute path string.
 	absPathStr, err := filepath.Abs(argPathStr)
 	if err != nil {
-		errMsg := fmt.Sprintf("fileInit: filepath.Abs(%s) error: %s", argPathStr, err.Error())
+		errMsg := fmt.Sprintf("filepath.Abs(%s) failed, reason: %s", argPathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -105,7 +105,7 @@ func fileInit(params []interface{}) interface{} {
 func fileGetPath(params []interface{}) interface{} {
 	fld, ok := params[0].(*object.Object).FieldTable[FilePath]
 	if !ok {
-		errMsg := "fileGetPath: File object lacks a FileHandle field"
+		errMsg := "File object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	bytes := fld.Fvalue.([]byte)
@@ -116,7 +116,7 @@ func fileGetPath(params []interface{}) interface{} {
 func fileIsInvalid(params []interface{}) interface{} {
 	status, ok := params[0].(*object.Object).FieldTable[FileStatus].Fvalue.(int64)
 	if !ok {
-		errMsg := "fileIsInvalid: File object lacks a FileStatus field"
+		errMsg := "File object lacks a FileStatus field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	if status == 0 {
@@ -130,7 +130,7 @@ func fileIsInvalid(params []interface{}) interface{} {
 func fileDelete(params []interface{}) interface{} {
 	bytes, ok := params[0].(*object.Object).FieldTable[FilePath].Fvalue.([]byte)
 	if !ok {
-		errMsg := "fileDelete: File object lacks a FilePath field"
+		errMsg := "File object lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	path := string(bytes)
@@ -145,7 +145,7 @@ func fileDelete(params []interface{}) interface{} {
 func fileCreate(params []interface{}) interface{} {
 	bytes, ok := params[0].(*object.Object).FieldTable[FilePath].Fvalue.([]byte)
 	if !ok {
-		errMsg := "fileCreate: File object lacks a FilePath field"
+		errMsg := "File object lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	path := string(bytes)

--- a/src/gfunction/javaIoFileInputStream.go
+++ b/src/gfunction/javaIoFileInputStream.go
@@ -101,19 +101,19 @@ func Load_Io_FileInputStream() {
 	MethodSignatures["java/io/FileInputStream.<init>(Ljava/io/FileDescriptor;)V"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  trapFileDescriptor,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/io/FileInputStream.getChannel()Ljava/nio/channels/FileChannel;"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  trapFileChannel,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/io/FileInputStream.getFD()Ljava/io/FileDescriptor;"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  trapFileDescriptor,
+			GFunction:  trapFunction,
 		}
 
 }
@@ -124,7 +124,7 @@ func initFileInputStreamFile(params []interface{}) interface{} {
 	// Get file path field from the File argument.
 	fld, ok := params[1].(*object.Object).FieldTable[FilePath]
 	if !ok {
-		errMsg := "initFileInputStreamFile: File argument lacks a FilePath field"
+		errMsg := "File object argument lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -134,7 +134,7 @@ func initFileInputStreamFile(params []interface{}) interface{} {
 	// Open the file for read-only, yielding a file handle.
 	osFile, err := os.Open(pathStr)
 	if err != nil {
-		errMsg := fmt.Sprintf("initFileInputStreamFile: os.Open(%s) error: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("os.Open(%s) failed, reason: %s", pathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -155,7 +155,7 @@ func initFileInputStreamString(params []interface{}) interface{} {
 	pathStr := object.GoStringFromStringObject(params[1].(*object.Object))
 	osFile, err := os.Open(pathStr)
 	if err != nil {
-		errMsg := fmt.Sprintf("initFileInputStreamString: os.Open(%s) error: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("os.Open(%s) failed, reason: %s", pathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -176,7 +176,7 @@ func fisAvailable(params []interface{}) interface{} {
 	// Get the file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "fisAvailable: FileInputStream object lacks a FileHandle field"
+		errMsg := "FileInputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -184,7 +184,7 @@ func fisAvailable(params []interface{}) interface{} {
 	fileInfo, err := osFile.Stat()
 	if err != nil {
 		path := string(params[0].(*object.Object).FieldTable["path"].Fvalue.([]byte))
-		errMsg := fmt.Sprintf("fisAvailable: osFile.Stat(%s) error: %s", path, err.Error())
+		errMsg := fmt.Sprintf("osFile.Stat(%s) failed, reason: %s", path, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	fsize := fileInfo.Size()
@@ -192,7 +192,7 @@ func fisAvailable(params []interface{}) interface{} {
 	// Get current file offset.
 	posn, err := osFile.Seek(0, io.SeekCurrent)
 	if err != nil {
-		errMsg := fmt.Sprintf("fisAvailable: osFile.Seek() error: %s", err.Error())
+		errMsg := fmt.Sprintf("osFile.Seek() failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -206,7 +206,7 @@ func fisReadOne(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "fisReadOne: FileInputStream object lacks a FileHandle field"
+		errMsg := "FileInputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -219,7 +219,7 @@ func fisReadOne(params []interface{}) interface{} {
 		return int64(-1) // return -1 on EOF
 	}
 	if err != nil {
-		errMsg := fmt.Sprintf("fisReadOne: osFile.Read error: %s", err.Error())
+		errMsg := fmt.Sprintf("osFile.Read failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -233,14 +233,14 @@ func fisReadByteArray(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "fisReadByteArray: FileInputStream object lacks a FileHandle field"
+		errMsg := "FileInputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Set buffer to the byte array parameter.
 	buffer, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
 	if !ok {
-		errMsg := "fisReadByteArray: Byte array parameter lacks a \"value\" field"
+		errMsg := "Byte array parameter lacks a \"value\" field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -250,7 +250,7 @@ func fisReadByteArray(params []interface{}) interface{} {
 		return int64(-1) // return -1 on EOF
 	}
 	if err != nil {
-		errMsg := fmt.Sprintf("fisReadByteArray: osFile.Read error: %s", err.Error())
+		errMsg := fmt.Sprintf("osFile.Read failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -268,14 +268,14 @@ func fisReadByteArrayOffset(params []interface{}) interface{} {
 	// Get the file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "fisReadByteArrayOffset: FileInputStream object lacks a FileHandle field"
+		errMsg := "FileInputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Set buffer (buf1) to the byte array parameter.
 	buf1, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
 	if !ok {
-		errMsg := "fisReadByteArrayOffset: Byte array parameter lacks a \"value\" field"
+		errMsg := "Byte array parameter lacks a \"value\" field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -288,7 +288,7 @@ func fisReadByteArrayOffset(params []interface{}) interface{} {
 		return int64(0)
 	}
 	if length < 0 || offset < 0 || length > (int64(len(buf1))-offset) {
-		errMsg := fmt.Sprintf("fisReadByteArrayOffset: error in parameters offset=%d length=%d bytes.length=%d",
+		errMsg := fmt.Sprintf("Error in parameters offset=%d length=%d bytes.length=%d",
 			offset, length, len(buf1))
 		return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
 	}
@@ -300,7 +300,7 @@ func fisReadByteArrayOffset(params []interface{}) interface{} {
 		return int64(-1) // return -1 on EOF
 	}
 	if err != nil {
-		errMsg := fmt.Sprintf("fisReadByteArrayOffset: osFile.Read error: %s", err.Error())
+		errMsg := fmt.Sprintf("osFile.Read failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -321,7 +321,7 @@ func fisSkip(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "fisSkip: FileInputStream object lacks a FileHandle field"
+		errMsg := "FileInputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -331,7 +331,7 @@ func fisSkip(params []interface{}) interface{} {
 	// Skip.
 	_, err := osFile.Seek(count, 1)
 	if err != nil {
-		errMsg := fmt.Sprintf("fisSkip: osFile.Seek(%d) error: %s", count, err.Error())
+		errMsg := fmt.Sprintf("osFile.Seek(%d) failed, reason: %s", count, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -345,14 +345,14 @@ func fisClose(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "fisClose: FileInputStream object lacks a FileHandle field"
+		errMsg := "FileInputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Close the file.
 	err := osFile.Close()
 	if err != nil {
-		errMsg := fmt.Sprintf("fisClose: osFile.Close() error: %s", err.Error())
+		errMsg := fmt.Sprintf("osFile.Close() failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	return nil

--- a/src/gfunction/javaIoFileOutputStream.go
+++ b/src/gfunction/javaIoFileOutputStream.go
@@ -73,13 +73,13 @@ func Load_Io_FileOutputStream() {
 	MethodSignatures["java/io/FileOutputStream.<init>(Ljava/io/FileDescriptor;)V"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  trapFileDescriptor,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/io/FileOutputStream.getFD()Ljava/io/FileDescriptor;"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  trapFileDescriptor,
+			GFunction:  trapFunction,
 		}
 
 }
@@ -90,7 +90,7 @@ func initFileOutputStreamFile(params []interface{}) interface{} {
 	// Get the file path.
 	fld, ok := params[1].(*object.Object).FieldTable[FilePath]
 	if !ok {
-		errMsg := "initFileOutputStreamFile: File argument lacks a FilePath field"
+		errMsg := "File object lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	pathStr := string(fld.Fvalue.([]byte))
@@ -98,7 +98,7 @@ func initFileOutputStreamFile(params []interface{}) interface{} {
 	// Open the file for write-only, yielding a file handle.
 	osFile, err := os.Create(pathStr)
 	if err != nil {
-		errMsg := fmt.Sprintf("initFileOutputStreamFile: os.Create(%s) error: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("os.Create(%s) failed, reason: %s", pathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -118,7 +118,7 @@ func initFileOutputStreamFileBoolean(params []interface{}) interface{} {
 	// Get file path field from the File argument.
 	fld, ok := params[1].(*object.Object).FieldTable[FilePath]
 	if !ok {
-		errMsg := "initFileOutputStreamFile: File argument lacks a FilePath field"
+		errMsg := "File object lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -128,7 +128,7 @@ func initFileOutputStreamFileBoolean(params []interface{}) interface{} {
 	// Get the boolean argument.
 	boolarg, ok := params[2].(int64)
 	if !ok {
-		errMsg := "initFileOutputStreamFile: Missing append-boolean argument"
+		errMsg := "Missing append-boolean argument"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -141,7 +141,7 @@ func initFileOutputStreamFileBoolean(params []interface{}) interface{} {
 		osFile, err = os.Create(pathStr)
 	}
 	if err != nil {
-		errMsg := fmt.Sprintf("initFileOutputStreamFileBoolean: os.Create(%s) error: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("os.Create(%s) failed, reason: %s", pathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -164,7 +164,7 @@ func initFileOutputStreamString(params []interface{}) interface{} {
 	// Open the file for write-only, yielding a file handle.
 	osFile, err := os.Create(pathStr)
 	if err != nil {
-		errMsg := fmt.Sprintf("initFileOutputStreamString: os.Create(%s) error: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("os.Create(%s) failed, reason: %s", pathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -188,7 +188,7 @@ func initFileOutputStreamStringBoolean(params []interface{}) interface{} {
 	// Get the boolean argument.
 	boolarg, ok := params[2].(int64)
 	if !ok {
-		errMsg := "initFileOutputStreamFileBoolean: Missing append-boolean argument"
+		errMsg := "Missing append-boolean argument"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -201,7 +201,7 @@ func initFileOutputStreamStringBoolean(params []interface{}) interface{} {
 		osFile, err = os.Create(pathStr)
 	}
 	if err != nil {
-		errMsg := fmt.Sprintf("initFileOutputStreamString: os.Create(%s) error: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("os.Create(%s) failed, reason: %s", pathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -222,14 +222,14 @@ func fosWriteOne(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "fosWriteOne: FileOutputStream object lacks a FileHandle field"
+		errMsg := "FileOutputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Get the integer argument.
 	wint, ok := params[1].(int64)
 	if !ok {
-		errMsg := "fosWriteOne: Missing integer argument"
+		errMsg := "Missing integer argument"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -240,7 +240,7 @@ func fosWriteOne(params []interface{}) interface{} {
 	// Write one byte.
 	_, err := osFile.Write(buffer)
 	if err != nil {
-		errMsg := fmt.Sprintf("fosWriteOne osFile.Write error: %s", err.Error())
+		errMsg := fmt.Sprintf("osFile.Write failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -253,21 +253,21 @@ func fosWriteByteArray(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "fosWriteByteArray: FileOutputStream object lacks a FileHandle field"
+		errMsg := "FileOutputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Set buffer to the byte array parameter.
 	buffer, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
 	if !ok {
-		errMsg := "fosWriteByteArray: Byte array parameter lacks a \"value\" field"
+		errMsg := "Byte array parameter lacks a \"value\" field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Write the buffer.
 	_, err := osFile.Write(buffer)
 	if err != nil {
-		errMsg := fmt.Sprintf("fosWriteByteArray osFile.Write error: %s", err.Error())
+		errMsg := fmt.Sprintf("osFile.Write failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -280,14 +280,14 @@ func fosWriteByteArrayOffset(params []interface{}) interface{} {
 	// Get the file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "fosWriteByteArrayOffset: FileOutputStream object lacks a FileHandle field"
+		errMsg := "FileOutputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Set buffer (buf1) to the byte array parameter.
 	buf1, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
 	if !ok {
-		errMsg := "fosWriteByteArrayOffset: Byte array parameter lacks a \"value\" field"
+		errMsg := "Byte array parameter lacks a \"value\" field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -300,7 +300,7 @@ func fosWriteByteArrayOffset(params []interface{}) interface{} {
 		return int64(0)
 	}
 	if length < 0 || offset < 0 || length > (int64(len(buf1))-offset) {
-		errMsg := fmt.Sprintf("fosWriteByteArrayOffset: error in parameters offset=%d length=%d bytes.length=%d",
+		errMsg := fmt.Sprintf("Error in parameters offset=%d length=%d bytes.length=%d",
 			offset, length, len(buf1))
 		return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
 	}
@@ -308,7 +308,7 @@ func fosWriteByteArrayOffset(params []interface{}) interface{} {
 	// Write the byte buffer.
 	_, err := osFile.Write(buf1[offset : offset+length])
 	if err != nil {
-		errMsg := fmt.Sprintf("fosWriteByteArrayOffset: osFile.Write error: %s", err.Error())
+		errMsg := fmt.Sprintf("osFile.Write failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -321,14 +321,14 @@ func fosClose(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "fosClose: FileOutputStream object lacks a FileHandle field"
+		errMsg := "FileOutputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Close the file.
 	err := osFile.Close()
 	if err != nil {
-		errMsg := fmt.Sprintf("fosClose: osFile.Close() error: %s", err.Error())
+		errMsg := fmt.Sprintf("osFile.Close() failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 

--- a/src/gfunction/javaIoFileReader.go
+++ b/src/gfunction/javaIoFileReader.go
@@ -41,19 +41,19 @@ func Load_Io_FileReader() {
 	MethodSignatures["java/io/FileReader.<init>(Ljava/io/FileDescriptor;)V"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  trapFileDescriptor,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/io/FileReader.<init>(Ljava/io/File;Ljava/nio/charset/Charset;)V"] =
 		GMeth{
 			ParamSlots: 2,
-			GFunction:  trapCharset,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/io/FileReader.<init>(Ljava/lang/String;Ljava/nio/charset/Charset;)V"] =
 		GMeth{
 			ParamSlots: 2,
-			GFunction:  trapCharset,
+			GFunction:  trapFunction,
 		}
 
 }
@@ -62,13 +62,13 @@ func Load_Io_FileReader() {
 func initFileReader(params []interface{}) interface{} {
 	fld1, ok := params[1].(*object.Object).FieldTable[FilePath]
 	if !ok {
-		errMsg := "initFileReader: File argument lacks a FilePath field"
+		errMsg := "File object lacks a FilePath field"
 		return getGErrBlk(excNames.InvalidTypeException, errMsg)
 	}
 	inPathStr := string(fld1.Fvalue.([]byte))
 	osFile, err := os.Open(inPathStr)
 	if err != nil {
-		errMsg := fmt.Sprintf("initFileReader: os.Open(%s) error: %s", inPathStr, err.Error())
+		errMsg := fmt.Sprintf("os.Open(%s) failed, reason: %s", inPathStr, err.Error())
 		return getGErrBlk(excNames.FileNotFoundException, errMsg)
 	}
 
@@ -88,7 +88,7 @@ func initFileReaderString(params []interface{}) interface{} {
 	pathStr := object.GoStringFromStringObject(params[1].(*object.Object))
 	osFile, err := os.Open(pathStr)
 	if err != nil {
-		errMsg := fmt.Sprintf("initFileReaderString: os.Open(%s) error: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("os.Open(%s) failed, reason: %s", pathStr, err.Error())
 		return getGErrBlk(excNames.FileNotFoundException, errMsg)
 	}
 

--- a/src/gfunction/javaIoFileWriter.go
+++ b/src/gfunction/javaIoFileWriter.go
@@ -81,31 +81,31 @@ func Load_Io_FileWriter() {
 	MethodSignatures["java/io/FileWriter.<init>(Ljava/io/FileDescriptor;)V"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  trapFileDescriptor,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/io/FileWriter.<init>(Ljava/io/File;Ljava/nio/charset/Charset;)V"] =
 		GMeth{
 			ParamSlots: 2,
-			GFunction:  trapCharset,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/io/FileWriter.<init>(Ljava/io/File;Ljava/nio/charset/Charset;Z)V"] =
 		GMeth{
 			ParamSlots: 3,
-			GFunction:  trapCharset,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/io/FileWriter.<init>(Ljava/lang/String;Ljava/nio/charset/Charset;)V"] =
 		GMeth{
 			ParamSlots: 2,
-			GFunction:  trapCharset,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/io/FileWriter.<init>(Ljava/lang/String;Ljava/nio/charset/Charset;Z)V"] =
 		GMeth{
 			ParamSlots: 3,
-			GFunction:  trapCharset,
+			GFunction:  trapFunction,
 		}
 
 }

--- a/src/gfunction/javaIoInputStreamReader.go
+++ b/src/gfunction/javaIoInputStreamReader.go
@@ -66,19 +66,19 @@ func Load_Io_InputStreamReader() {
 	MethodSignatures["java/io/InputStreamReader.<init>(Ljava/io/InputStream;Ljava/nio/charset/Charset;)V"] =
 		GMeth{
 			ParamSlots: 2,
-			GFunction:  trapCharset,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/io/InputStreamReader.<init>(Ljava/io/InputStream;Ljava/nio/charset/CharsetDecoder;)Ljava/lang.String;"] =
 		GMeth{
 			ParamSlots: 2,
-			GFunction:  trapCharset,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/io/InputStreamReader.getEncoding()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  trapCharset,
+			GFunction:  trapFunction,
 		}
 
 }
@@ -89,14 +89,14 @@ func inputStreamReaderInit(params []interface{}) interface{} {
 	// Get file path field.
 	fldPath, ok := params[1].(*object.Object).FieldTable[FilePath]
 	if !ok {
-		errMsg := "inputStreamReaderInit: InputStream argument lacks a FilePath field"
+		errMsg := "InputStream object lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Get file handle field.
 	fldHandle, ok := params[1].(*object.Object).FieldTable[FileHandle]
 	if !ok {
-		errMsg := "inputStreamReaderInit: InputStream argument lacks a FileHandle field"
+		errMsg := "InputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	osFile := fldHandle.Fvalue.(*os.File)
@@ -105,7 +105,7 @@ func inputStreamReaderInit(params []interface{}) interface{} {
 	_, err := osFile.Stat()
 	if err != nil {
 		pathStr := string(fldPath.Fvalue.([]byte))
-		errMsg := fmt.Sprintf("inputStreamReaderInit: os.Stat(%s) error: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("os.Stat(%s) failed, reason: %s", pathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -131,7 +131,7 @@ func isrClose(params []interface{}) interface{} {
 	// Close the file.
 	err := osFile.Close()
 	if err != nil {
-		errMsg := fmt.Sprintf("isrClose osFile.Close() error: %s", err.Error())
+		errMsg := fmt.Sprintf("osFile.Close() failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	return nil
@@ -147,7 +147,7 @@ func isrReadOneChar(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := obj.FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "isrReadOneChar: InputStreamReader object lacks a FileHandle field"
+		errMsg := "InputStreamReader object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -161,7 +161,7 @@ func isrReadOneChar(params []interface{}) interface{} {
 		return int64(-1) // return -1 on EOF
 	}
 	if err != nil {
-		errMsg := fmt.Sprintf("isrReadOneChar: osFile.Read error: %s", err.Error())
+		errMsg := fmt.Sprintf("osFile.Read failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -178,14 +178,14 @@ func isrReadCharBufferSubset(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := obj.FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "isrReadCharBufferSubset: InputStream object lacks a FileHandle field"
+		errMsg := "InputStreamReader object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Get the parameter buffer, offset, and length.
 	intArray, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]int64)
 	if !ok {
-		errMsg := "isrReadCharBufferSubset: InputStream object trouble with character array buffer"
+		errMsg := "InputStreamReader trouble with character array buffer"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	offset := params[2].(int64)
@@ -196,7 +196,7 @@ func isrReadCharBufferSubset(params []interface{}) interface{} {
 		return int64(0)
 	}
 	if length < 0 || offset < 0 || length > (int64(len(intArray))-offset) {
-		errMsg := fmt.Sprintf("isrReadCharBufferSubset: Error in parameters: offset=%d, length=%d, char.array.length=%d",
+		errMsg := fmt.Sprintf("Error in parameters: offset=%d, length=%d, char.array.length=%d",
 			offset, length, len(intArray))
 		return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
 	}
@@ -209,7 +209,7 @@ func isrReadCharBufferSubset(params []interface{}) interface{} {
 		return int64(-1) // return -1 on EOF
 	}
 	if err != nil {
-		errMsg := fmt.Sprintf("isrReadCharBufferSubset osFile.Read error: %s", err.Error())
+		errMsg := fmt.Sprintf("osFile.Read failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -233,14 +233,14 @@ func isrReady(params []interface{}) interface{} {
 	// Get file path.
 	fldPath, ok := params[1].(*object.Object).FieldTable[FilePath]
 	if !ok {
-		errMsg := "isrReady: InputStream argument lacks a FilePath field"
+		errMsg := "InputStreamReader object lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Get file handle.
 	fldHandle, ok := params[1].(*object.Object).FieldTable[FileHandle]
 	if !ok {
-		errMsg := "isrReady: InputStream argument lacks a FileHandle field"
+		errMsg := "InputStreamReader object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 

--- a/src/gfunction/javaIoOutputStreamWriter.go
+++ b/src/gfunction/javaIoOutputStreamWriter.go
@@ -70,19 +70,19 @@ func Load_Io_OutputStreamWriter() {
 	MethodSignatures["java/io/OutputStreamWriter.<init>(Ljava/io/OutputStream;Ljava/nio/charset/Charset;)V"] =
 		GMeth{
 			ParamSlots: 2,
-			GFunction:  trapCharset,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/io/OutputStreamWriter.<init>(Ljava/io/OutputStream;Ljava/nio/charset/CharsetDecoder;)Ljava/lang.String;"] =
 		GMeth{
 			ParamSlots: 2,
-			GFunction:  trapCharset,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/io/OutputStreamWriter.getEncoding()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  trapCharset,
+			GFunction:  trapFunction,
 		}
 
 }
@@ -93,14 +93,14 @@ func initOutputStreamWriter(params []interface{}) interface{} {
 	// Get file path field.
 	fldPath, ok := params[1].(*object.Object).FieldTable[FilePath]
 	if !ok {
-		errMsg := "initOutputStreamWriter: InputStream argument lacks a FilePath field"
+		errMsg := "OutputStream object lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Get file handle field.
 	fldHandle, ok := params[1].(*object.Object).FieldTable[FileHandle]
 	if !ok {
-		errMsg := "initOutputStreamWriter: InputStream argument lacks a FileHandle field"
+		errMsg := "OutputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	osFile := fldHandle.Fvalue.(*os.File)
@@ -109,7 +109,7 @@ func initOutputStreamWriter(params []interface{}) interface{} {
 	_, err := osFile.Stat()
 	if err != nil {
 		pathStr := string(fldPath.Fvalue.([]byte))
-		errMsg := fmt.Sprintf("initOutputStreamWriter: os.Stat(%s) error: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("os.Stat(%s) failed, reason: %s", pathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -127,14 +127,14 @@ func oswClose(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "oswClose: OutputStreamWriter object lacks a FileHandle field"
+		errMsg := "OutputStreamWriter object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Close the file.
 	err := osFile.Close()
 	if err != nil {
-		errMsg := fmt.Sprintf("oswClose: osFile.Close() error: %s", err.Error())
+		errMsg := fmt.Sprintf("osFile.Close() failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	return nil
@@ -145,14 +145,14 @@ func oswFlush(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "oswFlush: OutputStreamWriter object lacks a FileHandle field"
+		errMsg := "OutputStreamWriter object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Flush the file's buffers.
 	err := osFile.Sync()
 	if err != nil {
-		errMsg := fmt.Sprintf("oswFlush osFile.Sync() error: %s", err.Error())
+		errMsg := fmt.Sprintf("osFile.Sync() failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	return nil
@@ -167,14 +167,14 @@ func oswWriteOneChar(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := obj.FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "oswWriteOneChar: OutputStreamWriter object lacks a FileHandle field"
+		errMsg := "OutputStreamWriter object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Get the integer argument.
 	wint, ok := params[1].(int64)
 	if !ok {
-		errMsg := "osrWriteOne: Error in integer argument"
+		errMsg := "Error in integer argument"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -185,7 +185,7 @@ func oswWriteOneChar(params []interface{}) interface{} {
 	// Write one byte.
 	_, err := osFile.Write(buffer)
 	if err != nil {
-		errMsg := fmt.Sprintf("osrWriteOne osFile.Write error: %s", err.Error())
+		errMsg := fmt.Sprintf("osFile.Write failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -198,14 +198,14 @@ func oswWriteCharBuffer(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "oswWriteCharBuffer: OutputStream object lacks a FileHandle field"
+		errMsg := "OutputStreamWriter object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Get the parameter buffer, offset, and length.
 	intArray, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]int64)
 	if !ok {
-		errMsg := "oswWriteCharBuffer: OutputStream object trouble with value field ([]int64)"
+		errMsg := "Trouble with value field ([]int64)"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	offset := params[2].(int64)
@@ -216,7 +216,7 @@ func oswWriteCharBuffer(params []interface{}) interface{} {
 		return int64(0)
 	}
 	if length < 0 || offset < 0 || length > (int64(len(intArray))-offset) {
-		errMsg := fmt.Sprintf("oswWriteCharBuffer: Error in parameters: offset=%d, length=%d, char.array.length=%d",
+		errMsg := fmt.Sprintf("Error in parameters: offset=%d, length=%d, char.array.length=%d",
 			offset, length, len(intArray))
 		return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
 	}
@@ -230,7 +230,7 @@ func oswWriteCharBuffer(params []interface{}) interface{} {
 	// Write the byte buffer.
 	_, err := osFile.Write(outBytes)
 	if err != nil {
-		errMsg := fmt.Sprintf("oswWriteCharBuffer: osFile.Write error: %s", err.Error())
+		errMsg := fmt.Sprintf("osFile.Write failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -243,14 +243,14 @@ func oswWriteStringBuffer(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "oswWriteStringBuffer: OutputStream object lacks a FileHandle field"
+		errMsg := "OutputStreamWriter object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Get the parameter string byte array, offset, and length.
 	paramBytes, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
 	if !ok {
-		errMsg := "oswWriteStringBuffer: OutputStream object trouble with value field ([]int64)"
+		errMsg := "Trouble with value field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	offset := params[2].(int64)
@@ -261,7 +261,7 @@ func oswWriteStringBuffer(params []interface{}) interface{} {
 		return int64(0)
 	}
 	if length < 0 || offset < 0 || length > (int64(len(paramBytes))-offset) {
-		errMsg := fmt.Sprintf("oswWriteStringBuffer: Error in parameters: offset=%d, length=%d, char.array.length=%d",
+		errMsg := fmt.Sprintf("Error in parameters: offset=%d, length=%d, char.array.length=%d",
 			offset, length, len(paramBytes))
 		return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
 	}
@@ -275,7 +275,7 @@ func oswWriteStringBuffer(params []interface{}) interface{} {
 	// Write the byte buffer.
 	_, err := osFile.Write(outBytes)
 	if err != nil {
-		errMsg := fmt.Sprintf("osrWriteStringBuffer: osFile.Write error: %s", err.Error())
+		errMsg := fmt.Sprintf("osFile.Write failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 

--- a/src/gfunction/javaIoPrintStream.go
+++ b/src/gfunction/javaIoPrintStream.go
@@ -158,7 +158,7 @@ func Load_Io_PrintStream() {
 func PrintlnString(params []interface{}) interface{} {
 	param1, ok := params[1].(*object.Object)
 	if !ok {
-		errMsg := fmt.Sprintf("PrintlnString: expected params[1] of type *object.Object but observed type %T\n", params[1])
+		errMsg := fmt.Sprintf("Expected params[1] of type *object.Object but observed type %T\n", params[1])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -230,7 +230,7 @@ func PrintlnDoubleFloat(params []interface{}) interface{} {
 // "java/io/PrintStream.println(Ljava/lang/Object;)V"
 func PrintlnObject(params []interface{}) interface{} {
 	if params[1] == nil {
-		errMsg := fmt.Sprintf("PrintlnObject: expected params[1] of type *object.Object but observed type %T\n", params[1])
+		errMsg := fmt.Sprintf("Expected params[1] of type *object.Object but observed type %T\n", params[1])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	objPtr := params[1].(*object.Object)
@@ -308,7 +308,7 @@ func PrintString(params []interface{}) interface{} {
 	case *object.Object:
 		str = object.GoStringFromStringObject(params[1].(*object.Object))
 	default:
-		errMsg := fmt.Sprintf("PrintString: expected params[1] of type *object.Object but observed type %T\n", params[1])
+		errMsg := fmt.Sprintf("Expected params[1] of type *object.Object but observed type %T\n", params[1])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -320,7 +320,7 @@ func PrintString(params []interface{}) interface{} {
 // "java/io/PrintStream.print(Ljava/lang/Object;)V"
 func PrintObject(params []interface{}) interface{} {
 	if params[1] == nil {
-		errMsg := fmt.Sprintf("PrintObject: expected params[1] of type *object.Object but observed type %T\n", params[1])
+		errMsg := fmt.Sprintf("Expected params[1] of type *object.Object but observed type %T\n", params[1])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	objPtr := params[1].(*object.Object)

--- a/src/gfunction/javaLangByte.go
+++ b/src/gfunction/javaLangByte.go
@@ -55,7 +55,7 @@ func byteDecode(params []interface{}) interface{} {
 	parmObj := params[0].(*object.Object)
 	strArg := object.GoStringFromStringObject(parmObj)
 	if len(strArg) < 1 {
-		return getGErrBlk(excNames.NumberFormatException, "byteDecode: byte array length < 1")
+		return getGErrBlk(excNames.NumberFormatException, "Byte array length < 1")
 	}
 
 	// Strip off a leading "#" or "0x" in strArg.
@@ -69,11 +69,11 @@ func byteDecode(params []interface{}) interface{} {
 	// Parse the input integer.
 	int64Value, err := strconv.ParseInt(strArg, 16, 64)
 	if err != nil {
-		errMsg := fmt.Sprintf("byteDecode: arg=%s, err: %s", strArg, err.Error())
+		errMsg := fmt.Sprintf("strconv.ParseInt(%s) failed, reason: %s", strArg, err.Error())
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 	if int64Value > 255 {
-		errMsg := fmt.Sprintf("byteDecode: value too large: %d", int64Value)
+		errMsg := fmt.Sprintf("Byte value too large: %d", int64Value)
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 

--- a/src/gfunction/javaLangClass.go
+++ b/src/gfunction/javaLangClass.go
@@ -90,7 +90,7 @@ func getPrimitiveClass(params []interface{}) interface{} {
 	if err == nil {
 		return k
 	} else {
-		errMsg := fmt.Sprintf("getPrimitiveClass: does not handle: %s", str)
+		errMsg := fmt.Sprintf("Does not handle: %s", str)
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 }
@@ -111,7 +111,7 @@ func simpleClassLoadByName(className string) (*classloader.Klass, error) {
 		if className == "" {
 			errClassName = "<empty string>"
 		}
-		errMsg := fmt.Sprintf("simpleClassLoadByName: Failed to load class %s, error: %s", errClassName, err.Error())
+		errMsg := fmt.Sprintf("Failed to load class %s by name, reason: %s", errClassName, err.Error())
 		_ = log.Log(errMsg, log.SEVERE)
 		shutdown.Exit(shutdown.APP_EXCEPTION)
 		return nil, errors.New(errMsg) // needed for testing, which does not cause an O/S exit on failure

--- a/src/gfunction/javaLangDouble.go
+++ b/src/gfunction/javaLangDouble.go
@@ -170,13 +170,13 @@ func doubleParseDouble(params []interface{}) interface{} {
 	parmObj := params[0].(*object.Object)
 	strArg := object.GoStringFromStringObject(parmObj)
 	if len(strArg) < 1 {
-		return getGErrBlk(excNames.NumberFormatException, "doubleParseDouble: string length < 1")
+		return getGErrBlk(excNames.NumberFormatException, "String length is zero")
 	}
 
 	// Compute output.
 	output, err := strconv.ParseFloat(strArg, 64)
 	if err != nil {
-		errMsg := fmt.Sprintf("doubleParseDouble: strconv.ParseFloat(%s) error: %s", strArg, err.Error())
+		errMsg := fmt.Sprintf("strconv.ParseFloat(%s) failed, reason: %s", strArg, err.Error())
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 	return output

--- a/src/gfunction/javaLangInteger.go
+++ b/src/gfunction/javaLangInteger.go
@@ -129,7 +129,7 @@ func integerDecode(params []interface{}) interface{} {
 	parmObj := params[0].(*object.Object)
 	strArg := object.GoStringFromStringObject(parmObj)
 	if len(strArg) < 1 {
-		return getGErrBlk(excNames.NumberFormatException, "integerDecode: byte array length < 1")
+		return getGErrBlk(excNames.NumberFormatException, "Byte array length is zero")
 	}
 
 	// Replace a leading "#" with "0x" in strArg.
@@ -140,7 +140,7 @@ func integerDecode(params []interface{}) interface{} {
 	// Parse the input integer.
 	int64Value, err := strconv.ParseInt(strArg, 10, 64)
 	if err != nil {
-		errMsg := fmt.Sprintf("integerDecode: arg=%s, error: %s", strArg, err.Error())
+		errMsg := fmt.Sprintf("strconv.ParseInt(%s,10,64) failed, failed, reason: %s", strArg, err.Error())
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 
@@ -171,7 +171,7 @@ func integerParseInt(params []interface{}) interface{} {
 	parmObj := params[0].(*object.Object)
 	strArg := object.GoStringFromStringObject(parmObj)
 	if len(strArg) < 1 {
-		return getGErrBlk(excNames.NumberFormatException, "integerParseInt: string length < 1")
+		return getGErrBlk(excNames.NumberFormatException, "String length is zero")
 	}
 
 	// Replace a leading "#" with "0x" in strArg.
@@ -183,27 +183,27 @@ func integerParseInt(params []interface{}) interface{} {
 	switch params[1].(type) {
 	case int64:
 	default:
-		return getGErrBlk(excNames.NumberFormatException, "integerParseInt: radix is not an integer")
+		return getGErrBlk(excNames.NumberFormatException, "Radix is not an integer")
 	}
 	rdx := params[1].(int64)
 	if rdx < MinRadix || rdx > MaxRadix {
-		errMsg := fmt.Sprintf("integerParseInt: invalid radix value (%d)", rdx)
+		errMsg := fmt.Sprintf("Invalid radix value (%d)", rdx)
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 
 	// Compute output.
 	output, err := strconv.ParseInt(strArg, int(rdx), 64)
 	if err != nil {
-		errMsg := fmt.Sprintf("integerParseInt: arg=%s, radix=%d, strconv.ParseInt error: %s", strArg, rdx, err.Error())
+		errMsg := fmt.Sprintf("strconv.ParseInt(%s,%d,64) failed, reason: %s", strArg, rdx, err.Error())
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 
 	// Check Integer boundaries.
 	if output > MaxIntValue {
-		return getGErrBlk(excNames.NumberFormatException, "integerParseInt: upper limit is Integer.MAX_VALUE")
+		return getGErrBlk(excNames.NumberFormatException, "Computed integer exceeds upper limit")
 	}
 	if output < MinIntValue {
-		return getGErrBlk(excNames.NumberFormatException, "integerParseInt: lower limit is Integer.MIN_VALUE")
+		return getGErrBlk(excNames.NumberFormatException, "Computed integer is less than lower limit")
 	}
 
 	// Return computed value.
@@ -212,7 +212,6 @@ func integerParseInt(params []interface{}) interface{} {
 
 // "java/lang/Integer.valueOf(I)Ljava/lang/Integer;"
 func integerValueOf(params []interface{}) interface{} {
-	// fmt.Printf("DEBUG integerValueOf at entry params[0]: (%T) %v\n", params[0], params[0])
 	int64Value := params[0].(int64)
 	return populator("java/lang/Integer", types.Int, int64Value)
 }
@@ -257,12 +256,12 @@ func integerToUnsignedStringRadix(params []interface{}) interface{} {
 	switch params[1].(type) {
 	case int64:
 	default:
-		errMsg := fmt.Sprintf("integerToUnsignedStringRadix: invalid radix (%v) format", params[1])
+		errMsg := fmt.Sprintf("Invalid radix (%v) format", params[1])
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 	rdx := params[1].(int64)
 	if rdx < MinRadix || rdx > MaxRadix {
-		errMsg := fmt.Sprintf("integerToUnsignedStringRadix: invalid radix value (%d)", rdx)
+		errMsg := fmt.Sprintf("Invalid radix value (%d)", rdx)
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 

--- a/src/gfunction/javaLangLong.go
+++ b/src/gfunction/javaLangLong.go
@@ -8,8 +8,11 @@ package gfunction
 
 import (
 	"fmt"
+	"jacobin/excNames"
 	"jacobin/object"
 	"jacobin/types"
+	"math/bits"
+	"strconv"
 )
 
 func Load_Lang_Long() {
@@ -24,6 +27,24 @@ func Load_Lang_Long() {
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  longDoubleValue,
+		}
+
+	MethodSignatures["java/lang/Long.parseLong(Ljava/lang/String;)J"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  longParseLong,
+		}
+
+	MethodSignatures["java/lang/Long.rotateLeft(JI)J"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  longRotateLeft,
+		}
+
+	MethodSignatures["java/lang/Long.rotateRight(JI)J"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  longRotateRight,
 		}
 
 	MethodSignatures["java/lang/Long.toHexString(J)Ljava/lang/String;"] =
@@ -46,6 +67,34 @@ func longDoubleValue(params []interface{}) interface{} {
 	parmObj := params[0].(*object.Object)
 	jj = parmObj.FieldTable["value"].Fvalue.(int64)
 	return float64(jj)
+}
+
+// "java/lang/Long.parseLong(Ljava/lang/String;)J"
+func longParseLong(params []interface{}) interface{} {
+	obj := params[1].(*object.Object)
+	str := object.GoStringFromStringObject(obj)
+	jj, err := strconv.ParseInt(str, 10, 64)
+	if err != nil {
+		errMsg := fmt.Sprintf("strconv.ParseInt(%s,10,64), failed, reason: %s", str, err.Error())
+		return getGErrBlk(excNames.NumberFormatException, errMsg)
+	}
+	return jj
+}
+
+// "java/lang/Long.rotateLeft(JI)J"
+func longRotateLeft(params []interface{}) interface{} {
+	jj := uint64(params[0].(int64))
+	shiftLength := int(params[2].(int64))
+	value := bits.RotateLeft64(jj, shiftLength)
+	return int64(value)
+}
+
+// "java/lang/Long.rotateRight(JI)J"
+func longRotateRight(params []interface{}) interface{} {
+	jj := uint64(params[0].(int64))
+	shiftLength := int(params[2].(int64))
+	value := bits.RotateLeft64(jj, -shiftLength)
+	return int64(value)
 }
 
 // "java/lang/Long.valueOf(J)Ljava/lang/Long;"

--- a/src/gfunction/javaLangMath.go
+++ b/src/gfunction/javaLangMath.go
@@ -219,7 +219,7 @@ func Load_Lang_Math() {
 func mathClinit([]interface{}) interface{} {
 	klass := classloader.MethAreaFetch("java/lang/Math")
 	if klass == nil {
-		errMsg := "mathClinit, expected java/lang/Math to be in the MethodArea, but it was not"
+		errMsg := "Math<clinit>: Expected java/lang/Math to be in the MethodArea, but it was not"
 		_ = log.Log(errMsg, log.SEVERE)
 		return getGErrBlk(excNames.VirtualMachineError, errMsg)
 	}
@@ -323,7 +323,7 @@ func floorFloat64(params []interface{}) interface{} {
 // to the algebraic quotient.
 func floorDivInt64(dividend int64, divisor int64) interface{} {
 	if divisor == 0 {
-		return getGErrBlk(excNames.ArithmeticException, "floorDivInt64: Divide by zero attempted")
+		return getGErrBlk(excNames.ArithmeticException, "Divide by zero")
 	}
 	if dividend <= math.MinInt64 && divisor == -1 {
 		return math.MinInt64

--- a/src/gfunction/javaLangStackTraceElement.go
+++ b/src/gfunction/javaLangStackTraceElement.go
@@ -73,7 +73,7 @@ func of(params []interface{}) interface{} {
 	// get a pointer to the JVM stack
 	jvmStackRef := throwable.FieldTable["frameStackRef"].Fvalue.(*list.List)
 	if jvmStackRef == nil {
-		errMsg := "nil parameter for 'frameStackRef' in Throwable, found in StackTraceElement.of()"
+		errMsg := "java/lang/StackTraceElement.of: Nil parameter for 'frameStackRef' in Throwable, found in StackTraceElement.of()"
 		_ = log.Log(errMsg, log.SEVERE)
 		shutdown.Exit(shutdown.JVM_EXCEPTION)
 	}

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -70,28 +70,28 @@ func Load_Lang_String() {
 	MethodSignatures["java/lang/String.<init>([BIILjava/lang/String;)V"] =
 		GMeth{
 			ParamSlots: 4,
-			GFunction:  noSupportYetInString,
+			GFunction:  trapFunction,
 		}
 
 	// String(byte[] bytes, int offset, int length, Charset charset) ************** CHARSET
 	MethodSignatures["java/lang/String.<init>([BIILjava/nio/charset/Charset;)V"] =
 		GMeth{
 			ParamSlots: 4,
-			GFunction:  noSupportYetInString,
+			GFunction:  trapFunction,
 		}
 
 	// String(byte[] bytes, String charsetName) *********************************** CHARSET
 	MethodSignatures["java/lang/String.<init>([BLjava/lang/String;)V"] =
 		GMeth{
 			ParamSlots: 2,
-			GFunction:  noSupportYetInString,
+			GFunction:  trapFunction,
 		}
 
 	// String(byte[] bytes, Charset charset) ************************************** CHARSET
 	MethodSignatures["java/lang/String.<init>([BLjava/nio/charset/Charset;)V"] =
 		GMeth{
 			ParamSlots: 2,
-			GFunction:  noSupportYetInString,
+			GFunction:  trapFunction,
 		}
 
 	// String(byte[] bytes, Charset charset) ************************************** CHARSET
@@ -108,7 +108,7 @@ func Load_Lang_String() {
 	MethodSignatures["java/lang/String.<init>([III)V"] =
 		GMeth{
 			ParamSlots: 3,
-			GFunction:  noSupportYetInString,
+			GFunction:  trapFunction,
 		}
 
 	// String(String original) - works fine in Java
@@ -117,14 +117,14 @@ func Load_Lang_String() {
 	MethodSignatures["java/lang/String.<init>(Ljava/lang/StringBuffer;)V"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  noSupportYetInString,
+			GFunction:  trapFunction,
 		}
 
 	// String(StringBuilder builder) ******************************************* StringBuilder
 	MethodSignatures["java/lang/String.<init>(Ljava/lang/StringBuilder;)V"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  noSupportYetInString,
+			GFunction:  trapFunction,
 		}
 
 	// === METHOD FUNCTIONS ===
@@ -147,14 +147,14 @@ func Load_Lang_String() {
 	MethodSignatures["java/lang/String.getBytes(Ljava/lang/String;)[B"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  noSupportYetInString,
+			GFunction:  trapFunction,
 		}
 
 	// get the bytes from a string, given the specified Charset object ******************* CHARSET
 	MethodSignatures["java/lang/String.getBytes(Ljava/nio/charset/Charset;)[B"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  noSupportYetInString,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/lang/String.charAt(I)C"] =
@@ -209,7 +209,7 @@ func Load_Lang_String() {
 	MethodSignatures["java/lang/String.format(Ljava/util/Locale;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;"] =
 		GMeth{
 			ParamSlots: 3,
-			GFunction:  noSupportYetInString,
+			GFunction:  trapFunction,
 		}
 
 	// Return the length of a String.
@@ -344,17 +344,11 @@ func Load_Lang_String() {
 func stringClinit([]interface{}) interface{} {
 	klass := classloader.MethAreaFetch(types.StringClassName)
 	if klass == nil {
-		errMsg := fmt.Sprintf("stringClinit: Could not find class %s in the MethodArea", types.StringClassName)
+		errMsg := fmt.Sprintf("Could not find class %s in the MethodArea", types.StringClassName)
 		return getGErrBlk(excNames.ClassNotLoadedException, errMsg)
 	}
 	klass.Data.ClInit = types.ClInitRun // just mark that String.<clinit>() has been run
 	return nil
-}
-
-// No support YET for references to Charset objects nor for Unicode code point arrays
-func noSupportYetInString([]interface{}) interface{} {
-	errMsg := "noSupportYetInString: No support yet for user-specified character sets and Unicode code point arrays"
-	return getGErrBlk(excNames.UnsupportedEncodingException, errMsg)
 }
 
 // Get character at the given index.
@@ -424,7 +418,7 @@ func newStringFromBytesSubset(params []interface{}) interface{} {
 	// Validate boundaries.
 	totalLength := int64(len(bytes))
 	if totalLength < 1 || ssStart < 0 || ssEnd < 1 || ssStart > (totalLength-1) || (ssStart+ssEnd) > totalLength {
-		errMsg1 := "newStringFromBytesSubset: Either: nil input byte array, invalid substring offset, or invalid substring length"
+		errMsg1 := "Either nil input byte array, invalid substring offset, or invalid substring length"
 		errMsg2 := fmt.Sprintf("\n\twhole='%s' wholelen=%d, offset=%d, sslen=%d\n\n", string(bytes), totalLength, ssStart, ssEnd)
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg1+errMsg2)
 	}
@@ -610,7 +604,7 @@ func substringToTheEnd(params []interface{}) interface{} {
 	// Validate boundaries.
 	totalLength := int64(len(str))
 	if totalLength < 1 || ssStart < 0 || ssEnd < 1 || ssStart > (totalLength-1) || ssEnd > totalLength {
-		errMsg1 := "substringToTheEnd: Either: nil input byte array, invalid substring offset, or invalid substring length"
+		errMsg1 := "Either: nil input byte array, invalid substring offset, or invalid substring length"
 		errMsg2 := fmt.Sprintf("\n\twhole='%s' wholelen=%d, offset=%d, sslen=%d\n\n", str, totalLength, ssStart, ssEnd)
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg1+errMsg2)
 	}
@@ -638,7 +632,7 @@ func substringStartEnd(params []interface{}) interface{} {
 	// Validate boundaries.
 	totalLength := int64(len(str))
 	if totalLength < 1 || ssStart < 0 || ssEnd < 1 || ssStart > (totalLength-1) || ssEnd > totalLength {
-		errMsg1 := "substringStartEnd: Either: nil input byte array, invalid substring offset, or invalid substring length"
+		errMsg1 := "Either: nil input byte array, invalid substring offset, or invalid substring length"
 		errMsg2 := fmt.Sprintf("\n\twhole='%s' wholelen=%d, offset=%d, sslen=%d\n\n", str, totalLength, ssStart, ssEnd)
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg1+errMsg2)
 	}
@@ -741,7 +735,7 @@ func valueOfCharSubarray(params []interface{}) interface{} {
 	// Validate boundaries.
 	wholeLength := int64(len(wholeString))
 	if wholeLength < 1 || ssOffset < 0 || ssCount < 1 || ssOffset > (wholeLength-1) || (ssOffset+ssCount) > wholeLength {
-		errMsg := "valueOfCharSubarray: Either: nil input byte array, invalid substring offset, or invalid substring length"
+		errMsg := "Either: nil input byte array, invalid substring offset, or invalid substring length"
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 	}
 

--- a/src/gfunction/javaLangStringBuilder.go
+++ b/src/gfunction/javaLangStringBuilder.go
@@ -18,6 +18,7 @@ func Load_Lang_StringBuilder() {
 
 }
 
+// "java/lang/StringBuilder.isLatin1()Z"
 func isLatin1([]interface{}) interface{} {
 	// TODO: Someday, jacobin will need to discern between StringLatin1 and StringUTF16.
 	return int64(1)

--- a/src/gfunction/javaLangStringUTF16.go
+++ b/src/gfunction/javaLangStringUTF16.go
@@ -36,6 +36,7 @@ func Load_Lang_UTF16() {
 
 }
 
+// "java/lang/StringUTF16.isBigEndian()Z"
 // Return whether the current platform is big-endian.
 func isBigEndian([]interface{}) interface{} {
 	return types.JavaBoolFalse // Jacobin runs on no big-endian platform at present

--- a/src/gfunction/javaLangSystem.go
+++ b/src/gfunction/javaLangSystem.go
@@ -133,7 +133,7 @@ func clinit([]interface{}) interface{} {
 // docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/System.html#arraycopy(java.lang.Object,int,java.lang.Object,int,int)
 func arrayCopy(params []interface{}) interface{} {
 	if len(params) != 5 {
-		errMsg := fmt.Sprintf("java/lang/System.arraycopy: Expected 5 parameters, got %d", len(params))
+		errMsg := fmt.Sprintf("Expected 5 parameters, got %d", len(params))
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -144,13 +144,13 @@ func arrayCopy(params []interface{}) interface{} {
 	length := params[4].(int64)
 
 	if src == nil || dest == nil {
-		errMsg := fmt.Sprintf("java/lang/System.arraycopy: null src or dest")
+		errMsg := fmt.Sprintf("null src or dest")
 		return getGErrBlk(excNames.NullPointerException, errMsg)
 	}
 
 	if srcPos < 0 || destPos < 0 || length < 0 {
 		errMsg := fmt.Sprintf(
-			"java/lang/System.arraycopy: Negative position in: srcPose=%d, destPos=%d, or length=%d", srcPos, destPos, length)
+			"Negative position in: srcPose=%d, destPos=%d, or length=%d", srcPos, destPos, length)
 		return getGErrBlk(excNames.ArrayIndexOutOfBoundsException, errMsg)
 	}
 
@@ -166,7 +166,7 @@ func arrayCopy(params []interface{}) interface{} {
 	destLen := object.ArrayLength(dest)
 
 	if srcPos+length > srcLen || destPos+length > destLen {
-		errMsg := fmt.Sprintf("java/lang/System.arraycopy: array + length exceeds array size")
+		errMsg := fmt.Sprintf("Array position + length exceeds array size")
 		return getGErrBlk(excNames.ArrayIndexOutOfBoundsException, errMsg)
 	}
 

--- a/src/gfunction/javaLangSystem_test.go
+++ b/src/gfunction/javaLangSystem_test.go
@@ -240,7 +240,7 @@ func TestArrayCopyInvalidLength(t *testing.T) {
 	}
 
 	errMsg := err.(*GErrBlk).ErrMsg
-	if !strings.Contains(errMsg, "array + length exceeds array size") {
+	if !strings.Contains(errMsg, "Array position + length exceeds array size") {
 		t.Errorf("Expected error re invalid length, got %s", errMsg)
 	}
 }

--- a/src/gfunction/javaLangThread.go
+++ b/src/gfunction/javaLangThread.go
@@ -47,7 +47,7 @@ func Load_Lang_Thread() {
 func threadSleep(params []interface{}) interface{} {
 	sleepTime, ok := params[0].(int64)
 	if !ok {
-		errMsg := "threadSleep: Parameter must be an int64 (long)"
+		errMsg := "Parameter must be an int64 (long)"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	time.Sleep(time.Duration(sleepTime) * time.Millisecond)

--- a/src/gfunction/javaMathBigInteger.go
+++ b/src/gfunction/javaMathBigInteger.go
@@ -406,7 +406,7 @@ func addStaticBigInteger(argName string, argValue int64) {
 func bigIntegerClinit([]interface{}) interface{} {
 	klass := classloader.MethAreaFetch(bigIntegerClassName)
 	if klass == nil {
-		errMsg := fmt.Sprintf("bigIntegerClinit: Expected %s to be in the MethodArea, but it was not", bigIntegerClassName)
+		errMsg := fmt.Sprintf("BigInteger<clinit>: Expected %s to be in the MethodArea, but it was not", bigIntegerClassName)
 		_ = log.Log(errMsg, log.SEVERE)
 		return getGErrBlk(excNames.ClassNotLoadedException, errMsg)
 	}
@@ -480,7 +480,7 @@ func bigIntegerInitString(params []interface{}) interface{} {
 	var zz = new(big.Int)
 	_, ok := zz.SetString(str, 10)
 	if !ok {
-		errMsg := fmt.Sprintf("bigIntegerInitString: input (%s) not all numerics", str)
+		errMsg := fmt.Sprintf("<init> string (%s) not all numerics", str)
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 
@@ -502,7 +502,7 @@ func bigIntegerInitStringRadix(params []interface{}) interface{} {
 	var zz = new(big.Int)
 	_, ok := zz.SetString(str, int(rdx))
 	if !ok {
-		errMsg := fmt.Sprintf("bigIntegerInitStringRadix: input (%s) not all numerics or the radix (%d) is invalid", str, rdx)
+		errMsg := fmt.Sprintf("<init> string (%s) not all numerics or the radix (%d) is invalid", str, rdx)
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 
@@ -625,7 +625,7 @@ func bigIntegerByteValueExact(params []interface{}) interface{} {
 	xx := fld.Fvalue.(*big.Int)
 	ii := xx.Int64()
 	if ii < 0 || ii > 255 {
-		errMsg := fmt.Sprintf("byteValueExact: BigInteger value (%d) will not fit in a byte", ii)
+		errMsg := fmt.Sprintf("Value (%d) will not fit in a byte", ii)
 		return getGErrBlk(excNames.ArithmeticException, errMsg)
 	}
 	return ii & 0xFF
@@ -655,7 +655,7 @@ func bigIntegerDivide(params []interface{}) interface{} {
 	yy := objArg.FieldTable["value"].Fvalue.(*big.Int)
 	zero := big.NewInt(int64(0))
 	if yy.Cmp(zero) <= 0 {
-		errMsg := fmt.Sprintf("bigIntegerDivide: divisor (%d) = 0", yy.Int64())
+		errMsg := "Divide by zero"
 		return getGErrBlk(excNames.ArithmeticException, errMsg)
 	}
 
@@ -680,7 +680,7 @@ func bigIntegerDivideAndRemainder(params []interface{}) interface{} {
 	yy := objArg.FieldTable["value"].Fvalue.(*big.Int)
 	zero := big.NewInt(int64(0))
 	if yy.Cmp(zero) <= 0 {
-		errMsg := fmt.Sprintf("bigIntegerDivide: divisor (%d) = 0", yy.Int64())
+		errMsg := "Divide by zero"
 		return getGErrBlk(excNames.ArithmeticException, errMsg)
 	}
 
@@ -825,7 +825,7 @@ func bigIntegerMin(params []interface{}) interface{} {
 	return obj
 }
 
-// "java/math/BigInteger.min(Ljava/math/BigInteger;)Ljava/math/BigInteger;"
+// "java/math/BigInteger.mod(Ljava/math/BigInteger;)Ljava/math/BigInteger;"
 func bigIntegerMod(params []interface{}) interface{} {
 	// params[0]: base object (xx)
 	// params[1]: argument object (yy)
@@ -837,7 +837,7 @@ func bigIntegerMod(params []interface{}) interface{} {
 	yy := objArg.FieldTable["value"].Fvalue.(*big.Int)
 	zero := big.NewInt(int64(0))
 	if yy.Cmp(zero) <= 0 {
-		errMsg := fmt.Sprintf("bigIntegerMod: modulus (%d) not positive", yy.Int64())
+		errMsg := fmt.Sprintf("Modulus (%d) negative", yy.Int64())
 		return getGErrBlk(excNames.ArithmeticException, errMsg)
 	}
 
@@ -865,7 +865,7 @@ func bigIntegerModInverse(params []interface{}) interface{} {
 	mm := objModulus.FieldTable["value"].Fvalue.(*big.Int)
 	zero := big.NewInt(int64(0))
 	if mm.Cmp(zero) <= 0 {
-		errMsg := fmt.Sprintf("bigIntegerModInverse: modulus (%d) is not positive", mm.Int64())
+		errMsg := fmt.Sprintf("Modulus (%d) is negative", mm.Int64())
 		return getGErrBlk(excNames.ArithmeticException, errMsg)
 	}
 
@@ -894,7 +894,7 @@ func bigIntegerModPow(params []interface{}) interface{} {
 	mm := objMM.FieldTable["value"].Fvalue.(*big.Int)
 	zero := big.NewInt(int64(0))
 	if mm.Cmp(zero) <= 0 {
-		errMsg := fmt.Sprintf("bigIntegerModPow: modulus (%d) is not positive", mm.Int64())
+		errMsg := fmt.Sprintf("Modulus (%d) is negative", mm.Int64())
 		return getGErrBlk(excNames.ArithmeticException, errMsg)
 	}
 
@@ -991,7 +991,7 @@ func bigIntegerPow(params []interface{}) interface{} {
 	xx := objBase.FieldTable["value"].Fvalue.(*big.Int)
 	pow := params[1].(int64)
 	if pow < 0 {
-		errMsg := fmt.Sprintf("bigIntegerPow: power (%d) < 0", pow)
+		errMsg := fmt.Sprintf("Power (%d) is negative", pow)
 		return getGErrBlk(excNames.ArithmeticException, errMsg)
 	}
 	yy := big.NewInt(pow)
@@ -1017,7 +1017,7 @@ func bigIntegerRemainder(params []interface{}) interface{} {
 	yy := objArg.FieldTable["value"].Fvalue.(*big.Int)
 	zero := big.NewInt(int64(0))
 	if yy.Cmp(zero) <= 0 {
-		errMsg := fmt.Sprintf("bigIntegerRemainder: divisor (%d) = 0", yy.Int64())
+		errMsg := "Divide by zero"
 		return getGErrBlk(excNames.ArithmeticException, errMsg)
 	}
 
@@ -1048,7 +1048,7 @@ func bigIntegerSqrt(params []interface{}) interface{} {
 	xx := objBase.FieldTable["value"].Fvalue.(*big.Int)
 	zero := big.NewInt(int64(0))
 	if xx.Cmp(zero) < 0 {
-		errMsg := fmt.Sprintf("bigIntegerSqrt: argument (%d) < 0", xx.Int64())
+		errMsg := fmt.Sprintf("Argument (%d) is negative", xx.Int64())
 		return getGErrBlk(excNames.ArithmeticException, errMsg)
 	}
 
@@ -1114,7 +1114,7 @@ func bigIntegerToStringRadix(params []interface{}) interface{} {
 	xx := objBase.FieldTable["value"].Fvalue.(*big.Int)
 	rdx := params[1].(int64)
 	if rdx < 2 || rdx > 62 {
-		errMsg := fmt.Sprintf("bigIntegerToStringRadix: invalid radix value (%d)", rdx)
+		errMsg := fmt.Sprintf("Invalid radix value (%d)", rdx)
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 

--- a/src/gfunction/javaNioCharsetCharset.go
+++ b/src/gfunction/javaNioCharsetCharset.go
@@ -14,14 +14,14 @@ func Load_Nio_Charset_Charset() {
 	MethodSignatures["java/nio/charset/Charset.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  trapCharset,
+			GFunction:  trapFunction,
 		}
 
 	// Get the default character set.
 	MethodSignatures["java/nio/charset/Charset.defaultCharset()Ljava/nio/charset/Charset;"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  trapCharset,
+			GFunction:  trapFunction,
 		}
 
 }

--- a/src/gfunction/javaUtilHashMap.go
+++ b/src/gfunction/javaUtilHashMap.go
@@ -46,7 +46,7 @@ func hashMapHash(params []interface{}) interface{} {
 			bytes := make([]byte, 8)
 			binary.BigEndian.PutUint64(bytes, uint64(fld.Fvalue.(float64)))
 		default:
-			str := fmt.Sprintf("hashMapHash: unrecognized object field type: %T", fld.Ftype)
+			str := fmt.Sprintf("Unrecognized object field type: %T", fld.Ftype)
 			return getGErrBlk(excNames.VirtualMachineError, str)
 		}
 		roughHash := md5.Sum(bytes)            // md5.sum returns an array of bytes

--- a/src/gfunction/javaUtilRandom.go
+++ b/src/gfunction/javaUtilRandom.go
@@ -185,7 +185,7 @@ func randomNextIntBound(params []interface{}) interface{} {
 	r := GetStructFromRandomObject(obj)
 	bound := params[1].(int64)
 	if bound < 1 {
-		errMsg := fmt.Sprintf("randomNextIntBound: bound must be positive, observed: %d", bound)
+		errMsg := fmt.Sprintf("Bound must be positive, observed: %d", bound)
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	output := r.rand.Int63n(bound)
@@ -207,7 +207,7 @@ func randomNextLongBound(params []interface{}) interface{} {
 	r := GetStructFromRandomObject(obj)
 	bound := params[1].(int64)
 	if bound < 1 {
-		errMsg := fmt.Sprintf("randomNextLongBound: bound must be positive, observed: %d", bound)
+		errMsg := fmt.Sprintf("Bound must be positive, observed: %d", bound)
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	output := r.rand.Int63n(bound)

--- a/src/gfunction/jdkInternalMiscUnsafe.go
+++ b/src/gfunction/jdkInternalMiscUnsafe.go
@@ -81,7 +81,7 @@ var classUnsafeName = "jdk/internal/misc/Unsafe"
 func arrayBaseOffset(params []interface{}) interface{} {
 	p := params[0]
 	if p == nil || p == object.Null {
-		errMsg := "arrayBaseOffset: passed a null pointer"
+		errMsg := "Object is a null pointer"
 		return getGErrBlk(excNames.NullPointerException, errMsg)
 	}
 	return int64(0) // this should work...


### PR DESCRIPTION
@platypusguy As we discussed, error block text no longer includes the function name since the class name, method name, and method type will be supplied by runGfunction.

	modified:   gfunction/Traps.go
	modified:   gfunction/javaIoBufferedReader.go
	modified:   gfunction/javaIoConsole.go
	modified:   gfunction/javaIoFile.go
	modified:   gfunction/javaIoFileInputStream.go
	modified:   gfunction/javaIoFileOutputStream.go
	modified:   gfunction/javaIoFileReader.go
	modified:   gfunction/javaIoFileWriter.go
	modified:   gfunction/javaIoInputStreamReader.go
	modified:   gfunction/javaIoOutputStreamWriter.go
	modified:   gfunction/javaIoPrintStream.go
	modified:   gfunction/javaLangByte.go
	modified:   gfunction/javaLangClass.go
	modified:   gfunction/javaLangDouble.go
	modified:   gfunction/javaLangInteger.go
	modified:   gfunction/javaLangLong.go
	modified:   gfunction/javaLangMath.go
	modified:   gfunction/javaLangStackTraceElement.go
	modified:   gfunction/javaLangString.go
	modified:   gfunction/javaLangStringBuilder.go
	modified:   gfunction/javaLangStringUTF16.go
	modified:   gfunction/javaLangSystem.go
	modified:   gfunction/javaLangSystem_test.go
	modified:   gfunction/javaLangThread.go
	modified:   gfunction/javaMathBigInteger.go
	modified:   gfunction/javaNioCharsetCharset.go
	modified:   gfunction/javaUtilHashMap.go
	modified:   gfunction/javaUtilRandom.go
	modified:   gfunction/jdkInternalMiscUnsafe.go
