### PR TITLE
JACOBIN-531 Maintenance on classes java/lang/Long and java/util/Random

### DIFF
--- a/src/gfunction/javaLangLong.go
+++ b/src/gfunction/javaLangLong.go
@@ -53,6 +53,12 @@ func Load_Lang_Long() {
 			GFunction:  longToHexString,
 		}
 
+	MethodSignatures["java/lang/Long.toString(J)Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  longToString,
+		}
+
 	MethodSignatures["java/lang/Long.valueOf(J)Ljava/lang/Long;"] =
 		GMeth{
 			ParamSlots: 2,
@@ -108,6 +114,14 @@ func longToHexString(params []interface{}) interface{} {
 	int64Value := params[0].(int64)
 	uint64Value := uint64(int64Value)
 	str := fmt.Sprintf("%016x", uint64Value)
+	obj := object.StringObjectFromGoString(str)
+	return obj
+}
+
+// "java/lang/Long.toString(J)Ljava/lang/String;"
+func longToString(params []interface{}) interface{} {
+	int64Value := params[0].(int64)
+	str := fmt.Sprintf("%d", int64Value)
 	obj := object.StringObjectFromGoString(str)
 	return obj
 }

--- a/src/gfunction/javaUtilRandom.go
+++ b/src/gfunction/javaUtilRandom.go
@@ -64,7 +64,7 @@ func Load_Util_Random() {
 	MethodSignatures["java/util/Random.nextInt()I"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  randomNextInt,
+			GFunction:  randomNextIntLong,
 		}
 
 	MethodSignatures["java/util/Random.nextInt(I)I"] =
@@ -76,13 +76,7 @@ func Load_Util_Random() {
 	MethodSignatures["java/util/Random.nextLong()J"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  randomNextLong,
-		}
-
-	MethodSignatures["java/util/Random.nextLong(J)J"] =
-		GMeth{
-			ParamSlots: 2,
-			GFunction:  randomNextLongBound,
+			GFunction:  randomNextIntLong,
 		}
 
 	MethodSignatures["java/util/Random.setSeed(J)V"] =
@@ -169,9 +163,9 @@ func randomSetSeed(params []interface{}) interface{} {
 	return nil
 }
 
-// randomNextInt returns the next pseudorandom, uniformly distributed int64 value.
+// randomNextIntLong returns the next pseudorandom, uniformly distributed int64 value.
 // ChatGPT: func (r *Random) NextInt() int {
-func randomNextInt(params []interface{}) interface{} {
+func randomNextIntLong(params []interface{}) interface{} {
 	obj := params[0].(*object.Object)
 	r := GetStructFromRandomObject(obj)
 	output := r.rand.Int63()
@@ -181,28 +175,6 @@ func randomNextInt(params []interface{}) interface{} {
 // randomNextIntBound returns a pseudorandom, uniformly distributed int value between 0 (inclusive) and bound (exclusive).
 // ChatGPT: func (r *Random) NextIntBound(bound int) int, error {
 func randomNextIntBound(params []interface{}) interface{} {
-	obj := params[0].(*object.Object)
-	r := GetStructFromRandomObject(obj)
-	bound := params[1].(int64)
-	if bound < 1 {
-		errMsg := fmt.Sprintf("Bound must be positive, observed: %d", bound)
-		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
-	}
-	output := r.rand.Int63n(bound)
-	return output
-}
-
-// randomNextLong is identical to randomNextInt.
-// ChatGPT: func (r *Random) NextLong() int64 {
-func randomNextLong(params []interface{}) interface{} {
-	obj := params[0].(*object.Object)
-	r := GetStructFromRandomObject(obj)
-	output := r.rand.Int63()
-	return output
-}
-
-// randomNextLongBound returns a pseudorandom, uniformly distributed long value between 0 (inclusive) and bound (exclusive).
-func randomNextLongBound(params []interface{}) interface{} {
 	obj := params[0].(*object.Object)
 	r := GetStructFromRandomObject(obj)
 	bound := params[1].(int64)


### PR DESCRIPTION
* Add a Long.toString function for some jacotest cases.
* There was no need to have two golang functions for both Random.nextInt and Random.nextLong. The two method signatures can map to a single function.
* There was never a reason to have a randomNextLongBound function since there is no such API. The method signature and function should be deleted.