### PR TITLE
JACOBIN-577 String.intern(), a native, called outside of String class

### DIFF
--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -571,6 +571,12 @@ func Load_Lang_String() {
 			GFunction:  valueOfObject,
 		}
 
+	MethodSignatures["java/lang/String.intern()Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  stringIntern,
+		}
+
 }
 
 // ==== INSTANTIATION AND INITIALIZATION FUNCTIONS ====
@@ -1307,4 +1313,37 @@ func valueOfObject(params []interface{}) interface{} {
 
 	outObj := object.StringObjectFromGoString(str)
 	return outObj
+}
+
+// "java/lang/String.intern()Ljava/lang/String;"
+/**
+* Returns a canonical representation for the string object.
+* <p>
+* A pool of strings, initially empty, is maintained privately by the
+* class {@code String}.
+* <p>
+* When the intern method is invoked, if the pool already contains a
+* string equal to this {@code String} object as determined by
+* the {@link #equals(Object)} method, then the string from the pool is
+* returned. Otherwise, this {@code String} object is added to the
+* pool and a reference to this {@code String} object is returned.
+* <p>
+* It follows that for any two strings {@code s} and {@code t},
+* {@code s.intern() == t.intern()} is {@code true}
+* if and only if {@code s.equals(t)} is {@code true}.
+* <p>
+* All literal strings and string-valued constant expressions are
+* interned. String literals are defined in section {@jls 3.10.5} of the
+* <cite>The Java Language Specification</cite>.
+*
+* @return  a string that has the same contents as this string, but is
+*          guaranteed to be from a pool of unique strings.
+
+public native String intern();
+*/
+func stringIntern(params []interface{}) interface{} {
+	// params[0]: String object
+	// TODO: Need to add this to the String pool?
+	obj := params[0].(*object.Object)
+	return obj
 }


### PR DESCRIPTION
Before this fix, ```String.intern()``` was diagnosed as a Java native function (true).
Fix: The G function stringIntern() simply returns the input String object.
**TODO** (marked in source code): Should we add the input string to the string pool if not yet present?

This fix peels the onion to this crash:
```
com.sun.jdi.InternalException: locateExceptionFrame: Method jdk/internal/misc/CDS.<clinit> not found in MTable
 
goroutine 1 [running]:
jacobin/exceptions.minimalAbort(0x2e, {0xc004889c70, 0x4f})
	/home/elkins/BASIS/jacobin/src/exceptions/throw.go:282 +0x26
jacobin/exceptions.locateExceptionFrame(0xc00009a420, {0xc0048b92f0, 0x27}, 0x0)
	/home/elkins/BASIS/jacobin/src/exceptions/catchFrame.go:67 +0x125
jacobin/exceptions.FindCatchFrame(0xc0038c2510, {0xc0048b92f0?, 0x1?}, 0x2?)
	/home/elkins/BASIS/jacobin/src/exceptions/catchFrame.go:44 +0xad
jacobin/jvm.runFrame(0xc0038c2510)
	/home/elkins/BASIS/jacobin/src/jvm/run.go:2341 +0x3e5
jacobin/jvm.runJavaInitializer({0x5d7040?, 0xc003c3c200?}, 0xc004e8c6c0, 0x8?)
	/home/elkins/BASIS/jacobin/src/jvm/initializerBlock.go:118 +0x5e5
jacobin/jvm.runInitializationBlock(0xc004e8c6c0, {0x0?, 0xc004349a28?, 0x15?}, 0xc004349a58?)
	/home/elkins/BASIS/jacobin/src/jvm/initializerBlock.go:69 +0x35b
jacobin/jvm.runFrame(0xc0038c2510)
	/home/elkins/BASIS/jacobin/src/jvm/run.go:2295 +0xc392
jacobin/jvm.runJavaInitializer({0x5d7040?, 0xc003ed5e00?}, 0xc0038014e0, 0x8?)
	/home/elkins/BASIS/jacobin/src/jvm/initializerBlock.go:118 +0x5e5
jacobin/jvm.runInitializationBlock(0xc0038014e0, {0x0?, 0xc003cc0198?, 0x12?}, 0xc002de0210?)
	/home/elkins/BASIS/jacobin/src/jvm/initializerBlock.go:69 +0x35b
jacobin/jvm.runFrame(0xc0038c2510)
	/home/elkins/BASIS/jacobin/src/jvm/run.go:2295 +0xc392
jacobin/jvm.runThread(0x749500)
	/home/elkins/BASIS/jacobin/src/jvm/run.go:144 +0x87
jacobin/jvm.StartExec({0xc003e786ec, 0x4}, 0x749500, 0x749f00)
	/home/elkins/BASIS/jacobin/src/jvm/run.go:109 +0xa93
jacobin/jvm.JVMrun()
	/home/elkins/BASIS/jacobin/src/jvm/jvmStart.go:146 +0x7f7
main.main()
	/home/elkins/BASIS/jacobin/src/main.go:12 +0xf
```