### PR TITLE
JACOBIN-557 In most cases, VirtualMachineError --> InternalException

### DIFF
--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -186,12 +186,6 @@ func Load_Traps() {
 			GFunction:  trapFunction,
 		}
 
-	MethodSignatures["jdk/internal/access/SharedSecrets.<clinit>()V"] =
-		GMeth{
-			ParamSlots: 1,
-			GFunction:  trapClass,
-		}
-
 }
 
 // Generic trap for classes

--- a/src/gfunction/javaLangMath.go
+++ b/src/gfunction/javaLangMath.go
@@ -221,7 +221,7 @@ func mathClinit([]interface{}) interface{} {
 	if klass == nil {
 		errMsg := "Math<clinit>: Expected java/lang/Math to be in the MethodArea, but it was not"
 		_ = log.Log(errMsg, log.SEVERE)
-		return getGErrBlk(excNames.VirtualMachineError, errMsg)
+		return getGErrBlk(excNames.InternalException, errMsg)
 	}
 	return nil
 }

--- a/src/gfunction/javaUtilHashMap.go
+++ b/src/gfunction/javaUtilHashMap.go
@@ -47,7 +47,7 @@ func hashMapHash(params []interface{}) interface{} {
 			binary.BigEndian.PutUint64(bytes, uint64(fld.Fvalue.(float64)))
 		default:
 			str := fmt.Sprintf("Unrecognized object field type: %T", fld.Ftype)
-			return getGErrBlk(excNames.VirtualMachineError, str)
+			return getGErrBlk(excNames.IllegalArgumentException, str)
 		}
 		roughHash := md5.Sum(bytes)            // md5.sum returns an array of bytes
 		hash := roughHash[:]                   // convert the array to a slice
@@ -55,7 +55,7 @@ func hashMapHash(params []interface{}) interface{} {
 		return int64(uHash)                    // return an int64
 	default:
 		str := fmt.Sprintf("hashMapHash: unrecognized parameter type: %T", params[0])
-		return getGErrBlk(excNames.VirtualMachineError, str)
+		return getGErrBlk(excNames.IllegalArgumentException, str)
 	}
 	return hashValue
 }

--- a/src/gfunction/justReturn.go
+++ b/src/gfunction/justReturn.go
@@ -91,4 +91,10 @@ func Load_Just_Return() {
 			GFunction:  justReturn,
 		}
 
+	MethodSignatures["jdk/internal/access/SharedSecrets.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
 }

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -881,7 +881,7 @@ frameInterpreter:
 			if f.TOS < 0 {
 				errMsg := fmt.Sprintf("stack underflow in POP in %s.%s",
 					util.ConvertInternalClassNameToUserFormat(f.ClName), f.MethName)
-				status := exceptions.ThrowEx(excNames.VirtualMachineError, errMsg, f)
+				status := exceptions.ThrowEx(excNames.InternalException, errMsg, f)
 				if status != exceptions.Caught {
 					return errors.New(errMsg) // applies only if in test
 				}
@@ -892,7 +892,7 @@ frameInterpreter:
 			if f.TOS < 1 {
 				errMsg := fmt.Sprintf("stack underflow in POP2 in %s.%s",
 					util.ConvertInternalClassNameToUserFormat(f.ClName), f.MethName)
-				status := exceptions.ThrowEx(excNames.VirtualMachineError, errMsg, f)
+				status := exceptions.ThrowEx(excNames.InternalException, errMsg, f)
 				if status != exceptions.Caught {
 					return errors.New(errMsg) // applies only if in test
 				}
@@ -1929,7 +1929,7 @@ frameInterpreter:
 			if !ok {
 				errMsg := fmt.Sprintf("GETFIELD PC=%d: Missing field (%s) in FieldTable for %s.%s%s",
 					f.PC, fieldName, f.ClName, f.MethName, f.MethType)
-				status := exceptions.ThrowEx(excNames.VirtualMachineError, errMsg, f)
+				status := exceptions.ThrowEx(excNames.IllegalArgumentException, errMsg, f)
 				if status != exceptions.Caught {
 					return errors.New(errMsg) // applies only if in test
 				}
@@ -2729,7 +2729,7 @@ frameInterpreter:
 			default:
 				glob.ErrorGoStack = string(debug.Stack())
 				errMsg := fmt.Sprintf("ARRAYLENGTH: Invalid ref.(type): %T", ref)
-				status := exceptions.ThrowEx(excNames.VirtualMachineError, errMsg, f)
+				status := exceptions.ThrowEx(excNames.IllegalArgumentException, errMsg, f)
 				if status != exceptions.Caught {
 					return errors.New(errMsg) // applies only if in test
 				}

--- a/src/jvm/runUtils.go
+++ b/src/jvm/runUtils.go
@@ -252,7 +252,7 @@ func pop(f *frames.Frame) interface{} {
 	if f.TOS == -1 {
 		errMsg := fmt.Sprintf("stack underflow in pop() in %s.%s",
 			util.ConvertInternalClassNameToUserFormat(f.ClName), f.MethName)
-		status := exceptions.ThrowEx(excNames.VirtualMachineError, errMsg, f)
+		status := exceptions.ThrowEx(excNames.InternalException, errMsg, f)
 		if status != exceptions.Caught {
 			return nil // applies only if in test
 		}
@@ -310,7 +310,7 @@ func peek(f *frames.Frame) interface{} {
 	if f.TOS == -1 {
 		errMsg := fmt.Sprintf("stack underflow in peek() in %s.%s",
 			util.ConvertInternalClassNameToUserFormat(f.ClName), f.MethName)
-		status := exceptions.ThrowEx(excNames.VirtualMachineError, errMsg, f)
+		status := exceptions.ThrowEx(excNames.InternalException, errMsg, f)
 		if status != exceptions.Caught {
 			return nil // applies only if in test
 		}


### PR DESCRIPTION
- Mostly, as we discussed in email.
- In one case, the op code argument was illegal so, ```IllegalArgumentException```; in another, a required field was missing so ditto.
- "jdk/internal/access/SharedSecrets.<clinit>()V": trap --> justReturn.