### PR TITLE
jacobin-610 Alleviate some of anomalies that jacotest case JACOBIN-0433-HexFormat is exposing

### DIFF
--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -132,15 +132,19 @@ func Load_Traps() {
 			GFunction:  trapDeprecated,
 		}
 
-	// Class initialisation for Console.
 	MethodSignatures["java/nio/charset/Charset.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapFunction,
 		}
 
-	// Get the default character set.
 	MethodSignatures["java/nio/charset/Charset.defaultCharset()Ljava/nio/charset/Charset;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/nio/charset/StandardCharsets.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapFunction,

--- a/src/gfunction/otherMethods.go
+++ b/src/gfunction/otherMethods.go
@@ -68,14 +68,6 @@ func Load_Other_methods() {
 			GFunction:  clinitGeneric,
 		}
 
-	/***
-	MethodSignatures["java/util/HexFormat.<clinit>()V"] =
-		GMeth{
-			ParamSlots: 0,
-			GFunction:  clinitGeneric,
-		}
-		***/
-
 	MethodSignatures["java/util/Locale$Category.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,


### PR DESCRIPTION
* added `java/nio/charset/StandardCharsets.<clinit>()V` as a `trapFunction` in `otherModules.go`