### PR TITLE
JACOBIN-561 Migrate use of InternalError to InternalException

### DIFF
--- a/src/exceptions/catchFrame.go
+++ b/src/exceptions/catchFrame.go
@@ -58,12 +58,12 @@ func locateExceptionFrame(f *frames.Frame, excName string, pc int) (*frames.Fram
 	methEntry, found := classloader.MTable[fullMethName]
 	if !found {
 		errMsg := fmt.Sprintf("locateExceptionFrame: Method %s not found in MTable", fullMethName)
-		minimalAbort(excNames.InternalError, errMsg)
+		minimalAbort(excNames.InternalException, errMsg)
 	}
 
 	if methEntry.MType != 'J' {
 		errMsg := fmt.Sprintf("locateExceptionFrame: Method %s is a native method", fullMethName)
-		minimalAbort(excNames.InternalError, errMsg)
+		minimalAbort(excNames.InternalException, errMsg)
 	}
 
 	method := methEntry.Meth.(classloader.JmEntry)

--- a/src/gfunction/testGfunctions.go
+++ b/src/gfunction/testGfunctions.go
@@ -159,7 +159,7 @@ func ld(params []any) any {
 }
 
 func ie(params []any) any {
-	geb := GErrBlk{excNames.InternalError, "intended return of test error"}
+	geb := GErrBlk{excNames.InternalException, "intended return of test error"}
 	return &geb
 }
 


### PR DESCRIPTION
Impacted source code:

	modified:   exceptions/catchFrame.go
	modified:   gfunction/testGfunctions.go
