### PR TITLE
JACOBIN-547 implement various functions in javaLangStringBuilder.go and  javaLangStringBuffer.go

### DIFF
--- a/src/gfunction/javaLangInteger.go
+++ b/src/gfunction/javaLangInteger.go
@@ -71,6 +71,12 @@ func Load_Lang_Integer() {
 			GFunction:  integerParseIntRadix,
 		}
 
+	MethodSignatures["java/lang/Integer.signum(I)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  integerSignum,
+		}
+
 	MethodSignatures["java/lang/Integer.valueOf(I)Ljava/lang/Integer;"] =
 		GMeth{
 			ParamSlots: 1,
@@ -240,6 +246,19 @@ func integerParseIntRadix(params []interface{}) interface{} {
 
 	// Return computed value.
 	return output
+}
+
+// "java/lang/Integer.signum(I)I"
+func integerSignum(params []interface{}) interface{} {
+	int64Value := params[0].(int64)
+	switch {
+	case int64Value < 0:
+		return int64(-1)
+	case int64Value > 0:
+		return int64(+1)
+	default:
+		return int64(0)
+	}
 }
 
 // "java/lang/Integer.valueOf(I)Ljava/lang/Integer;"

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -147,7 +147,7 @@ func Load_Lang_String() {
 	MethodSignatures["java/lang/String.compareTo(Ljava/lang/String;)I"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  compareToCaseSensitive,
+			GFunction:  stringCompareToCaseSensitive,
 		}
 
 	// Compare 2 strings lexicographically, ignoring case (upper/lower).
@@ -157,7 +157,7 @@ func Load_Lang_String() {
 	MethodSignatures["java/lang/String.compareToIgnoreCase(Ljava/lang/String;)I"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  compareToIgnoreCase,
+			GFunction:  stringCompareToIgnoreCase,
 		}
 
 	MethodSignatures["java/lang/String.concat(Ljava/lang/String;)Ljava/lang/String;"] =
@@ -548,7 +548,7 @@ func stringCharAt(params []interface{}) interface{} {
 }
 
 // "java/lang/String.compareTo(Ljava/lang/String;)I"
-func compareToCaseSensitive(params []interface{}) interface{} {
+func stringCompareToCaseSensitive(params []interface{}) interface{} {
 	obj := params[0].(*object.Object)
 	str1 := object.GoStringFromStringObject(obj)
 	obj = params[1].(*object.Object)
@@ -563,7 +563,7 @@ func compareToCaseSensitive(params []interface{}) interface{} {
 }
 
 // "java/lang/String.compareToIgnoreCase(Ljava/lang/String;)I"
-func compareToIgnoreCase(params []interface{}) interface{} {
+func stringCompareToIgnoreCase(params []interface{}) interface{} {
 	obj := params[0].(*object.Object)
 	str1 := strings.ToLower(object.GoStringFromStringObject(obj))
 	obj = params[1].(*object.Object)

--- a/src/gfunction/javaLangStringBuffer.go
+++ b/src/gfunction/javaLangStringBuffer.go
@@ -1,17 +1,19 @@
 /*
  * Jacobin VM - A Java virtual machine
- * Copyright (c) 2024 by the Jacobin Authors. All rights reserved.
- * Licensed under Mozilla Public License 2.0 (MPL 2.0)  Consult jacobin.org.
+ * Copyright (c) 2023 by  the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
  */
 
 package gfunction
 
-import "jacobin/object"
+import (
+	"fmt"
+	"jacobin/excNames"
+	"jacobin/object"
+	"jacobin/types"
+)
 
-// Implement the minimum number of gfunctions to be able to run the java/lang/StringBuffer class,
-// which is the younger brother of java/lang/Stringbuilder. Both classes enable you to create
-// a String from an array of characters, but only StringBuffer is thread-safe.
-// see: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/StringBuffer.html
+// Implementation of some of the functions in Java/lang/Class.
 
 func Load_Lang_StringBuffer() {
 
@@ -26,78 +28,410 @@ func Load_Lang_StringBuffer() {
 	MethodSignatures["java/lang/StringBuffer.<init>()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  justReturn,
+			GFunction:  stringBufferInit,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.<init>(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBufferInit,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.<init>(Ljava/lang/CharSequence;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.<init>(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBufferInitString,
 		}
 
 	// === Methods ===
 
-	MethodSignatures["java/lang/StringBuffer.append(Ljava/lang/String;)Ljava/lang/StringBuffer;"] = // append string
+	MethodSignatures["java/lang/StringBuffer.append(Z)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  appendStringToStringBuffer,
+			GFunction:  stringBuilderAppendBoolean,
 		}
 
-	MethodSignatures["java/lang/StringBuffer.append([C)Ljava/lang/StringBuffer"] = // append char array
+	MethodSignatures["java/lang/StringBuffer.append(C)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  appendStringToStringBuffer,
+			GFunction:  stringBuilderAppendChar,
 		}
 
-	MethodSignatures["java/lang/StringBuffer.append(Ljava/lang/CharSequence;)Ljava/lang/StringBuffer"] = // append char seq
+	MethodSignatures["java/lang/StringBuffer.append([C)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  appendStringToStringBuffer,
-		}
-	MethodSignatures["java/lang/StringBuffer.append(Ljava/lang/Object;)Ljava/lang/StringBuffer;"] = // append object
-		GMeth{
-			ParamSlots: 1,
-			GFunction:  appendStringToStringBuffer,
+			GFunction:  stringBuilderAppend,
 		}
 
-	MethodSignatures["java/lang/StringBuffer.append(Ljava/lang/StringBuffer;)Ljava/lang/StringBuffer"] = // append stringBuffer
+	MethodSignatures["java/lang/StringBuffer.append([CII)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  stringBuilderAppend,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.append(D)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderAppend,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.append(F)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  appendStringToStringBuffer,
+			GFunction:  stringBuilderAppend,
 		}
+
+	MethodSignatures["java/lang/StringBuffer.append(I)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBuilderAppend,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.append(J)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderAppend,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.append(Ljava/lang/CharSequence;)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.append(Ljava/lang/CharSequence;II)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.append(Ljava/lang/Object;)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBuilderAppend,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.append(Ljava/lang/String;)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBuilderAppend,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.append(Ljava/lang/StringBuffer;)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBuilderAppend,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.appendCodePoint(I)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.capacity()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  stringBuilderCapacity,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.charAt(I)C"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBuilderCharAt,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.chars()Ljava/util/stream/IntStream;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.codePointAt(I)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.codePointBefore(I)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.codePointCount(II)I"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.codePoints()Ljava/util/stream/IntStream;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.compareTo(Ljava/lang/StringBuffer;)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringCompareToCaseSensitive,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.delete(II)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderDelete,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.deleteCharAt(I)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBuilderDelete,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.ensureCapacity(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.getChars(II[CI)V"] =
+		GMeth{
+			ParamSlots: 4,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.indexOf(Ljava/lang/String;)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.indexOf(Ljava/lang/String;I)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.insert(IZ)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderInsertBoolean,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.insert(IC)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderInsertChar,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.insert(I[C)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderInsert,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.insert(I[CII)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 4,
+			GFunction:  stringBuilderInsert,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.insert(ID)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  stringBuilderInsert,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.insert(IF)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderInsert,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.insert(II)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderInsert,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.insert(IJ)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  stringBuilderInsert,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.insert(ILjava/lang/CharSequence;)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.insert(ILjava/lang/CharSequence;II)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 4,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.insert(ILjava/lang/Object;)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderInsert,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.insert(ILjava/lang/String;)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderInsert,
+		}
+	MethodSignatures["java/lang/StringBuffer.isLatin1()Z"] = // internal member function, not in API
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  returnTrue,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.lastIndexOf(Ljava/lang/String;)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.lastIndexOf(Ljava/lang/String;I)I"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.length()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  stringBuilderLength,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.offsetByCodePoints(II)I"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.replace(IILjava/lang/String;)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.reverse()Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.setCharAt(IC)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderSetCharAt,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.setLength(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBuilderSetLength,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.subSequence(II)Ljava/lang/CharSequence;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.substring(I)Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  substringToTheEnd, // javaLangString.go
+		}
+
+	MethodSignatures["java/lang/StringBuffer.substring(II)Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  substringStartEnd, // javaLangString.go
+		}
+
+	MethodSignatures["java/lang/StringBuffer.toString()Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  stringBuilderToString,
+		}
+
+	MethodSignatures["java/lang/StringBuffer.trimToSize()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
 }
 
-// append the string in the second parameter to the chars in the StringBuffer that's
-// passed in the objectRef parameter (the first param)
-func appendStringToStringBuffer(params []any) any {
-	stringBufferObject := params[0].(*object.Object)
-	stringBufferStringLen := stringBufferObject.FieldTable["count"].Fvalue.(int64)
+var classStringBuffer = "java/lang/StringBuffer"
 
-	strObjectToAppend := params[1].(*object.Object)
-	strToAppend := strObjectToAppend.FieldTable["value"].Fvalue.([]byte)
+// Initialise StringBuffer with or without a capacity integer.
+func stringBufferInit(params []any) any {
+	// Get File object and initialise the field map.
+	obj := params[0].(*object.Object)
+	obj.FieldTable = make(map[string]object.Field)
 
-	switch stringBufferObject.FieldTable["value"].Fvalue.(type) {
-	case []byte: // the usual case
-		if stringBufferStringLen == 0 {
-			stringBufferObject.FieldTable["value"] = object.Field{
-				Ftype:  "[B",
-				Fvalue: strToAppend,
-			}
-			stringBufferObject.FieldTable["count"] = object.Field{
-				Ftype:  "I",
-				Fvalue: int64(len(strToAppend)),
-			}
-		} else {
-			stringBufferContent := stringBufferObject.FieldTable["value"].Fvalue.([]byte)
-			stringBufferContent = append(stringBufferContent, strToAppend...)
-			stringBufferObject.FieldTable["count"] = object.Field{
-				Ftype:  "I",
-				Fvalue: int64(len(stringBufferContent)),
-			}
-		}
-	case nil: // a raw StringBuffer
-		stringBufferObject.FieldTable["value"] = object.Field{
-			Ftype:  "[B",
-			Fvalue: strToAppend,
-		}
-		stringBufferObject.FieldTable["count"] = object.Field{
-			Ftype:  "I",
-			Fvalue: int64(len(strToAppend)),
-		}
+	// Set the count = 0.
+	fld := object.Field{Ftype: types.Int, Fvalue: int64(0)}
+	obj.FieldTable["count"] = fld
+
+	// Set the value = nil byte array.
+	fld = object.Field{Ftype: types.ByteArray, Fvalue: make([]byte, 0)}
+	obj.FieldTable["value"] = fld
+
+	// Set the capacity field value.
+	var capacity int64
+	if len(params) > 1 { // Was a capacity parameter supplied?
+		capacity = params[1].(int64)
+	} else {
+		capacity = 16 // default capacity value per API
 	}
-	return stringBufferObject
+	fld = object.Field{Ftype: types.Int, Fvalue: capacity}
+	obj.FieldTable["capacity"] = fld
+
+	return nil
+}
+
+// Initialise StringBuffer with a String object.
+func stringBufferInitString(params []any) any {
+	// Get File object and initialise the field map.
+	obj := params[0].(*object.Object)
+	obj.FieldTable = make(map[string]object.Field)
+
+	var byteArray []byte
+	var ok bool
+	switch params[1].(type) {
+	case *object.Object: // String
+		byteArray, ok = params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
+		if !ok {
+			errMsg := "Value field missing in <init> object argument or the field is not a byte array"
+			return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+		}
+	default:
+		errMsg := fmt.Sprintf("Parameter type (%T) is illegal", params[1])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Append parmArray to the byteArray.
+	// Set the byte count.
+	count := int64(len(byteArray))
+	capacity := count + 16
+	obj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
+	obj.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
+	obj.FieldTable["capacity"] = object.Field{Ftype: types.Int, Fvalue: capacity}
+
+	return nil
 }

--- a/src/gfunction/javaLangStringBuilder.go
+++ b/src/gfunction/javaLangStringBuilder.go
@@ -578,7 +578,7 @@ func stringBuilderDelete(params []any) any {
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 	}
 	if end < start {
-		errMsg := fmt.Sprintf("End value (%d) < Start value (%d)", start, end, start)
+		errMsg := fmt.Sprintf("End value (%d) < Start value (%d)", start, end)
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 	}
 	if end > initLen {

--- a/src/gfunction/javaLangStringBuilder.go
+++ b/src/gfunction/javaLangStringBuilder.go
@@ -208,6 +208,18 @@ func Load_Lang_StringBuilder() {
 			GFunction:  trapFunction,
 		}
 
+	MethodSignatures["java/lang/StringBuilder.indexOf(Ljava/lang/String;)Ljava/lang/StringBuilder;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.indexOf(Ljava/lang/String;I)Ljava/lang/StringBuilder;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
 	MethodSignatures["java/lang/StringBuilder.insert(IZ)Ljava/lang/StringBuilder;"] =
 		GMeth{
 			ParamSlots: 2,

--- a/src/gfunction/javaLangStringBuilder.go
+++ b/src/gfunction/javaLangStringBuilder.go
@@ -11,6 +11,7 @@ import (
 	"jacobin/excNames"
 	"jacobin/object"
 	"jacobin/types"
+	"strconv"
 )
 
 // Implementation of some of the functions in Java/lang/Class.
@@ -60,7 +61,7 @@ func Load_Lang_StringBuilder() {
 	MethodSignatures["java/lang/StringBuilder.append(C)Ljava/lang/StringBuilder;"] = // append char
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  stringBuilderAppend,
+			GFunction:  stringBuilderAppendChar,
 		}
 
 	MethodSignatures["java/lang/StringBuilder.append([C)Ljava/lang/StringBuilder;"] = // append char array
@@ -99,43 +100,37 @@ func Load_Lang_StringBuilder() {
 			GFunction:  stringBuilderAppend,
 		}
 
-	MethodSignatures["java/lang/StringBuilder.append(Ljava/lang/CharSequence;)Ljava/lang/StringBuilder;"] = // append char seq
+	MethodSignatures["java/lang/StringBuilder.append(Ljava/lang/CharSequence;)Ljava/lang/StringBuilder;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  trapFunction,
 		}
 
-	MethodSignatures["java/lang/StringBuilder.append(Ljava/lang/CharSequence;II)Ljava/lang/StringBuilder;"] = // append char seq
+	MethodSignatures["java/lang/StringBuilder.append(Ljava/lang/CharSequence;II)Ljava/lang/StringBuilder;"] =
 		GMeth{
 			ParamSlots: 3,
 			GFunction:  trapFunction,
 		}
 
-	MethodSignatures["java/lang/StringBuilder.append(Ljava/lang/Object;)Ljava/lang/StringBuilder;"] = // append object
+	MethodSignatures["java/lang/StringBuilder.append(Ljava/lang/Object;)Ljava/lang/StringBuilder;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  stringBuilderAppend,
 		}
 
-	MethodSignatures["java/lang/StringBuilder.append(Ljava/lang/Object;)Ljava/lang/StringBuilder;"] = // append string
+	MethodSignatures["java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  stringBuilderAppend,
 		}
 
-	MethodSignatures["java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;"] = // append string
+	MethodSignatures["java/lang/StringBuilder.append(Ljava/lang/StringBuffer;)Ljava/lang/StringBuilder;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  stringBuilderAppend,
 		}
 
-	MethodSignatures["java/lang/StringBuilder.append(Ljava/lang/StringBuffer;)Ljava/lang/StringBuilder;"] = // append stringBuffer
-		GMeth{
-			ParamSlots: 1,
-			GFunction:  stringBuilderAppend,
-		}
-
-	MethodSignatures["java/lang/StringBuilder.appendCodePoint(I)Ljava/lang/StringBuilder;"] = // append CodePoint
+	MethodSignatures["java/lang/StringBuilder.appendCodePoint(I)Ljava/lang/StringBuilder;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  trapFunction,
@@ -147,9 +142,33 @@ func Load_Lang_StringBuilder() {
 			GFunction:  stringBuilderCapacity,
 		}
 
+	MethodSignatures["java/lang/StringBuilder.charAt(I)C"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  stringBuilderCharAt,
+		}
+
 	MethodSignatures["java/lang/StringBuilder.chars()Ljava/util/stream/IntStream;"] =
 		GMeth{
 			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.codePointAt(I)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.codePointBefore(I)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.codePointCount(II)I"] =
+		GMeth{
+			ParamSlots: 2,
 			GFunction:  trapFunction,
 		}
 
@@ -159,16 +178,159 @@ func Load_Lang_StringBuilder() {
 			GFunction:  trapFunction,
 		}
 
+	MethodSignatures["java/lang/StringBuilder.compareTo(Ljava/lang/StringBuilder;)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.delete(II)Ljava/lang/StringBuilder;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.deleteCharAt(I)Ljava/lang/StringBuilder;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.ensureCapacity(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.getChars(II[CI)V"] =
+		GMeth{
+			ParamSlots: 4,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.insert(IZ)Ljava/lang/StringBuilder;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderInsertBoolean,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.insert(IC)Ljava/lang/StringBuilder;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderInsert,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.insert(I[C)Ljava/lang/StringBuilder;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderInsert,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.insert(I[CII)Ljava/lang/StringBuilder;"] =
+		GMeth{
+			ParamSlots: 4,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.insert(ID)Ljava/lang/StringBuilder;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderInsert,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.insert(IF)Ljava/lang/StringBuilder;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderInsert,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.insert(II)Ljava/lang/StringBuilder;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderInsert,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.insert(IJ)Ljava/lang/StringBuilder;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderInsert,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.insert(ILjava/lang/CharSequence;)Ljava/lang/StringBuilder;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.insert(ILjava/lang/CharSequence;II)Ljava/lang/StringBuilder;"] =
+		GMeth{
+			ParamSlots: 4,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.insert(ILjava/lang/Object;)Ljava/lang/StringBuilder;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderInsert,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.insert(ILjava/lang/String;)Ljava/lang/StringBuilder;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  stringBuilderInsert,
+		}
+	MethodSignatures["java/lang/StringBuilder.isLatin1()Z"] = // internal member function, not in API
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  returnTrue,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.lastIndexOf(Ljava/lang/String;)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.lastIndexOf(Ljava/lang/String;I)I"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
 	MethodSignatures["java/lang/StringBuilder.length()I"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  stringBuilderLength,
 		}
 
-	MethodSignatures["java/lang/StringBuilder.isLatin1()Z"] =
+	MethodSignatures["java/lang/StringBuilder.offsetByCodePoints(II)I"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.replace(IILjava/lang/String;)Ljava/lang/StringBuilder;"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.reverse()Ljava/lang/StringBuilder;"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  returnTrue,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.setCharAt(IC)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/StringBuilder.setLength(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/lang/StringBuilder.subSequence(II)Ljava/lang/CharSequence;"] =
@@ -207,7 +369,7 @@ func Load_Lang_StringBuilder() {
 
 var classStringBuilder = "java/lang/StringBuilder"
 
-// Initialise StringBuilder with or without a capacity integer (ignored).
+// Initialise StringBuilder with or without a capacity integer.
 func stringBuilderInit(params []any) any {
 	// Get File object and initialise the field map.
 	obj := params[0].(*object.Object)
@@ -221,7 +383,7 @@ func stringBuilderInit(params []any) any {
 	fld = object.Field{Ftype: types.ByteArray, Fvalue: make([]byte, 0)}
 	obj.FieldTable["value"] = fld
 
-	// Set the capacity field value even though it is always ignored.
+	// Set the capacity field value.
 	var capacity int64
 	if len(params) > 1 { // Was a capacity parameter supplied?
 		capacity = params[1].(int64)
@@ -256,8 +418,11 @@ func stringBuilderInitString(params []any) any {
 
 	// Append parmArray to the byteArray.
 	// Set the byte count.
+	count := int64(len(byteArray))
+	capacity := count + 16
 	obj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
-	obj.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: int64(len(byteArray))}
+	obj.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
+	obj.FieldTable["capacity"] = object.Field{Ftype: types.Int, Fvalue: capacity}
 
 	return nil
 }
@@ -274,25 +439,26 @@ func stringBuilderAppend(params []any) any {
 	objOut.FieldTable = objBase.FieldTable
 
 	var parmArray []byte
-	var ok bool
 	switch params[1].(type) {
-	case *object.Object: // String, StringBuffer, or StringBuilder
-		parmArray, ok = params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
-		if !ok {
-			errMsg := "Value field missing in append object argument or the field is not a byte array"
+	case *object.Object: // char array, String, StringBuffer, or StringBuilder
+		fvalue := params[1].(*object.Object).FieldTable["value"].Fvalue
+		switch fvalue.(type) {
+		case []byte: // String, StringBuffer, or StringBuilder
+			parmArray = fvalue.([]byte)
+		case []int64: // char array
+			for _, elem := range fvalue.([]int64) {
+				parmArray = append(parmArray, byte(elem))
+			}
+		default:
+			errMsg := fmt.Sprintf("Object value field value type (%T) is not a byte array nor a char array", params[1])
 			return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 		}
-	case int64: // character, integer, long
+	case int64: // integer, long
 		str := fmt.Sprintf("%d", params[1].(int64))
 		parmArray = []byte(str)
-	case []int64: // character array
-		for ii := range params[1].([]int64) {
-			parmArray = append(parmArray, byte(ii))
-		}
 	case float64: // float, double
 		ff := params[1].(float64)
-		form := getDoubleFormat(ff)
-		str := fmt.Sprintf(form, ff)
+		str := strconv.FormatFloat(ff, 'f', -1, 64)
 		parmArray = []byte(str)
 	default:
 		errMsg := fmt.Sprintf("Parameter type (%T) is illegal", params[1])
@@ -302,8 +468,10 @@ func stringBuilderAppend(params []any) any {
 	// Append parmArray to the byteArray.
 	// Set the byte count.
 	byteArray = append(byteArray, parmArray...)
+	count := int64(len(byteArray))
 	objOut.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
-	objOut.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: int64(len(byteArray))}
+	objOut.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
+	expandCapacity(objOut, count)
 
 	return objOut
 }
@@ -337,8 +505,202 @@ func stringBuilderAppendBoolean(params []any) any {
 	// Append parmArray to the byteArray.
 	// Set the byte count.
 	byteArray = append(byteArray, parmArray...)
+	count := int64(len(byteArray))
 	objOut.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
-	objOut.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: int64(len(byteArray))}
+	objOut.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
+	expandCapacity(objOut, count)
+
+	return objOut
+}
+
+// Append the second parameter (char) to the bytes in the StringBuilder that is
+// passed in the objectRef parameter (the first param).
+func stringBuilderAppendChar(params []any) any {
+	// Get base object and its value field, byteArray.
+	objBase := params[0].(*object.Object)
+	byteArray := objBase.FieldTable["value"].Fvalue.([]byte)
+
+	// Initialise the output object.
+	objOut := object.MakeEmptyObjectWithClassName(&classStringBuilder)
+	objOut.FieldTable = objBase.FieldTable
+
+	var parmArray = make([]byte, 1)
+	switch params[1].(type) {
+	case int64: // char
+		bb := byte(params[1].(int64))
+		parmArray[0] = bb
+	default:
+		errMsg := fmt.Sprintf("Parameter type (%T) is illegal", params[1])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Append parmArray to the byteArray.
+	// Set the byte count.
+	byteArray = append(byteArray, parmArray...)
+	count := int64(len(byteArray))
+	objOut.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
+	objOut.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
+	expandCapacity(objOut, count)
+
+	return objOut
+}
+
+// Extract a character at the given index.
+func stringBuilderCharAt(params []any) any {
+	obj := params[0].(*object.Object)
+	ix := params[1].(int64)
+	bytes := obj.FieldTable["value"].Fvalue.([]byte)
+	if ix >= int64(len(bytes)) {
+		errMsg := fmt.Sprintf("Index value (%d) exceeds the byte array size (%d)", ix, len(bytes))
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	return int64(bytes[ix])
+}
+
+// Insert the second parameter to the bytes into the StringBuilder
+// at the given index.
+func stringBuilderInsert(params []any) any {
+	// Get base object and its value field, byteArray.
+	objBase := params[0].(*object.Object)
+	byteArray := objBase.FieldTable["value"].Fvalue.([]byte)
+
+	// Get the index value.
+	ix := params[1].(int64)
+	if ix >= int64(len(byteArray)) {
+		errMsg := fmt.Sprintf("Index value (%d) exceeds the byte array size (%d)", ix, len(byteArray))
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Initialise the output object.
+	objOut := object.MakeEmptyObjectWithClassName(&classStringBuilder)
+	objOut.FieldTable = objBase.FieldTable
+
+	var parmArray []byte
+	switch params[1].(type) {
+	case *object.Object: // char array, String, StringBuffer, or StringBuilder
+		fvalue := params[1].(*object.Object).FieldTable["value"].Fvalue
+		switch fvalue.(type) {
+		case []byte: // String, StringBuffer, or StringBuilder
+			parmArray = fvalue.([]byte)
+		case []int64: // char array
+			for _, elem := range fvalue.([]int64) {
+				parmArray = append(parmArray, byte(elem))
+			}
+		default:
+			errMsg := fmt.Sprintf("Object value field value type (%T) is not a byte array nor a char array", params[1])
+			return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+		}
+	case int64: // integer, long
+		str := fmt.Sprintf("%d", params[1].(int64))
+		parmArray = []byte(str)
+	case float64: // float, double
+		ff := params[1].(float64)
+		str := strconv.FormatFloat(ff, 'f', -1, 64)
+		parmArray = []byte(str)
+	default:
+		errMsg := fmt.Sprintf("Parameter type (%T) is illegal", params[1])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Append parmArray to the byteArray.
+	// Set the byte count.
+	newArray := byteArray[:(ix - 1)]
+	newArray = append(newArray, parmArray...)
+	newArray = append(newArray, byteArray[ix:]...)
+	count := int64(len(newArray))
+
+	objOut.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: newArray}
+	objOut.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
+	expandCapacity(objOut, count)
+
+	return objOut
+}
+
+// Insert the boolean parameter into the bytes into the StringBuilder
+// at the given index.
+func stringBuilderInsertBoolean(params []any) any {
+	// Get base object and its value field, byteArray.
+	objBase := params[0].(*object.Object)
+	byteArray := objBase.FieldTable["value"].Fvalue.([]byte)
+
+	// Get the index value.
+	ix := params[1].(int64)
+	if ix >= int64(len(byteArray)) {
+		errMsg := fmt.Sprintf("Index value (%d) exceeds the byte array size (%d)", ix, len(byteArray))
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Initialise the output object.
+	objOut := object.MakeEmptyObjectWithClassName(&classStringBuilder)
+	objOut.FieldTable = objBase.FieldTable
+
+	var parmArray []byte
+	switch params[1].(type) {
+	case int64: // boolean
+		var str string
+		if params[1].(int64) == types.JavaBoolTrue {
+			str = "true"
+		} else {
+			str = "false"
+		}
+		parmArray = []byte(str)
+	default:
+		errMsg := fmt.Sprintf("Parameter type (%T) is illegal", params[1])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Append parmArray to the byteArray.
+	// Set the byte count.
+	newArray := byteArray[:(ix - 1)]
+	newArray = append(newArray, parmArray...)
+	newArray = append(newArray, byteArray[ix:]...)
+	count := int64(len(newArray))
+
+	objOut.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: newArray}
+	objOut.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
+	expandCapacity(objOut, count)
+
+	return objOut
+}
+
+// Insert the char parameter into the bytes into the StringBuilder
+// at the given index.
+func stringBuilderInsertChar(params []any) any {
+	// Get base object and its value field, byteArray.
+	objBase := params[0].(*object.Object)
+	byteArray := objBase.FieldTable["value"].Fvalue.([]byte)
+
+	// Get the index value.
+	ix := params[1].(int64)
+	if ix >= int64(len(byteArray)) {
+		errMsg := fmt.Sprintf("Index value (%d) exceeds the byte array size (%d)", ix, len(byteArray))
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Initialise the output object.
+	objOut := object.MakeEmptyObjectWithClassName(&classStringBuilder)
+	objOut.FieldTable = objBase.FieldTable
+
+	var parmArray = make([]byte, 1)
+	switch params[1].(type) {
+	case int64: // char
+		bb := byte(params[1].(int64))
+		parmArray[0] = bb
+	default:
+		errMsg := fmt.Sprintf("Parameter type (%T) is illegal", params[1])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Append parmArray to the byteArray.
+	// Set the byte count.
+	newArray := byteArray[:(ix - 1)]
+	newArray = append(newArray, parmArray...)
+	newArray = append(newArray, byteArray[ix:]...)
+	count := int64(len(newArray))
+
+	objOut.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: newArray}
+	objOut.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
+	expandCapacity(objOut, count)
 
 	return objOut
 }
@@ -351,20 +713,25 @@ func stringBuilderToString(params []any) any {
 	return objOut
 }
 
-// Return the StringBuilder object capacity or count, whichever is larger.
-// Note: This is what the OpenJDK JVM does.
+// Return the StringBuilder object capacity.
 func stringBuilderCapacity(params []any) any {
 	objBase := params[0].(*object.Object)
-	capacity := objBase.FieldTable["capacity"].Fvalue.(int64)
-	count := objBase.FieldTable["count"].Fvalue.(int64)
-	if count > capacity {
-		capacity = count
-	}
-	return capacity
+	return objBase.FieldTable["capacity"].Fvalue.(int64)
 }
 
 // Return the StringBuilder object length.
 func stringBuilderLength(params []any) any {
 	objBase := params[0].(*object.Object)
 	return objBase.FieldTable["count"].Fvalue.(int64)
+}
+
+// Expand the capacity of a StringBuilder object.
+func expandCapacity(obj *object.Object, count int64) {
+	capField := obj.FieldTable["capacity"]
+	capacity := capField.Fvalue.(int64)
+	for count > capacity { // Expand capacity while count exceeds capacity.
+		capacity = (capacity * 2) + 2
+	}
+	capField.Fvalue = capacity
+	obj.FieldTable["capacity"] = capField
 }

--- a/src/gfunction/javaLangStringBuilder.go
+++ b/src/gfunction/javaLangStringBuilder.go
@@ -217,7 +217,7 @@ func Load_Lang_StringBuilder() {
 	MethodSignatures["java/lang/StringBuilder.insert(IC)Ljava/lang/StringBuilder;"] =
 		GMeth{
 			ParamSlots: 2,
-			GFunction:  stringBuilderInsert,
+			GFunction:  stringBuilderInsertChar,
 		}
 
 	MethodSignatures["java/lang/StringBuilder.insert(I[C)Ljava/lang/StringBuilder;"] =
@@ -234,7 +234,7 @@ func Load_Lang_StringBuilder() {
 
 	MethodSignatures["java/lang/StringBuilder.insert(ID)Ljava/lang/StringBuilder;"] =
 		GMeth{
-			ParamSlots: 2,
+			ParamSlots: 3,
 			GFunction:  stringBuilderInsert,
 		}
 
@@ -252,7 +252,7 @@ func Load_Lang_StringBuilder() {
 
 	MethodSignatures["java/lang/StringBuilder.insert(IJ)Ljava/lang/StringBuilder;"] =
 		GMeth{
-			ParamSlots: 2,
+			ParamSlots: 3,
 			GFunction:  stringBuilderInsert,
 		}
 
@@ -566,9 +566,9 @@ func stringBuilderInsert(params []any) any {
 
 	// Get the index value.
 	ix := params[1].(int64)
-	if ix >= int64(len(byteArray)) {
-		errMsg := fmt.Sprintf("Index value (%d) exceeds the byte array size (%d)", ix, len(byteArray))
-		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	if ix < 0 || ix > int64(len(byteArray)) {
+		errMsg := fmt.Sprintf("Index value (%d) is negative or exceeds the byte array size (%d)", ix, len(byteArray))
+		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 	}
 
 	// Initialise the output object.
@@ -576,9 +576,9 @@ func stringBuilderInsert(params []any) any {
 	objOut.FieldTable = objBase.FieldTable
 
 	var parmArray []byte
-	switch params[1].(type) {
+	switch params[2].(type) {
 	case *object.Object: // char array, String, StringBuffer, or StringBuilder
-		fvalue := params[1].(*object.Object).FieldTable["value"].Fvalue
+		fvalue := params[2].(*object.Object).FieldTable["value"].Fvalue
 		switch fvalue.(type) {
 		case []byte: // String, StringBuffer, or StringBuilder
 			parmArray = fvalue.([]byte)
@@ -591,10 +591,10 @@ func stringBuilderInsert(params []any) any {
 			return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 		}
 	case int64: // integer, long
-		str := fmt.Sprintf("%d", params[1].(int64))
+		str := fmt.Sprintf("%d", params[2].(int64))
 		parmArray = []byte(str)
 	case float64: // float, double
-		ff := params[1].(float64)
+		ff := params[2].(float64)
 		str := strconv.FormatFloat(ff, 'f', -1, 64)
 		parmArray = []byte(str)
 	default:
@@ -604,7 +604,10 @@ func stringBuilderInsert(params []any) any {
 
 	// Append parmArray to the byteArray.
 	// Set the byte count.
-	newArray := byteArray[:(ix - 1)]
+	newArray := make([]byte, ix)
+	if ix > 0 {
+		copy(newArray, byteArray[0:ix])
+	}
 	newArray = append(newArray, parmArray...)
 	newArray = append(newArray, byteArray[ix:]...)
 	count := int64(len(newArray))
@@ -625,9 +628,9 @@ func stringBuilderInsertBoolean(params []any) any {
 
 	// Get the index value.
 	ix := params[1].(int64)
-	if ix >= int64(len(byteArray)) {
-		errMsg := fmt.Sprintf("Index value (%d) exceeds the byte array size (%d)", ix, len(byteArray))
-		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	if ix < 0 || ix > int64(len(byteArray)) {
+		errMsg := fmt.Sprintf("Index value (%d) is negative or exceeds the byte array size (%d)", ix, len(byteArray))
+		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 	}
 
 	// Initialise the output object.
@@ -635,10 +638,10 @@ func stringBuilderInsertBoolean(params []any) any {
 	objOut.FieldTable = objBase.FieldTable
 
 	var parmArray []byte
-	switch params[1].(type) {
+	switch params[2].(type) {
 	case int64: // boolean
 		var str string
-		if params[1].(int64) == types.JavaBoolTrue {
+		if params[2].(int64) == types.JavaBoolTrue {
 			str = "true"
 		} else {
 			str = "false"
@@ -651,7 +654,10 @@ func stringBuilderInsertBoolean(params []any) any {
 
 	// Append parmArray to the byteArray.
 	// Set the byte count.
-	newArray := byteArray[:(ix - 1)]
+	newArray := make([]byte, ix)
+	if ix > 0 {
+		copy(newArray, byteArray[0:ix])
+	}
 	newArray = append(newArray, parmArray...)
 	newArray = append(newArray, byteArray[ix:]...)
 	count := int64(len(newArray))
@@ -672,20 +678,19 @@ func stringBuilderInsertChar(params []any) any {
 
 	// Get the index value.
 	ix := params[1].(int64)
-	if ix >= int64(len(byteArray)) {
-		errMsg := fmt.Sprintf("Index value (%d) exceeds the byte array size (%d)", ix, len(byteArray))
-		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	if ix < 0 || ix > int64(len(byteArray)) {
+		errMsg := fmt.Sprintf("Index value (%d) is negative or exceeds the byte array size (%d)", ix, len(byteArray))
+		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 	}
 
 	// Initialise the output object.
 	objOut := object.MakeEmptyObjectWithClassName(&classStringBuilder)
 	objOut.FieldTable = objBase.FieldTable
 
-	var parmArray = make([]byte, 1)
-	switch params[1].(type) {
+	var bb byte
+	switch params[2].(type) {
 	case int64: // char
-		bb := byte(params[1].(int64))
-		parmArray[0] = bb
+		bb = byte(params[2].(int64))
 	default:
 		errMsg := fmt.Sprintf("Parameter type (%T) is illegal", params[1])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
@@ -693,8 +698,11 @@ func stringBuilderInsertChar(params []any) any {
 
 	// Append parmArray to the byteArray.
 	// Set the byte count.
-	newArray := byteArray[:(ix - 1)]
-	newArray = append(newArray, parmArray...)
+	newArray := make([]byte, ix)
+	if ix > 0 {
+		copy(newArray, byteArray[0:ix])
+	}
+	newArray = append(newArray, bb)
 	newArray = append(newArray, byteArray[ix:]...)
 	count := int64(len(newArray))
 

--- a/src/gfunction/javaLangString_test.go
+++ b/src/gfunction/javaLangString_test.go
@@ -71,7 +71,7 @@ func TestCompareToIgnoreCaseOk(t *testing.T) {
 	aObj := object.StringObjectFromGoString(aString)
 	bObj := object.StringObjectFromGoString(bString)
 	params := []interface{}{aObj, bObj}
-	result := compareToIgnoreCase(params).(int64)
+	result := stringCompareToIgnoreCase(params).(int64)
 	if result != 0 {
 		t.Errorf("TestCompareToIgnoreCaseOk: expected: 0, observed: %d", result)
 	}
@@ -84,7 +84,7 @@ func TestCompareToIgnoreCaseNotOk_1(t *testing.T) {
 	aObj := object.StringObjectFromGoString(aString)
 	bObj := object.StringObjectFromGoString(bString)
 	params := []interface{}{aObj, bObj}
-	result := compareToIgnoreCase(params).(int64)
+	result := stringCompareToIgnoreCase(params).(int64)
 	if result >= 0 {
 		t.Errorf("TestCompareToIgnoreCaseOk_1: expected: <0, observed: %d", result)
 	}
@@ -97,7 +97,7 @@ func TestCompareToIgnoreCaseNotOk_2(t *testing.T) {
 	aObj := object.StringObjectFromGoString(aString)
 	bObj := object.StringObjectFromGoString(bString)
 	params := []interface{}{aObj, bObj}
-	result := compareToIgnoreCase(params).(int64)
+	result := stringCompareToIgnoreCase(params).(int64)
 	if result <= 0 {
 		t.Errorf("TestCompareToIgnoreCaseOk_2: expected: >0, observed: %d", result)
 	}

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -2505,7 +2505,7 @@ frameInterpreter:
 			// For more info: https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-5.html#jvms-5.4.3.4
 
 			clData := *class.Data
-			if len(clData.Interfaces) == 0 {
+			if len(clData.Interfaces) == 0 { // TODO: Determine whether this is correct behavior. See Jacotest results.
 				errMsg := fmt.Sprintf("INVOKEINTERFACE: class %s does not implement interface %s",
 					objRefClassName, interfaceName)
 				status := exceptions.ThrowEx(excNames.IncompatibleClassChangeError, errMsg, f)


### PR DESCRIPTION
Amendments to javaLangStringBuilder.go:

* append
* insert
* delete, deleteCharAt
* more append
* compareTo
* more insert
* setCharAt
* setLength

Added function signum to javaLangInteger.go.

StringBuffer (not yet thread safe):
* Unique <clinit> and <init> functions.
* Uses StringBuilder member functions otherwise.

A thread safe strategy for G functions is proposed in JACOBIN-564.