### PR TITLE
JACOBIN-528, JACOBIN-529

### DIFF
--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -524,7 +524,7 @@ func StringFormatter(params []interface{}) interface{} {
 				str := string(fld.Fvalue.([]byte))
 				valuesOut = append(valuesOut, str)
 			case types.Byte:
-				valuesOut = append(valuesOut, fld.Fvalue.(int64))
+				valuesOut = append(valuesOut, uint8(fld.Fvalue.(int64)))
 			case types.Bool:
 				var zz bool
 				if fld.Fvalue.(int64) == 0 {

--- a/src/jvm/gfunctionExec.go
+++ b/src/jvm/gfunctionExec.go
@@ -86,9 +86,9 @@ func runGfunction(mt classloader.MTentry, fs *list.List,
 		} else {
 			threadName = fmt.Sprintf("%d", f.Thread)
 		}
-		errMsg := fmt.Sprintf("Exception in thread: %s, %s:\n",
-			threadName, fullMethName)
-		status := exceptions.ThrowEx(errBlk.ExceptionType, errBlk.ErrMsg, f)
+		errMsg := fmt.Sprintf("%s in thread: %s, method: %s",
+			errBlk.ErrMsg, threadName, fullMethName)
+		status := exceptions.ThrowEx(errBlk.ExceptionType, errMsg, f)
 		if status != exceptions.Caught {
 			return errors.New(errMsg + " " + errBlk.ErrMsg) // applies only if in test
 		} else {


### PR DESCRIPTION
JACOBIN-528: Solve byte case of formatting string output with specifier %x
Its a one-line fix in function sprintf of javaLangString.go. See line 527.

JACOBIN-529: Identify class and method of G function in error message.