### PR TITLE
JACOBIN-544 : Resurrect missing NeedsContext code in runGfunction

### DIFF
--- a/src/jvm/gfunctionExec.go
+++ b/src/jvm/gfunctionExec.go
@@ -41,6 +41,14 @@ func runGfunction(mt classloader.MTentry, fs *list.List,
 	params *[]interface{}, objRef bool) any {
 
 	f := fs.Front().Value.(*frames.Frame)
+
+	// If the method needs context (i.e., if mt.Meth.NeedsContext == true),
+	// then add pointer to the JVM frame stack to the parameter list here.
+	entry := mt.Meth.(gfunction.GMeth)
+	if entry.NeedsContext {
+		*params = append(*params, fs)
+	}
+
 	var paramCount int
 	if params == nil {
 		paramCount = 0


### PR DESCRIPTION
See YouTrack.
One file impacted: runGfunction.go