### PR TITLE
JACOBIN-498 Incremental PR

### DIFF
--- a/src/classloader/classloader.go
+++ b/src/classloader/classloader.go
@@ -840,12 +840,6 @@ func Init() error {
 
 	// Load the base jmod
 	GetBaseJmodBytes()
-	_, err := GetClassBytes("java.base.jmod", types.StringClassName)
-	if err != nil {
-		msg := fmt.Sprintf("classloader.Init: GetClassBytes failed for java/lang/String in java.base.jmod")
-		_ = log.Log(msg, log.SEVERE)
-		shutdown.Exit(shutdown.JVM_EXCEPTION)
-	}
 
 	// initialize the method area
 	InitMethodArea()

--- a/src/globals/globals.go
+++ b/src/globals/globals.go
@@ -102,6 +102,13 @@ type Globals struct {
 	FuncFillInStackTrace func([]any) any
 }
 
+// ---- trace categories
+var TraceInit bool
+var TraceCloadi bool
+var TraceInst bool
+var TraceClass bool
+var TraceVerbose bool
+
 // ----- String Pool
 var StringPoolTable map[string]uint32
 var StringPoolList []string

--- a/src/trace/trace.go
+++ b/src/trace/trace.go
@@ -1,0 +1,58 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2021-2 by the Jacobin authors. All rights reserved.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)
+ */
+
+package trace
+
+// The principal logging function. Note it currently logs to stderr.
+// At some future point, might allow the user to specify where logging should go.
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+// Should never see an indication of an empty trace message!
+const EmptyMsg = "*** EMPTY LOGGING MESSAGE !!!"
+
+// Mutex for protecting the Log function during multithreading.
+var mutex = sync.Mutex{}
+
+// StartTime is the start time of this instance of the Jacoby VM.
+var StartTime time.Time
+
+// Initialize the trace frame.
+func Init() {
+	StartTime = time.Now()
+}
+
+// Trace is the principal tracing function. Note that it currently
+// writes to stderr. At some future point, this might become an option.
+func Trace(msg string) {
+
+	var err error
+
+	if len(msg) == 0 {
+		msg = EmptyMsg
+	}
+
+	// if the message is more low-level than a WARNING,
+	// prefix it with the elapsed time in millisecs.
+	duration := time.Since(StartTime)
+	var millis = duration.Milliseconds()
+
+	// Lock access to the logging stream to prevent inter-thread overwrite issues
+	mutex.Lock()
+	_, err = fmt.Fprintf(os.Stderr, "[%3d.%03ds] %s\n", millis/1000, millis%1000, msg)
+	mutex.Unlock()
+
+	// Report on stdout if stderr failed
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stdout, "[%3d.%03ds] *** stderr failed, err: %v\n", millis/1000, millis%1000, err)
+		_, _ = fmt.Fprintf(os.Stdout, "[%3d.%03ds] %s\n", millis/1000, millis%1000, msg)
+	}
+
+}

