### PR TITLE
JACOBIN-547 Incremental fixes to support stringer-1

### DIFF
--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -297,6 +297,13 @@ func Load_Lang_String() {
 			GFunction:  stringReplaceCC,
 		}
 
+	// Split a string into an array of strings.
+	MethodSignatures["java/lang/String.split(Ljava/lang/String;)[Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringSplit,
+		}
+
 	// Return a string in all lower case, using the reference object string as input.
 	MethodSignatures["java/lang/String.substring(I)Ljava/lang/String;"] =
 		GMeth{
@@ -853,6 +860,22 @@ func stringReplaceCC(params []interface{}) interface{} {
 	// Return final string in an object.
 	obj := object.StringObjectFromGoString(newStr)
 	return obj
+
+}
+
+// "java/lang/String.split(Ljava/lang/String;)[Ljava/lang/String;"
+func stringSplit(params []interface{}) interface{} {
+	// params[0] = base string
+	// params[1] = regular expression in a string
+	// TODO: As of 2024-07-10, a string, not a regular expression, is assumed to be in params[1].
+	oldStr := object.GoStringFromStringObject(params[0].(*object.Object))
+	splitter := object.GoStringFromStringObject(params[1].(*object.Object))
+	newStrArray := strings.Split(oldStr, splitter)
+	var outObjArray []*object.Object
+	for ix := 0; ix < len(newStrArray); ix++ {
+		outObjArray = append(outObjArray, object.StringObjectFromGoString(newStrArray[ix]))
+	}
+	return populator("[Ljava/lang/String;", types.RefArray, outObjArray)
 
 }
 

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -282,11 +282,19 @@ func Load_Lang_String() {
 			ParamSlots: 4,
 			GFunction:  stringRegionMatchesILII,
 		}
+
 	// Returns a string whose value is the concatenation of this string repeated the specified number of times.
 	MethodSignatures["java/lang/String.repeat(I)Ljava/lang/String;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  stringRepeat,
+		}
+
+	// Replace a single character by another in the given string.
+	MethodSignatures["java/lang/String.replace(CC)Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringReplaceCC,
 		}
 
 	// Return a string in all lower case, using the reference object string as input.
@@ -827,6 +835,22 @@ func stringRepeat(params []interface{}) interface{} {
 	}
 
 	// Return new string in an object.
+	obj := object.StringObjectFromGoString(newStr)
+	return obj
+
+}
+
+// "java/lang/String.replace(CC)Ljava/lang/String;"
+func stringReplaceCC(params []interface{}) interface{} {
+	// params[0] = base string
+	// params[1] = character to be replaced
+	// params[2] = replacement character
+	str := object.GoStringFromStringObject(params[0].(*object.Object))
+	oldChar := byte((params[1].(int64)) & 0xFF)
+	newChar := byte((params[2].(int64)) & 0xFF)
+	newStr := strings.ReplaceAll(str, string(oldChar), string(newChar))
+
+	// Return final string in an object.
 	obj := object.StringObjectFromGoString(newStr)
 	return obj
 

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -572,10 +572,15 @@ frameInterpreter:
 				index = int(f.Meth[f.PC+1])
 				f.PC += 1
 			}
-			f.Locals[index] = pop(f).(int64)
+			//f.Locals[index] = pop(f).(int64)
+			popped := pop(f)
+			f.Locals[index] = convertInterfaceToInt64(popped)
+
 			// longs and doubles are stored in localvar[x] and again in localvar[x+1]
 			if opcode == opcodes.LSTORE {
-				f.Locals[index+1] = pop(f).(int64)
+				//f.Locals[index+1] = pop(f).(int64)
+				popped := pop(f)
+				f.Locals[index+1] = convertInterfaceToInt64(popped)
 			}
 		case opcodes.FSTORE: //  0x38 (store popped top of stack float into local[index])
 			var index int

--- a/src/jvm/runUtils.go
+++ b/src/jvm/runUtils.go
@@ -90,6 +90,22 @@ func convertInterfaceToUint64(val interface{}) uint64 {
 	return 0
 }
 
+// converts an interface{} value into int64
+func convertInterfaceToInt64(arg interface{}) int64 {
+	switch t := arg.(type) {
+	case int64:
+		return t
+	case uint8:
+		return int64(t)
+	case uint32:
+		return int64(t)
+	default:
+		errMsg := fmt.Sprintf("convertInterfaceToInt64: Invalid argument type: %T", arg)
+		exceptions.ThrowEx(excNames.InvalidTypeException, errMsg, nil)
+	}
+	return 0
+}
+
 // Convert an interface{} consisting of some integral value to int64.
 // Appears primarily in the runFrame{} IF* bytecodes.
 func convertIntegralValueToInt64(arg interface{}) int64 {


### PR DESCRIPTION
* jvm/run.go - ISTORE lines 575 and 578 expanded to tolerate non-int64 integers.
* jvm/runUtils.go - new function `convertInterfaceToInt64` (called in ISTORE).
* gfunction/javaLangString.go - new G functions replaceCC and split.
