### PR TITLE
JACOBIN-525 add Integer.parseInt(string without radix)

### DIFF
--- a/src/gfunction/javaLangInteger.go
+++ b/src/gfunction/javaLangInteger.go
@@ -61,7 +61,7 @@ func Load_Lang_Integer() {
 
 	MethodSignatures["java/lang/Integer.parseInt(Ljava/lang/String;)I"] =
 		GMeth{
-			ParamSlots: 2,
+			ParamSlots: 1,
 			GFunction:  integerParseInt,
 		}
 

--- a/src/gfunction/javaLangInteger.go
+++ b/src/gfunction/javaLangInteger.go
@@ -59,10 +59,16 @@ func Load_Lang_Integer() {
 			GFunction:  integerIntLongValue,
 		}
 
-	MethodSignatures["java/lang/Integer.parseInt(Ljava/lang/String;I)I"] =
+	MethodSignatures["java/lang/Integer.parseInt(Ljava/lang/String;)I"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  integerParseInt,
+		}
+
+	MethodSignatures["java/lang/Integer.parseInt(Ljava/lang/String;I)I"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  integerParseIntRadix,
 		}
 
 	MethodSignatures["java/lang/Integer.valueOf(I)Ljava/lang/Integer;"] =
@@ -165,8 +171,34 @@ func integerIntLongValue(params []interface{}) interface{} {
 	return ii
 }
 
-// "java/lang/Integer.parseInt(Ljava/lang/String;I)I"
+// "java/lang/Integer.parseInt(Ljava/lang/String;)I"
+// Radix = 10
 func integerParseInt(params []interface{}) interface{} {
+	// Extract and validate the string argument.
+	parmObj := params[0].(*object.Object)
+	strArg := object.GoStringFromStringObject(parmObj)
+	if len(strArg) < 1 {
+		return getGErrBlk(excNames.NumberFormatException, "String length is zero")
+	}
+
+	// Replace a leading "#" with "0x" in strArg.
+	if strings.HasPrefix(strArg, "#") {
+		strArg = strings.Replace(strArg, "#", "0x", 1)
+	}
+
+	// Compute output.
+	output, err := strconv.ParseInt(strArg, 10, 64)
+	if err != nil {
+		errMsg := fmt.Sprintf("strconv.ParseInt(%s,10,64) failed, reason: %s", strArg, err.Error())
+		return getGErrBlk(excNames.NumberFormatException, errMsg)
+	}
+
+	// Return computed value.
+	return output
+}
+
+// "java/lang/Integer.parseInt(Ljava/lang/String;I)I"
+func integerParseIntRadix(params []interface{}) interface{} {
 	// Extract and validate the string argument.
 	parmObj := params[0].(*object.Object)
 	strArg := object.GoStringFromStringObject(parmObj)


### PR DESCRIPTION
It turns out that the we did not have a G function for "java/lang/Integer.parseInt(Ljava/lang/String;)I" (no radix specified). This gave us questionable results by using the OpenJDK JVM library function.

This has been added as a G function.