### PR TITLE
JACOBIN-586 ensure that DumpStatics is called for all anomalies

### DIFF
--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -107,8 +107,6 @@ func StartExec(className string, mainThread *thread.ExecThread, globals *globals
 
 	err = runThread(&MainThread)
 	if err != nil {
-		statics.DumpStatics()
-		config.DumpConfig(os.Stderr)
 		return err
 	}
 
@@ -132,8 +130,6 @@ func runThread(t *thread.ExecThread) error {
 			exceptions.ShowPanicCause(r)
 			exceptions.ShowFrameStack(t)
 			exceptions.ShowGoStackTrace(nil)
-			statics.DumpStatics()
-			config.DumpConfig(os.Stderr)
 			return shutdown.Exit(shutdown.APP_EXCEPTION)
 		}
 		return shutdown.OK

--- a/src/shutdown/exit.go
+++ b/src/shutdown/exit.go
@@ -8,8 +8,10 @@ package shutdown
 
 import (
 	"fmt"
+	"jacobin/config"
 	"jacobin/globals"
 	"jacobin/log"
+	"jacobin/statics"
 	"os"
 )
 
@@ -26,8 +28,8 @@ const (
 	UNKNOWN_ERROR
 )
 
-// Shutdown is the exit function. Later on, this will check a list of JVM Shutdown hooks
-// before closing down in order to have an orderly exit
+// This is the exit-to-O/S function.
+// TODO: Check a list of JVM Shutdown hooks before closing down in order to have an orderly exit.
 func Exit(errorCondition ExitStatus) int {
 	globals.LoaderWg.Wait()
 	g := globals.GetGlobalRef()
@@ -50,6 +52,10 @@ func Exit(errorCondition ExitStatus) int {
 		return 1
 	}
 
+	if errorCondition != OK {
+		statics.DumpStatics()
+		config.DumpConfig(os.Stderr)
+	}
 	os.Exit(errorCondition)
 
 	return 0 // required by go

--- a/src/statics/statics_test.go
+++ b/src/statics/statics_test.go
@@ -3,9 +3,6 @@ package statics
 import (
 	"fmt"
 	"io"
-	"jacobin/classloader"
-	"sync"
-
 	// "jacobin/classloader"
 	"jacobin/globals"
 	"jacobin/log"
@@ -59,7 +56,8 @@ func tCheckStatic(t *testing.T, className string, fieldName string, expValue any
 func TestStatics1(t *testing.T) {
 	globals.InitGlobals("test")
 	log.Init()
-	// _ = log.SetLogLevel(log.CLASS)
+	Statics = make(map[string]Static)
+	/***
 	PreloadStatics()
 	classloader.MethArea = &sync.Map{}
 	k := classloader.Klass{}
@@ -70,6 +68,9 @@ func TestStatics1(t *testing.T) {
 	k.Data = &clData
 	classloader.MethAreaInsert("AlphaBetaGamma", &k)
 	ref := classloader.MethAreaFetch("AlphaBetaGamma")
+	***/
+	ii := 42
+	ref := &ii
 
 	/**
 	Set statics values.
@@ -92,7 +93,6 @@ func TestStatics1(t *testing.T) {
 	Check statics values.
 	*/
 	tCheckStatic(t, "main", "$assertionsDisabled", int64(1))
-	tCheckStatic(t, types.StringClassName, "COMPACT_STRINGS", true)
 	tCheckStatic(t, "AlphaBetaGamma", "ONE", int64(0x31))
 	tCheckStatic(t, "AlphaBetaGamma", "QM", int64('?'))
 	tCheckStatic(t, "AlphaBetaGamma", "PI", float64(3.14159265))


### PR DESCRIPTION
	modified:   jvm/run.go
	modified:   shutdown/exit.go
	modified:   statics/statics_test.go  (fixed a cycle)
