### PR TITLE
JACOBIN-549 System.getSecurityManager --> null

### DIFF
--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -198,3 +198,8 @@ func eofGet(obj *object.Object) bool {
 	}
 	return value
 }
+
+// Return a null object.
+func returnNullObject(params []interface{}) interface{} {
+	return object.Null
+}

--- a/src/gfunction/javaLangSystem.go
+++ b/src/gfunction/javaLangSystem.go
@@ -91,6 +91,12 @@ func Load_Lang_System() {
 			GFunction:  clinit,
 		}
 
+	MethodSignatures["java/lang/System.getSecurityManager()Ljava/lang.SecurityManager;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  returnNullObject,
+		}
+
 }
 
 /*

--- a/src/jvm/gfunctionExec.go
+++ b/src/jvm/gfunctionExec.go
@@ -60,7 +60,7 @@ func runGfunction(mt classloader.MTentry, fs *list.List,
 	if MainThread.Trace {
 		traceInfo := fmt.Sprintf("runGfunction: %s, objectRef: %v, paramSlots: %d",
 			fullMethName, objRef, paramCount)
-		_ = log.Log(traceInfo, log.FINE)
+		_ = log.Log(traceInfo, log.TRACE_INST)
 		logTraceStack(f)
 	}
 


### PR DESCRIPTION
Trying to head off access to deprecated classes and functions related to the deprecated Java security management.
E.g. There are OpenJDK library functions that call System.getSecurityManager.
Strategy: return null.