### PR TITLE
JACOBIN-598 need to allocate double-slots for local variables type D and J; JACOBIN-592 fix arguments in various functions

### DIFF
--- a/src/gfunction/javaLangMath.go
+++ b/src/gfunction/javaLangMath.go
@@ -250,7 +250,7 @@ func addExactII(params []interface{}) interface{} {
 	return params[0].(int64) + params[1].(int64)
 }
 func addExactJJ(params []interface{}) interface{} {
-	return params[0].(int64) + params[2].(int64)
+	return params[0].(int64) + params[1].(int64)
 }
 
 // Arc sine of a value; the returned angle is in the range -pi/2 through pi/2.
@@ -266,7 +266,7 @@ func atanFloat64(params []interface{}) interface{} {
 // Returns the angle theta from the conversion of rectangular coordinates (x, y)
 // to polar coordinates (r, theta).
 func atan2Float64(params []interface{}) interface{} {
-	return math.Atan2(params[0].(float64), params[2].(float64))
+	return math.Atan2(params[0].(float64), params[1].(float64))
 }
 
 // Cube root of a double value.
@@ -285,7 +285,7 @@ func copySignFF(params []interface{}) interface{} {
 	return math.Copysign(params[0].(float64), params[1].(float64))
 }
 func copySignDD(params []interface{}) interface{} {
-	return math.Copysign(params[0].(float64), params[2].(float64))
+	return math.Copysign(params[0].(float64), params[1].(float64))
 }
 
 // Cosine of an angle expressed in radians.

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -3346,9 +3346,16 @@ func createAndInitNewFrame(
 		trace.Trace(traceInfo)
 	}
 
+	ptpx := 0
 	for j := lenArgList - 1; j >= 0; j-- {
 		fram.Locals[destLocal] = argList[j]
-		destLocal += 1
+		switch paramsToPass[ptpx] {
+		case "D", "J":
+			destLocal += 2
+		default:
+			destLocal += 1
+		}
+		ptpx++
 	}
 
 	fram.TOS = -1


### PR DESCRIPTION
Modified: 
* jvm/run.go function createAndInitNewFrame, near the end
* gfunction/javaLangMath.go - fix double arguments in addExactJJ, atan2Float64, and copySignDD