### PR TITLE
JACOBIN-547 mostly StringBuilder append

### DIFF
--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -144,24 +144,6 @@ func Load_Traps() {
 			GFunction:  trapDeprecated,
 		}
 
-	MethodSignatures["java/lang/StringBuilder.<init>(I)V"] =
-		GMeth{
-			ParamSlots: 0,
-			GFunction:  trapFunction,
-		}
-
-	MethodSignatures["java/lang/StringBuilder.<init>(Ljava/lang/CharSequence;)V"] =
-		GMeth{
-			ParamSlots: 0,
-			GFunction:  trapFunction,
-		}
-
-	MethodSignatures["java/lang/StringBuilder.<init>(Ljava/lang/String;)V"] =
-		GMeth{
-			ParamSlots: 0,
-			GFunction:  trapFunction,
-		}
-
 	MethodSignatures["java/nio/charset/Charset.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,

--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -113,7 +113,8 @@ func MTableLoadGFunctions(MTable *classloader.MT) {
 	Load_Nio_Charset_Charset()
 
 	// java/security/*
-	// Load_Security_SecureRandom()
+	// Load_Security_SecureRandom() <--------------- TODO
+	Load_Security_AccessController()
 
 	// java/util/*
 	Load_Util_Concurrent_Atomic_AtomicInteger()

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -307,14 +307,14 @@ func Load_Lang_String() {
 			GFunction:  stringSplit,
 		}
 
-	// Return a string in all lower case, using the reference object string as input.
+	// Return a substring starting at the given index of the byte array.
 	MethodSignatures["java/lang/String.substring(I)Ljava/lang/String;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  substringToTheEnd,
 		}
 
-	// Return a string in all lower case, using the reference object string as input.
+	// Return a substring starting at the given index of the byte array of the given length.
 	MethodSignatures["java/lang/String.substring(II)Ljava/lang/String;"] =
 		GMeth{
 			ParamSlots: 2,
@@ -335,14 +335,14 @@ func Load_Lang_String() {
 			GFunction:  toLowerCase,
 		}
 
-	// Return a string in all lower case, using the reference object string as input.
+	// Return a string in all upper case, using the reference object string as input.
 	MethodSignatures["java/lang/String.toUpperCase()Ljava/lang/String;"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  toUpperCase,
 		}
 
-	// Return a string in all lower case, using the reference object string as input.
+	// Return a string trimmed of leading and trailing whitespace.
 	MethodSignatures["java/lang/String.trim()Ljava/lang/String;"] =
 		GMeth{
 			ParamSlots: 0,

--- a/src/gfunction/javaLangStringBuilder.go
+++ b/src/gfunction/javaLangStringBuilder.go
@@ -10,11 +10,160 @@ import (
 	"fmt"
 	"jacobin/excNames"
 	"jacobin/object"
+	"jacobin/types"
 )
 
 // Implementation of some of the functions in Java/lang/Class.
 
 func Load_Lang_StringBuilder() {
+
+	// === Instantiation ===
+
+	MethodSignatures["java/lang/StringBuilder.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.<init>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  stringBuilderInit,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.<init>(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBuilderInit,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.<init>(Ljava/lang/CharSequence;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.<init>(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBuilderInitString,
+		}
+
+	// === Methods ===
+
+	MethodSignatures["java/lang/StringBuilder.append(Z)Ljava/lang/StringBuilder;"] = // append boolean
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBuilderAppendBoolean,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.append(C)Ljava/lang/StringBuilder;"] = // append char
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBuilderAppend,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.append([C)Ljava/lang/StringBuilder;"] = // append char array
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBuilderAppend,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.append([CII)Ljava/lang/StringBuilder;"] = // append subset of char array
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.append(D)Ljava/lang/StringBuilder;"] = // append double
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderAppend,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.append(F)Ljava/lang/StringBuilder;"] = // append float
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBuilderAppend,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.append(I)Ljava/lang/StringBuilder;"] = // append integer
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBuilderAppend,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.append(J)Ljava/lang/StringBuilder;"] = // append long
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderAppend,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.append(Ljava/lang/CharSequence;)Ljava/lang/StringBuilder;"] = // append char seq
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.append(Ljava/lang/CharSequence;II)Ljava/lang/StringBuilder;"] = // append char seq
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.append(Ljava/lang/Object;)Ljava/lang/StringBuilder;"] = // append object
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBuilderAppend,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.append(Ljava/lang/Object;)Ljava/lang/StringBuilder;"] = // append string
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBuilderAppend,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;"] = // append string
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBuilderAppend,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.append(Ljava/lang/StringBuffer;)Ljava/lang/StringBuilder;"] = // append stringBuffer
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBuilderAppend,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.appendCodePoint(I)Ljava/lang/StringBuilder;"] = // append CodePoint
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.capacity()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  stringBuilderCapacity,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.chars()Ljava/util/stream/IntStream;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.codePoints()Ljava/util/stream/IntStream;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.length()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  stringBuilderLength,
+		}
 
 	MethodSignatures["java/lang/StringBuilder.isLatin1()Z"] =
 		GMeth{
@@ -22,25 +171,200 @@ func Load_Lang_StringBuilder() {
 			GFunction:  returnTrue,
 		}
 
-	MethodSignatures["java/lang/StringBuilder.append(Ljava/lang/Object;)Ljava/lang/StringBuilder;"] =
+	MethodSignatures["java/lang/StringBuilder.subSequence(II)Ljava/lang/CharSequence;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	// Return a substring starting at the given index of the byte array.
+	MethodSignatures["java/lang/StringBuilder.substring(I)Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  substringToTheEnd, // javaLangString.go
+		}
+
+	// Return a substring starting at the given index of the byte array of the given length.
+	MethodSignatures["java/lang/StringBuilder.substring(II)Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  substringStartEnd, // javaLangString.go
+		}
+
+	MethodSignatures["java/lang/StringBuilder.toString()Ljava/lang/String;"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  stringBuilderAppendObject,
+			GFunction:  stringBuilderToString,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.trimToSize()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
 		}
 
 }
 
-// "java/lang/StringBuilder.append(Ljava/lang/Object;)Ljava/lang/StringBuilder;"
-// Appends the string representation of the Object argument.
-// The overall effect is exactly as if the argument were converted to
-// a string by the method String.valueOf(Object), and the characters of that string
-// were then appended to this character sequence.
-func stringBuilderAppendObject(params []interface{}) interface{} {
-	// params[0]: input StringBuilder Object
-	inObj := params[0].(*object.Object)
-	str := object.ObjectFieldToString(inObj, "value")
-	errMsg := fmt.Sprintf("Not working yet. Object: %s", str)
-	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
+var classStringBuilder = "java/lang/StringBuilder"
 
-	//return nil
+// Initialise StringBuilder with or without a capacity integer (ignored).
+func stringBuilderInit(params []any) any {
+	// Get File object and initialise the field map.
+	obj := params[0].(*object.Object)
+	obj.FieldTable = make(map[string]object.Field)
+
+	// Set the count = 0.
+	fld := object.Field{Ftype: types.Int, Fvalue: int64(0)}
+	obj.FieldTable["count"] = fld
+
+	// Set the value = nil byte array.
+	fld = object.Field{Ftype: types.ByteArray, Fvalue: make([]byte, 0)}
+	obj.FieldTable["value"] = fld
+
+	// Set the capacity field value even though it is always ignored.
+	var capacity int64
+	if len(params) > 1 { // Was a capacity parameter supplied?
+		capacity = params[1].(int64)
+	} else {
+		capacity = 16 // default capacity value per API
+	}
+	fld = object.Field{Ftype: types.Int, Fvalue: capacity}
+	obj.FieldTable["capacity"] = fld
+
+	return nil
+}
+
+// Initialise StringBuilder with a String object.
+func stringBuilderInitString(params []any) any {
+	// Get File object and initialise the field map.
+	obj := params[0].(*object.Object)
+	obj.FieldTable = make(map[string]object.Field)
+
+	var byteArray []byte
+	var ok bool
+	switch params[1].(type) {
+	case *object.Object: // String
+		byteArray, ok = params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
+		if !ok {
+			errMsg := "Value field missing in <init> object argument or the field is not a byte array"
+			return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+		}
+	default:
+		errMsg := fmt.Sprintf("Parameter type (%T) is illegal", params[1])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Append parmArray to the byteArray.
+	// Set the byte count.
+	obj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
+	obj.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: int64(len(byteArray))}
+
+	return nil
+}
+
+// Append the second parameter to the bytes in the StringBuilder that is
+// passed in the objectRef parameter (the first param).
+func stringBuilderAppend(params []any) any {
+	// Get base object and its value field, byteArray.
+	objBase := params[0].(*object.Object)
+	byteArray := objBase.FieldTable["value"].Fvalue.([]byte)
+
+	// Initialise the output object.
+	objOut := object.MakeEmptyObjectWithClassName(&classStringBuilder)
+	objOut.FieldTable = objBase.FieldTable
+
+	var parmArray []byte
+	var ok bool
+	switch params[1].(type) {
+	case *object.Object: // String, StringBuffer, or StringBuilder
+		parmArray, ok = params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
+		if !ok {
+			errMsg := "Value field missing in append object argument or the field is not a byte array"
+			return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+		}
+	case int64: // character, integer, long
+		str := fmt.Sprintf("%d", params[1].(int64))
+		parmArray = []byte(str)
+	case []int64: // character array
+		for ii := range params[1].([]int64) {
+			parmArray = append(parmArray, byte(ii))
+		}
+	case float64: // float, double
+		ff := params[1].(float64)
+		form := getDoubleFormat(ff)
+		str := fmt.Sprintf(form, ff)
+		parmArray = []byte(str)
+	default:
+		errMsg := fmt.Sprintf("Parameter type (%T) is illegal", params[1])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Append parmArray to the byteArray.
+	// Set the byte count.
+	byteArray = append(byteArray, parmArray...)
+	objOut.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
+	objOut.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: int64(len(byteArray))}
+
+	return objOut
+}
+
+// Append the second parameter (boolean) to the bytes in the StringBuilder that is
+// passed in the objectRef parameter (the first param).
+func stringBuilderAppendBoolean(params []any) any {
+	// Get base object and its value field, byteArray.
+	objBase := params[0].(*object.Object)
+	byteArray := objBase.FieldTable["value"].Fvalue.([]byte)
+
+	// Initialise the output object.
+	objOut := object.MakeEmptyObjectWithClassName(&classStringBuilder)
+	objOut.FieldTable = objBase.FieldTable
+
+	var parmArray []byte
+	switch params[1].(type) {
+	case int64: // boolean
+		var str string
+		if params[1].(int64) == types.JavaBoolTrue {
+			str = "true"
+		} else {
+			str = "false"
+		}
+		parmArray = []byte(str)
+	default:
+		errMsg := fmt.Sprintf("Parameter type (%T) is illegal", params[1])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Append parmArray to the byteArray.
+	// Set the byte count.
+	byteArray = append(byteArray, parmArray...)
+	objOut.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
+	objOut.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: int64(len(byteArray))}
+
+	return objOut
+}
+
+// Convert the byte array of a StringBuilder object to a String object. Then, return it.
+func stringBuilderToString(params []any) any {
+	objBase := params[0].(*object.Object)
+	byteArray := objBase.FieldTable["value"].Fvalue.([]byte)
+	objOut := object.StringObjectFromGoString(string(byteArray))
+	return objOut
+}
+
+// Return the StringBuilder object capacity or count, whichever is larger.
+// Note: This is what the OpenJDK JVM does.
+func stringBuilderCapacity(params []any) any {
+	objBase := params[0].(*object.Object)
+	capacity := objBase.FieldTable["capacity"].Fvalue.(int64)
+	count := objBase.FieldTable["count"].Fvalue.(int64)
+	if count > capacity {
+		capacity = count
+	}
+	return capacity
+}
+
+// Return the StringBuilder object length.
+func stringBuilderLength(params []any) any {
+	objBase := params[0].(*object.Object)
+	return objBase.FieldTable["count"].Fvalue.(int64)
 }

--- a/src/gfunction/javaSecurityAccessController.go
+++ b/src/gfunction/javaSecurityAccessController.go
@@ -1,0 +1,23 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2024 by  the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package gfunction
+
+func Load_Security_AccessController() {
+
+	MethodSignatures["java/security/AccessController.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/security/AccessController.doPrivileged(Ljava/security/PrivilegedAction;)Ljava/lang/Object;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  returnNullObject,
+		}
+
+}

--- a/src/object/string.go
+++ b/src/object/string.go
@@ -163,11 +163,11 @@ func ObjectFieldToString(obj *Object, fieldName string) string {
 		return "null"
 	}
 
-	// If the field is missing, give a warning and return a 0-length string.
+	// If the field is missing, give a warning (if tracing) and return a 0-length string.
 	fld, ok := obj.FieldTable[fieldName]
 	if !ok {
 		warnMsg := fmt.Sprintf("ObjectFieldToString: field \"%s\" was not found. Returning \"null\"", fieldName)
-		_ = log.Log(warnMsg, log.WARNING)
+		_ = log.Log(warnMsg, log.TRACE_INST)
 		return "null"
 	}
 

--- a/src/object/string.go
+++ b/src/object/string.go
@@ -78,10 +78,19 @@ func StringObjectFromGoString(str string) *Object {
 
 // GoStringFromStringObject: convenience method to extract a Go string from a String object (Java string)
 func GoStringFromStringObject(obj *Object) string {
-	if obj != nil && obj.KlassName == types.StringPoolStringIndex {
-		if len(obj.FieldTable["value"].Fvalue.([]byte)) > 0 {
-			return string(obj.FieldTable["value"].Fvalue.([]byte))
-		}
+	if IsNull(obj) {
+		return ""
+	}
+	fld, ok := obj.FieldTable["value"]
+	if !ok {
+		return ""
+	}
+	bytes, ok := fld.Fvalue.([]byte)
+	if !ok {
+		return ""
+	}
+	if len(bytes) > 0 {
+		return string(bytes)
 	}
 	return ""
 }
@@ -160,6 +169,8 @@ func IsStringObject(unknown any) bool {
 func ObjectFieldToString(obj *Object, fieldName string) string {
 	// If null, return a 0-length string.
 	if IsNull(obj) {
+		warnMsg := "ObjectFieldToString: object is null. Returning \"null\""
+		_ = log.Log(warnMsg, log.FINE)
 		return "null"
 	}
 
@@ -167,7 +178,7 @@ func ObjectFieldToString(obj *Object, fieldName string) string {
 	fld, ok := obj.FieldTable[fieldName]
 	if !ok {
 		warnMsg := fmt.Sprintf("ObjectFieldToString: field \"%s\" was not found. Returning \"null\"", fieldName)
-		_ = log.Log(warnMsg, log.TRACE_INST)
+		_ = log.Log(warnMsg, log.FINE)
 		return "null"
 	}
 
@@ -231,6 +242,6 @@ func ObjectFieldToString(obj *Object, fieldName string) string {
 	// None of the above.
 	warnMsg := fmt.Sprintf("ObjectFieldToString: field \"%s\" Ftype \"%s\" not yet supported. Returning the class name",
 		fieldName, fld.Ftype)
-	_ = log.Log(warnMsg, log.WARNING)
+	_ = log.Log(warnMsg, log.FINE)
 	return GoStringFromStringPoolIndex(obj.KlassName)
 }

--- a/src/object/string_test.go
+++ b/src/object/string_test.go
@@ -66,13 +66,9 @@ func TestStringObjectFromGoString(t *testing.T) {
 func TestGoStringFromInvalidStringObject(t *testing.T) {
 	globals.InitGlobals("test")
 	statics.LoadStaticsString()
-
-	constStr := "Mary had a little lamb whose fleece was white as snow."
-
-	strObj := StringObjectFromGoString(constStr)
-	strLit := "invalidString"
-	strObj.KlassName = stringPool.GetStringIndex(&strLit)
-	strValue := GoStringFromStringObject(strObj)
+	className := "Oregano"
+	obj := MakeEmptyObjectWithClassName(&className)
+	strValue := GoStringFromStringObject(obj)
 	if strValue != "" {
 		t.Errorf("expected empty string , observed: '%s'", strValue)
 	}


### PR DESCRIPTION
* Neutralize that pesky Java security access control.
* Allow StringBuilder and StringBuffer (upcoming) to leverage the object/*.go functions.
* ObjectFieldToString does not have to be a warning-blabbermouth; set the log level to FINE.