### PR TITLE
Fixed Double bug as documented in recent email

### DIFF
--- a/src/gfunction/javaLangDouble.go
+++ b/src/gfunction/javaLangDouble.go
@@ -100,7 +100,7 @@ func doubleByteValue(params []interface{}) interface{} {
 // "java/lang/Double.compare(DD)I"
 func doubleCompare(params []interface{}) interface{} {
 	dd1 := params[0].(float64)
-	dd2 := params[1].(float64)
+	dd2 := params[2].(float64)
 	if dd1 == dd2 {
 		return int64(0)
 	}


### PR DESCRIPTION
In javaLangDouble.go, function Double.compare(doubleA, doubleB)
```
    MethodSignatures["java/lang/Double.compare(DD)I"] =
            GMeth{
                ParamSlots: 4,
                GFunction:  doubleCompare,
            }

    // "java/lang/Double.compare(DD)I" (corrected from current source code!)
    func doubleCompare(params []interface{}) interface{} {
        dd1 := params[0].(float64)
        dd2 := params[2].(float64) // Corrected: 1 --> 2 !
        if dd1 == dd2 {
            return int64(0)
        }
        if dd1 < dd2 {
            return int64(-1)
        }
        return int(1)
    }
```