### PR TITLE
JACOBIN-498 check trace.Trace duration value

### DIFF
--- a/src/jvm/jvmStart.go
+++ b/src/jvm/jvmStart.go
@@ -29,6 +29,8 @@ var globPtr *globals.Globals
 // instead an int is returned (because calling exit() during testing exits the testing run as well).
 func JVMrun() int {
 
+	trace.Init()
+
 	// capture any panics and print diagnostic data
 	defer func() int {
 		if r := recover(); r != nil {

--- a/src/trace/trace.go
+++ b/src/trace/trace.go
@@ -40,6 +40,7 @@ func Trace(argMsg string) {
 
 	// if the message is more low-level than a WARNING,
 	// prefix it with the elapsed time in millisecs.
+	// check duration accuracy: time.Sleep(100 * time.Millisecond)
 	duration := time.Since(StartTime)
 	var millis = duration.Milliseconds()
 


### PR DESCRIPTION
1. I forgot to call trace.Init() in jvmStart.go but it makes little difference.
2. I checked the duration calculation by inserting a time.Sleep call for 100 ms in trace.Trace. The calculation is accurate. I subsequently commented out the time.Sleep call.

I don't know why the trace shows insignificant elapsed time. What was the case when we used the log package? I'd guess that the same phenomenon occured.