### PR TITLE
JACOBIN-564 StringBuffer usage of flag ThreadSafe

### DIFF
--- a/src/classloader/methArea.go
+++ b/src/classloader/methArea.go
@@ -9,6 +9,7 @@ package classloader
 import (
 	"errors"
 	"fmt"
+	"jacobin/globals"
 	"jacobin/log"
 	"jacobin/stringPool"
 	"jacobin/types"
@@ -119,7 +120,7 @@ func WaitForClassStatus(className string) error {
 	_ = log.Log("WaitForClassStatus: class name: "+className, log.CLASS)
 	klass := MethAreaFetch(className)
 	if klass == nil { // class not there yet
-		time.Sleep(100 * time.Millisecond) // sleep 100 milliseconds
+		time.Sleep(globals.SleepMsecs * time.Millisecond) // sleep awhile
 		klass = MethAreaFetch(className)
 		if klass == nil {
 			errMsg := fmt.Sprintf("WaitClassStatus: Timeout waiting for class %s to load", className)
@@ -127,7 +128,7 @@ func WaitForClassStatus(className string) error {
 		}
 	}
 	if klass.Status == 'I' { // class is being initialized by a loader, so wait
-		time.Sleep(100 * time.Millisecond) // sleep 100 milliseconds
+		time.Sleep(globals.SleepMsecs * time.Millisecond) // sleep awhile
 		klass = MethAreaFetch(className)
 		if klass.Status == 'I' {
 			errMsg := fmt.Sprintf("WaitClassStatus: Timeout waiting for class %s to be initialized", className)

--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -162,12 +162,6 @@ func Load_Traps() {
 			GFunction:  trapClass,
 		}
 
-	MethodSignatures["java/util/Random.next(I)V"] =
-		GMeth{
-			ParamSlots: 1,
-			GFunction:  trapFunction,
-		}
-
 }
 
 // Generic trap for classes

--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -48,6 +48,7 @@ type GMeth struct {
 	ParamSlots   int
 	GFunction    func([]interface{}) interface{}
 	NeedsContext bool
+	ThreadSafe   bool
 }
 
 // G function error block.
@@ -166,6 +167,7 @@ func loadlib(tbl *classloader.MT, libMeths map[string]GMeth) {
 		gme.ParamSlots = val.ParamSlots
 		gme.GFunction = val.GFunction
 		gme.NeedsContext = val.NeedsContext
+		gme.ThreadSafe = val.ThreadSafe
 
 		tableEntry := classloader.MTentry{
 			MType: 'G',

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -69,7 +69,7 @@ func Load_Lang_String() {
 			GFunction:  trapDeprecated,
 		}
 
-	// String(byte[] bytes, int offset, int length, String charsetName) *********** CHARSET
+	// String(byte[] bytes, int offset, int length, String charsetName) *********** CHARSET NAME
 	MethodSignatures["java/lang/String.<init>([BIILjava/lang/String;)V"] =
 		GMeth{
 			ParamSlots: 4,
@@ -83,7 +83,7 @@ func Load_Lang_String() {
 			GFunction:  trapFunction,
 		}
 
-	// String(byte[] bytes, String charsetName) *********************************** CHARSET
+	// String(byte[] bytes, String charsetName) *********************************** CHARSET NAME
 	MethodSignatures["java/lang/String.<init>([BLjava/lang/String;)V"] =
 		GMeth{
 			ParamSlots: 2,
@@ -116,20 +116,25 @@ func Load_Lang_String() {
 			GFunction:  trapFunction,
 		}
 
-	// String(String original) - works fine in Java
+	// String(String original)
+	MethodSignatures["java/lang/String.<init>(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  newStringFromString,
+		}
 
-	// String(StringBuffer buffer) ********************************************* StringBuffer
+	// String(StringBuffer buffer)
 	MethodSignatures["java/lang/String.<init>(Ljava/lang/StringBuffer;)V"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  trapFunction,
+			GFunction:  newStringFromString,
 		}
 
-	// String(StringBuilder builder) ******************************************* StringBuilder
+	// String(StringBuilder builder)
 	MethodSignatures["java/lang/String.<init>(Ljava/lang/StringBuilder;)V"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  trapFunction,
+			GFunction:  newStringFromString,
 		}
 
 	// ==== METHOD FUNCTIONS (in alpha order by their Java names) ====
@@ -516,6 +521,15 @@ func newStringFromCharsSubset(params []interface{}) interface{} {
 	obj := object.StringObjectFromByteArray(bytes)
 	return obj
 
+}
+
+// New String from String, StringBuilder, or StringBuffer.
+func newStringFromString(params []interface{}) interface{} {
+	// params[0] = reference string (to be updated with byte array)
+	// params[1] = String, StringBuilder, or StringBuffer object
+	bytes := params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
+	object.UpdateValueFieldFromBytes(params[0].(*object.Object), bytes)
+	return nil
 }
 
 // "java/lang/String.<clinit>()V" -- String class initialisation

--- a/src/gfunction/javaLangStringBuffer.go
+++ b/src/gfunction/javaLangStringBuffer.go
@@ -29,24 +29,28 @@ func Load_Lang_StringBuffer() {
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  stringBufferInit,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.<init>(I)V"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  stringBufferInit,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.<init>(Ljava/lang/CharSequence;)V"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  trapFunction,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.<init>(Ljava/lang/String;)V"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  stringBufferInitString,
+			ThreadSafe: true,
 		}
 
 	// === Methods ===
@@ -55,323 +59,378 @@ func Load_Lang_StringBuffer() {
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  stringBuilderAppendBoolean,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.append(C)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  stringBuilderAppendChar,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.append([C)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  stringBuilderAppend,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.append([CII)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 3,
 			GFunction:  stringBuilderAppend,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.append(D)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  stringBuilderAppend,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.append(F)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  stringBuilderAppend,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.append(I)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  stringBuilderAppend,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.append(J)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  stringBuilderAppend,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.append(Ljava/lang/CharSequence;)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  trapFunction,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.append(Ljava/lang/CharSequence;II)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 3,
 			GFunction:  trapFunction,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.append(Ljava/lang/Object;)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  stringBuilderAppend,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.append(Ljava/lang/String;)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  stringBuilderAppend,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.append(Ljava/lang/StringBuffer;)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  stringBuilderAppend,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.appendCodePoint(I)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  trapFunction,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.capacity()I"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  stringBuilderCapacity,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.charAt(I)C"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  stringBuilderCharAt,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.chars()Ljava/util/stream/IntStream;"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapFunction,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.codePointAt(I)I"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  trapFunction,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.codePointBefore(I)I"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  trapFunction,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.codePointCount(II)I"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  trapFunction,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.codePoints()Ljava/util/stream/IntStream;"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapFunction,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.compareTo(Ljava/lang/StringBuffer;)I"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  stringCompareToCaseSensitive,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.delete(II)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  stringBuilderDelete,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.deleteCharAt(I)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  stringBuilderDelete,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.ensureCapacity(I)V"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  justReturn,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.getChars(II[CI)V"] =
 		GMeth{
 			ParamSlots: 4,
 			GFunction:  trapFunction,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.indexOf(Ljava/lang/String;)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  trapFunction,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.indexOf(Ljava/lang/String;I)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  trapFunction,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.insert(IZ)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  stringBuilderInsertBoolean,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.insert(IC)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  stringBuilderInsertChar,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.insert(I[C)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  stringBuilderInsert,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.insert(I[CII)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 4,
 			GFunction:  stringBuilderInsert,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.insert(ID)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 3,
 			GFunction:  stringBuilderInsert,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.insert(IF)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  stringBuilderInsert,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.insert(II)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  stringBuilderInsert,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.insert(IJ)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 3,
 			GFunction:  stringBuilderInsert,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.insert(ILjava/lang/CharSequence;)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  trapFunction,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.insert(ILjava/lang/CharSequence;II)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 4,
 			GFunction:  trapFunction,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.insert(ILjava/lang/Object;)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  stringBuilderInsert,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.insert(ILjava/lang/String;)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  stringBuilderInsert,
+			ThreadSafe: true,
 		}
+
 	MethodSignatures["java/lang/StringBuffer.isLatin1()Z"] = // internal member function, not in API
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  returnTrue,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.lastIndexOf(Ljava/lang/String;)I"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  trapFunction,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.lastIndexOf(Ljava/lang/String;I)I"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  trapFunction,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.length()I"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  stringBuilderLength,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.offsetByCodePoints(II)I"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  trapFunction,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.replace(IILjava/lang/String;)Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 3,
 			GFunction:  stringBuilderReplace,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.reverse()Ljava/lang/StringBuffer;"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  stringBuilderReverse,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.setCharAt(IC)V"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  stringBuilderSetCharAt,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.setLength(I)V"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  stringBuilderSetLength,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.subSequence(II)Ljava/lang/CharSequence;"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  trapFunction,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.substring(I)Ljava/lang/String;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  substringToTheEnd, // javaLangString.go
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.substring(II)Ljava/lang/String;"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  substringStartEnd, // javaLangString.go
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.toString()Ljava/lang/String;"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  stringBuilderToString,
+			ThreadSafe: true,
 		}
 
 	MethodSignatures["java/lang/StringBuffer.trimToSize()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  justReturn,
+			ThreadSafe: true,
 		}
 
 }

--- a/src/gfunction/javaMathBigInteger.go
+++ b/src/gfunction/javaMathBigInteger.go
@@ -251,6 +251,12 @@ func Load_Math_Big_Integer() {
 			GFunction:  bigIntegerModPow,
 		}
 
+	MethodSignatures["java/math/BigInteger.multiply(J)Ljava/math/BigInteger;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  bigIntegerMultiply,
+		}
+
 	MethodSignatures["java/math/BigInteger.multiply(Ljava/math/BigInteger;)Ljava/math/BigInteger;"] =
 		GMeth{
 			ParamSlots: 1,
@@ -408,8 +414,18 @@ func getPrime(bitLength int) (*big.Int, string) {
 // Fvalue holds *big.Int (pointer).
 func initBigIntegerField(obj *object.Object, argValue int64) {
 	ptrBigInt := big.NewInt(argValue)
-	fld := object.Field{Ftype: types.BigInteger, Fvalue: ptrBigInt}
-	obj.FieldTable["value"] = fld
+	fldValue := object.Field{Ftype: types.BigInteger, Fvalue: ptrBigInt}
+	obj.FieldTable["value"] = fldValue
+	var fldSign object.Field
+	switch {
+	case argValue == 0:
+		fldSign = object.Field{Ftype: types.BigInteger, Fvalue: int64(0)}
+	case argValue < 0:
+		fldSign = object.Field{Ftype: types.BigInteger, Fvalue: int64(-1)}
+	default:
+		fldSign = object.Field{Ftype: types.BigInteger, Fvalue: int64(+1)}
+	}
+	obj.FieldTable["signum"] = fldSign
 }
 
 // addStaticBigInteger: Form a BigInteger object based on the parameter value.
@@ -578,6 +594,12 @@ func bigIntegerInitString(params []interface{}) interface{} {
 	// Update base object and return nil
 	fld.Fvalue = zz
 	obj.FieldTable["value"] = fld
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld = object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return nil
 }
 
@@ -600,6 +622,12 @@ func bigIntegerInitStringRadix(params []interface{}) interface{} {
 	// Update base object and return nil
 	fld.Fvalue = zz
 	obj.FieldTable["value"] = fld
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld = object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return nil
 }
 
@@ -618,6 +646,12 @@ func bigIntegerAbs(params []interface{}) interface{} {
 
 	// Create return object
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld = object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }
 
@@ -638,6 +672,12 @@ func bigIntegerAdd(params []interface{}) interface{} {
 
 	// Create return object
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }
 
@@ -658,6 +698,12 @@ func bigIntegerAnd(params []interface{}) interface{} {
 
 	// Create return object
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }
 
@@ -678,6 +724,12 @@ func bigIntegerAndNot(params []interface{}) interface{} {
 
 	// Create return object
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }
 
@@ -756,6 +808,12 @@ func bigIntegerDivide(params []interface{}) interface{} {
 
 	// Create return object
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }
 
@@ -788,6 +846,12 @@ func bigIntegerDivideAndRemainder(params []interface{}) interface{} {
 	// Create the return object with the object-array
 	var objectArray = []*object.Object{obj1, obj2}
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, objectArray)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }
 
@@ -836,6 +900,12 @@ func bigIntegerGCD(params []interface{}) interface{} {
 
 	// Create return object
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }
 
@@ -866,6 +936,7 @@ func bigIntegerIsProbablePrime(params []interface{}) interface{} {
 	if xx.ProbablyPrime(int(certaintyInt64)) {
 		return int64(1)
 	}
+
 	return int64(0)
 }
 
@@ -890,6 +961,12 @@ func bigIntegerMax(params []interface{}) interface{} {
 
 	// Create return object
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }
 
@@ -914,6 +991,12 @@ func bigIntegerMin(params []interface{}) interface{} {
 
 	// Create return object
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }
 
@@ -939,6 +1022,12 @@ func bigIntegerMod(params []interface{}) interface{} {
 
 	// Create return object
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }
 
@@ -973,6 +1062,12 @@ func bigIntegerModInverse(params []interface{}) interface{} {
 
 	// Create return object
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }
 
@@ -1002,6 +1097,12 @@ func bigIntegerModPow(params []interface{}) interface{} {
 
 	// Create return object
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }
 
@@ -1012,9 +1113,18 @@ func bigIntegerMultiply(params []interface{}) interface{} {
 	// zz = xx * yy
 
 	objBase := params[0].(*object.Object)
-	objArg := params[1].(*object.Object)
 	xx := objBase.FieldTable["value"].Fvalue.(*big.Int)
-	yy := objArg.FieldTable["value"].Fvalue.(*big.Int)
+
+	// yy = BigInteger argument.
+	var yy *big.Int
+	switch params[1].(type) {
+	case int64:
+		argLong := params[1].(int64)
+		yy = big.NewInt(argLong)
+	default: // BigInteger object
+		objArg := params[1].(*object.Object)
+		yy = objArg.FieldTable["value"].Fvalue.(*big.Int)
+	}
 
 	// BigInteger operation
 	var zz = new(big.Int)
@@ -1022,6 +1132,12 @@ func bigIntegerMultiply(params []interface{}) interface{} {
 
 	// Create return object
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }
 
@@ -1039,6 +1155,12 @@ func bigIntegerNegate(params []interface{}) interface{} {
 
 	// Create return object
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }
 
@@ -1056,6 +1178,12 @@ func bigIntegerNot(params []interface{}) interface{} {
 
 	// Create return object
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }
 
@@ -1076,6 +1204,12 @@ func bigIntegerOr(params []interface{}) interface{} {
 
 	// Create return object
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }
 
@@ -1100,6 +1234,12 @@ func bigIntegerPow(params []interface{}) interface{} {
 
 	// Create return object
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }
 
@@ -1125,6 +1265,12 @@ func bigIntegerRemainder(params []interface{}) interface{} {
 
 	// Create return object
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }
 
@@ -1140,6 +1286,12 @@ func bigIntegerProbablyPrime(params []interface{}) interface{} {
 	if zz != nil {
 		// Create return object.
 		obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+		// Set signum field to the sign.
+		signum := zz.Sign()
+		fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+		obj.FieldTable["signum"] = fld
+
 		return obj
 	}
 	return getGErrBlk(excNames.ArithmeticException, errMsg)
@@ -1172,6 +1324,12 @@ func bigIntegerSqrt(params []interface{}) interface{} {
 
 	// Create return object
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }
 
@@ -1192,6 +1350,12 @@ func bigIntegerSubtract(params []interface{}) interface{} {
 
 	// Create return object
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }
 
@@ -1267,5 +1431,11 @@ func bigIntegerXor(params []interface{}) interface{} {
 
 	// Create return object
 	obj := object.MakePrimitiveObject(bigIntegerClassName, types.BigInteger, zz)
+
+	// Set signum field to the sign.
+	signum := zz.Sign()
+	fld := object.Field{Ftype: types.BigInteger, Fvalue: signum}
+	obj.FieldTable["signum"] = fld
+
 	return obj
 }

--- a/src/gfunction/javaUtilRandom.go
+++ b/src/gfunction/javaUtilRandom.go
@@ -31,7 +31,7 @@ func Load_Util_Random() {
 			GFunction:  randomInitLong,
 		}
 
-	MethodSignatures["java/util/Random.next(I)V"] =
+	MethodSignatures["java/util/Random.next(I)I"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  trapFunction,

--- a/src/gfunction/javaUtilRandom.go
+++ b/src/gfunction/javaUtilRandom.go
@@ -31,6 +31,12 @@ func Load_Util_Random() {
 			GFunction:  randomInitLong,
 		}
 
+	MethodSignatures["java/util/Random.next(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
 	MethodSignatures["java/util/Random.nextBoolean()Z"] =
 		GMeth{
 			ParamSlots: 0,

--- a/src/globals/globals.go
+++ b/src/globals/globals.go
@@ -17,6 +17,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 )
 
 var StringEnvVarHeadless = "java.awt.headless"
@@ -109,6 +110,10 @@ var StringIndexString uint32
 // LoaderWg is a wait group for various channels used for parallel loading of classes.
 var LoaderWg sync.WaitGroup
 
+// Standard Sleep amount in milliseconds used in various places.
+var SleepMsecs time.Duration = 5
+
+// Instantiate the Globals struct.
 var global Globals
 
 // InitGlobals initializes the global values that are known at start-up

--- a/src/jvm/gfunctionExec.go
+++ b/src/jvm/gfunctionExec.go
@@ -16,10 +16,16 @@ import (
 	"jacobin/frames"
 	"jacobin/gfunction"
 	"jacobin/log"
+	"jacobin/object"
 	"slices"
+	"sync"
+	"time"
 )
 
 var CaughtGfunctionException = errors.New("caught gfunction exception")
+
+var thSafeMap sync.Map
+var dummy uint8
 
 // Execution of gfunctions (that is, Java functions ported to golang).
 // As part of JACOBIN-519, this code seeks to replace the previous set of
@@ -49,6 +55,7 @@ func runGfunction(mt classloader.MTentry, fs *list.List,
 		*params = append(*params, fs)
 	}
 
+	// Compute the parameter count.
 	var paramCount int
 	if params == nil {
 		paramCount = 0
@@ -56,6 +63,7 @@ func runGfunction(mt classloader.MTentry, fs *list.List,
 		paramCount = len(*params)
 	}
 
+	// Form the full method name.
 	fullMethName := fmt.Sprintf("%s.%s%s", className, methodName, methodType)
 	if MainThread.Trace {
 		traceInfo := fmt.Sprintf("runGfunction: %s, objectRef: %v, paramSlots: %d",
@@ -64,16 +72,47 @@ func runGfunction(mt classloader.MTentry, fs *list.List,
 		logTraceStack(f)
 	}
 
+	// Reverse the parameter order. Last appended will be fetched first.
 	if paramCount > 0 {
 		slices.Reverse(*params)
 	}
 
+	// Discern between thread-safe G functions and ordinary ones.
+	// No matter what, ret = the result from the G function.
 	var ret any
-	// call the function, passing it a pointer to the slice of arguments
-	if paramCount == 0 {
-		ret = mt.Meth.(gfunction.GMeth).GFunction(nil)
+	gmeth := mt.Meth.(gfunction.GMeth)
+	if gmeth.ThreadSafe {
+		var loaded = true
+		// Make sure that an object reference is the first parameter.
+		if !objRef {
+			errMsg := "Thread-safe G function requested but no object reference was supplied"
+			exceptions.ThrowEx(excNames.IllegalArgumentException, errMsg, f)
+		}
+		// Get key = object pointer.
+		key := (*(params))[0].(*object.Object)
+		// Lock the key.
+	lockloop:
+		_, loaded = thSafeMap.LoadOrStore(key, dummy)
+		if loaded {
+			time.Sleep(100 * time.Millisecond)
+			goto lockloop
+		}
+		// The key is locked to me.
+		// Call the G function, passing it a pointer to the slice of arguments.
+		if paramCount == 0 {
+			ret = gmeth.GFunction(nil)
+		} else {
+			ret = gmeth.GFunction(*params)
+		}
+		// Unlock thw key.
+		thSafeMap.Delete(key)
 	} else {
-		ret = mt.Meth.(gfunction.GMeth).GFunction(*params)
+		// Call the function, passing it a pointer to the slice of arguments.
+		if paramCount == 0 {
+			ret = gmeth.GFunction(nil)
+		} else {
+			ret = gmeth.GFunction(*params)
+		}
 	}
 
 	// if an error occured

--- a/src/jvm/gfunctionExec.go
+++ b/src/jvm/gfunctionExec.go
@@ -15,6 +15,7 @@ import (
 	"jacobin/exceptions"
 	"jacobin/frames"
 	"jacobin/gfunction"
+	"jacobin/globals"
 	"jacobin/log"
 	"jacobin/object"
 	"slices"
@@ -94,7 +95,7 @@ func runGfunction(mt classloader.MTentry, fs *list.List,
 	lockloop:
 		_, loaded = thSafeMap.LoadOrStore(key, dummy)
 		if loaded {
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(globals.SleepMsecs * time.Millisecond) // sleep awhile
 			goto lockloop
 		}
 		// The key is locked to me.


### PR DESCRIPTION
*  gfunction/gfunction.go - add ```ThreadSafe   bool``` to ```GMeth``` struct.
* gfunction/javaLangStringBuffer.go - add ```ThreadSafe: true``` everywhere except ```<clinit>``` (justReturn caller).
* Off topic but ..... gfunction/javaMathBigInteger.go - add ```signum``` field to object ```BigInteger```.
* jvm/gfunctionExec.go - use ```Gmeth.ThreadSafe``` boolean to govern the use of lock/unlock.

JACOBIN-547 - Add String <init> functions for argument types String, StringBuilder, & StringBuffer

JACOBIN-566 - Use standard ```globals.SleepMsecs``` (currently, = 5 msecs) in classloader/methArea.go, globals/globals.go, and jvm/gfunctionExec.go.
