### PR TITLE
JACOBIN-548 jacotest case fits: failing on deprecated security

### DIFF
--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -48,12 +48,6 @@ func Load_Traps() {
 			GFunction:  trapFunction,
 		}
 
-	MethodSignatures["java/io/FileDescriptor.<clinit>()V"] =
-		GMeth{
-			ParamSlots: 0,
-			GFunction:  trapClass,
-		}
-
 	MethodSignatures["java/io/FileSystem.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,

--- a/src/gfunction/javaIoRandomAccessFile.go
+++ b/src/gfunction/javaIoRandomAccessFile.go
@@ -6,6 +6,14 @@
 
 package gfunction
 
+import (
+	"fmt"
+	"jacobin/excNames"
+	"jacobin/object"
+	"jacobin/types"
+	"os"
+)
+
 func Load_Io_RandomAccessFile() {
 
 	MethodSignatures["java/io/RandomAccessFile.<clinit>()V"] =
@@ -14,9 +22,27 @@ func Load_Io_RandomAccessFile() {
 			GFunction:  justReturn,
 		}
 
+	MethodSignatures["java/io/RandomAccessFile.<init>(Ljava/lang/String;Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  rafInitString,
+		}
+
+	MethodSignatures["java/io/RandomAccessFile.<init>(Ljava/io/File;Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  rafInitFile,
+		}
+
+	MethodSignatures["java/io/RandomAccessFile.getFilePointer()J"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  rafGetFilePointer,
+		}
+
 	// ----------------------------------------------------------
-	// initIDs justReturn
-	// These are private functiona that calls C native functions.
+	// initIDs - justReturn
+	// This is a private function that call C native functions.
 	// ----------------------------------------------------------
 
 	MethodSignatures["java/io/RandomAccessFile.initIDs()V"] =
@@ -24,5 +50,113 @@ func Load_Io_RandomAccessFile() {
 			ParamSlots: 0,
 			GFunction:  justReturn,
 		}
+
+}
+
+// "java/io/RandomAccessFile.<init>(Ljava/lang/String;Ljava/lang/String;)V"
+// RandomAccessFile raf = new RandomAccessFile(Stringname, Stringmode);
+func rafInitString(params []interface{}) interface{} {
+
+	// Using the argument path string, open the file for read-only.
+	pathStr := object.GoStringFromStringObject(params[1].(*object.Object))
+
+	// Mode.
+	var modeInt int
+	modeStr := object.GoStringFromStringObject(params[2].(*object.Object))
+	switch modeStr {
+	case "r":
+		modeInt = os.O_RDONLY
+	case "rw", "rws", "rwd":
+		modeInt = os.O_RDWR | os.O_CREATE | os.O_APPEND
+	default:
+		errMsg := fmt.Sprintf("mode string (%s) invalid", modeStr)
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Open the file in the specified mode.
+	osFile, err := os.OpenFile(pathStr, modeInt, CreateFilePermissions)
+	if err != nil {
+		errMsg := fmt.Sprintf("os.OpenFile(%s) failed, reason: %s", pathStr, err.Error())
+		return getGErrBlk(excNames.IOException, errMsg)
+	}
+
+	// Copy the file path field into the RandomAccessFile object.
+	fld := object.Field{Ftype: types.ByteArray, Fvalue: []byte(pathStr)}
+	params[0].(*object.Object).FieldTable[FilePath] = fld
+
+	// Copy the file handle into the RandomAccessFile object.
+	fld = object.Field{Ftype: types.FileHandle, Fvalue: osFile}
+	params[0].(*object.Object).FieldTable[FileHandle] = fld
+
+	return nil
+
+}
+
+// "java/io/RandomAccessFile.<init>(Ljava/io/File;Ljava/lang/String;)V"
+// RandomAccessFile raf = new RandomAccessFile(Fileobject, Stringmode);
+func rafInitFile(params []interface{}) interface{} {
+
+	// Using the argument path string, open the file for read-only.
+	obj := params[1].(*object.Object)
+	fld, ok := obj.FieldTable[FilePath]
+	if !ok {
+		errMsg := "java/io/File object is missing the FilePath field"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	pathStr := string(fld.Fvalue.([]byte))
+
+	// Mode.
+	var modeInt int
+	modeStr := object.GoStringFromStringObject(params[2].(*object.Object))
+	switch modeStr {
+	case "r":
+		modeInt = os.O_RDONLY
+	case "rw", "rws", "rwd":
+		modeInt = os.O_RDWR | os.O_CREATE | os.O_APPEND
+	default:
+		errMsg := fmt.Sprintf("mode string (%s) invalid", modeStr)
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Open the file in the specified mode.
+	osFile, err := os.OpenFile(pathStr, modeInt, CreateFilePermissions)
+	if err != nil {
+		errMsg := fmt.Sprintf("os.Open(%s) failed, reason: %s", pathStr, err.Error())
+		return getGErrBlk(excNames.IOException, errMsg)
+	}
+
+	// Copy the file path field into the RandomAccessFile object.
+	fld = object.Field{Ftype: types.ByteArray, Fvalue: []byte(pathStr)}
+	params[0].(*object.Object).FieldTable[FilePath] = fld
+
+	// Copy the file handle into the RandomAccessFile object.
+	fld = object.Field{Ftype: types.FileHandle, Fvalue: osFile}
+	params[0].(*object.Object).FieldTable[FileHandle] = fld
+
+	return nil
+
+}
+
+// "java/io/RandomAccessFile.getFilePointer()J"
+// Get current file position (offset from the beginning of file).
+func rafGetFilePointer(params []interface{}) interface{} {
+
+	// Get the open file handle.
+	obj := params[0].(*object.Object)
+	fld, ok := obj.FieldTable[FileHandle]
+	if !ok {
+		errMsg := "java/io/RandomAccessFile object is missing the FileHandle field"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	var osFile *os.File = fld.Fvalue.(*os.File)
+
+	// Get the current position relative to the beginning of file.
+	posn, err := osFile.Seek(0, 1)
+	if err != nil {
+		errMsg := fmt.Sprintf("osFile.Seek(0, 1) failed, reason: %s", err.Error())
+		return getGErrBlk(excNames.IOException, errMsg)
+	}
+
+	return posn
 
 }

--- a/src/gfunction/javaLangStackTraceElement.go
+++ b/src/gfunction/javaLangStackTraceElement.go
@@ -10,6 +10,8 @@ import (
 	"container/list"
 	"fmt"
 	"jacobin/classloader"
+	"jacobin/excNames"
+	"jacobin/exceptions"
 	"jacobin/frames"
 	"jacobin/globals"
 	"jacobin/log"
@@ -156,7 +158,12 @@ func initStackTraceElement(ste *object.Object, frm *frames.Frame) {
 		if rawMethod.MType == 'G' { // nothing more to do if it's a native method
 			return
 		}
-		method := rawMethod.Meth.(classloader.JmEntry)
+		method, ok := rawMethod.Meth.(classloader.JmEntry)
+		if !ok {
+			errMsg := fmt.Sprintf("initStackTraceElement: %s.%s, Invalid operand type for rawMethod.Meth: %T",
+				util.ConvertInternalClassNameToUserFormat(frame.ClName), frame.MethName, rawMethod.Meth)
+			_ = exceptions.ThrowEx(excNames.InternalException, errMsg, &frame)
+		}
 		for i := 0; i < len(method.Attribs); i++ {
 			index := method.Attribs[i].AttrName
 			if method.Cp.Utf8Refs[index] == "LineNumberTable" {

--- a/src/gfunction/javaLangSystem.go
+++ b/src/gfunction/javaLangSystem.go
@@ -79,12 +79,6 @@ func Load_Lang_System() {
 			GFunction:  getProperty,
 		}
 
-	MethodSignatures["java/lang/System.registerNatives()V"] =
-		GMeth{
-			ParamSlots: 0,
-			GFunction:  justReturn,
-		}
-
 	MethodSignatures["java/lang/System.console()Ljava/io/Console;"] =
 		GMeth{
 			ParamSlots: 0,

--- a/src/gfunction/javaUtilLocale.go
+++ b/src/gfunction/javaUtilLocale.go
@@ -47,6 +47,12 @@ func Load_Util_Locale() {
 			GFunction:  getDefaultLocale,
 		}
 
+	MethodSignatures["java/util/Locale.getDefault(Ljava/util/Locale$Category;)Ljava/util/Locale;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  getDefaultLocale, // ignore input
+		}
+
 }
 
 // "java/util/Locale.<init>(Ljava/lang/String;)V"

--- a/src/gfunction/justReturn.go
+++ b/src/gfunction/justReturn.go
@@ -43,6 +43,12 @@ func Load_Just_Return() {
 			GFunction:  justReturn,
 		}
 
+	MethodSignatures["java/io/FileDescriptor.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
 	MethodSignatures["java/math/MathContext.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
@@ -58,6 +64,24 @@ func Load_Just_Return() {
 	MethodSignatures["java/lang/AbstractStringBuilder.ensureCapacityInternal(I)V"] =
 		GMeth{
 			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkRead(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/System.getSecurityManager()Ljava/lang/SecurityManager;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/System.registerNatives()V"] =
+		GMeth{
+			ParamSlots: 0,
 			GFunction:  justReturn,
 		}
 

--- a/src/gfunction/justReturn.go
+++ b/src/gfunction/justReturn.go
@@ -85,4 +85,16 @@ func Load_Just_Return() {
 			GFunction:  justReturn,
 		}
 
+	MethodSignatures["java/util/Locale$Category.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/util/Locale$Category.<init>(Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 6,
+			GFunction:  justReturn,
+		}
+
 }


### PR DESCRIPTION
Fixed in this PR.
Jacotest case fits is moved along to failing in java/text/SimpleDateFormat.