--- a/src/trace/trace_test.go
+++ b/src/trace/trace_test.go
@@ -1,0 +1,118 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2021 by the Jacobin authors. All rights reserved.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)
+ */
+
+package trace
+
+import (
+	"io"
+	"jacobin/globals"
+	"os"
+	"strings"
+	"testing"
+)
+
+func initialize() {
+	globals.InitGlobals("test")
+	Init()
+}
+
+func TestEmptyTraceMessage(t *testing.T) {
+
+	initialize()
+
+	// Save existing stderr
+	savedStderr := os.Stderr
+
+	// Capture the writing done to stderr in a pipe
+	rdr, wrtr, _ := os.Pipe()
+	os.Stderr = wrtr
+	Trace("")
+	_ = wrtr.Close()
+
+	// Restore stderr to what it was before
+	os.Stderr = savedStderr
+
+	// Collect stderr output bytes --> string
+	outBytes, _ := io.ReadAll(rdr)
+	outString := string(outBytes[:])
+
+	// What we expected?
+	if !strings.Contains(outString, EmptyMsg) { // No
+		t.Errorf("Empty trace message failed: expected [%s] as a subset of [%s]\n", EmptyMsg, outString)
+	}
+
+}
+
+func TestValidTraceMessage(t *testing.T) {
+
+	initialize()
+
+	const expected = "Mary had a little lamb whose fleece was white as snow"
+
+	// Save existing stderr
+	savedStderr := os.Stderr
+
+	// Capture the writing done to stderr in a pipe
+	rdr, wrtr, _ := os.Pipe()
+	os.Stderr = wrtr
+	Trace(expected)
+	_ = wrtr.Close()
+
+	// Restore stderr to what it was before
+	os.Stderr = savedStderr
+
+	// Collect stderr output bytes --> string
+	outBytes, _ := io.ReadAll(rdr)
+	outString := string(outBytes[:])
+
+	// What we expected?
+	if !strings.Contains(outString, expected) { // No
+		t.Errorf("Nonempty trace message failed: expected [%s] as a subset of [%s]\n", EmptyMsg, outString)
+	}
+
+}
+
+func TestFailoverToStdout(t *testing.T) {
+
+	initialize()
+
+	const expected = "Mary had a little lamb whose fleece was white as snow"
+
+	// Save existing stderr
+	savedStderr := os.Stderr
+	savedStdout := os.Stdout
+
+	// Set up stderr from a pipe and then close it
+	_, wrtrErr, _ := os.Pipe()
+	os.Stderr = wrtrErr
+	err := os.Stderr.Close()
+	if err != nil {
+		os.Stderr = savedStderr
+		os.Stdout = savedStdout
+		t.Errorf("Failed to close os.Stderr, err: %v\n", err)
+	}
+
+	// Capture the writing done to stdout in a pipe
+	rdrOut, wrtrOut, _ := os.Pipe()
+	os.Stdout = wrtrOut
+
+	Trace(expected)
+	_ = wrtrOut.Close()
+
+	// Restore stderr to what it was before
+	os.Stderr = savedStderr
+	os.Stdout = savedStdout
+
+	// Collect stderr output bytes --> string
+	outBytes, _ := io.ReadAll(rdrOut)
+	outString := string(outBytes[:])
+
+	// What we expected?
+	if !strings.Contains(outString, expected) { // No
+		t.Errorf("Stdout trace message failed: expected [%s] as a subset of [%s]\n", EmptyMsg, outString)
+	}
+
+}


### PR DESCRIPTION
First commit:
* trace/trace.go (new)
* trace/trace_test.go (new)
* globals/globals.go  <--- only the Trace flags; still need to do the CLI options in concert with jvm/cli.go and jvm/option_table_loader.go
* classloader/classloader.go <--- One-off loading of java/lang/Class during init is unnecessary

The complete list of files to convert i.e. TBD (mostly, log.Log calls to trace.Trace calls conditioned on the new globals.Trace* flags):

1. classloader/archives.go
2. classloader/classes.go
3. classloader/classloader.go
4. classloader/formatCheck.go
5. classloader/jmodBase.go
6. classloader/jmodBytes.go
7. classloader/jmodMap.go
8. classloader/methArea.go
9. classloader/methodParser.go
10. classloader/parser.go
11. exceptions/catchFrame.go
12. exceptions/errors.go
13. exceptions/throw.go
14. frames/frames.go
15. gfunction/gfunctionExec.go
16. gfunction/javaIoFile.go
17. gfunction/javaLangClass.go
18. gfunction/javaLangMath.go
19. gfunction/javaLangStackTraceElement.go
20. gfunction/javaLangSystem.go
21. gfunction/javaLangThrowable.go
22. gfunction/javaMathBigInteger.go
23. globals/globals.go // <------ CLI options in concert with jvm/cli.go and jvm/option_table_loader.go
24. jvm/cli.go
25. jvm/initializerBlock.go
26. jvm/instantiate.go
27. jvm/jvmStart.go
28. jvm/run.go
29. jvm/runUtils.go
30. native/nativeFuncExec.go
31. native/nativeInit.go
32. native/osBridgePosix.go
33. native/osBridgeWindows.go
34. object/string.go
35. statics/statics.go
36. util/execUtilities.go


