### PR TITLE
JACOBIN-614 vastly improved support for HexFormat but one gerkhin: equals()

### DIFF
--- a/src/gfunction/javaUtilHexFormat.go
+++ b/src/gfunction/javaUtilHexFormat.go
@@ -8,6 +8,7 @@ package gfunction
 
 import (
 	"fmt"
+	"jacobin/excNames"
 	"jacobin/object"
 	"jacobin/statics"
 	"jacobin/types"
@@ -41,10 +42,22 @@ func Load_Util_HexFormat() {
 			GFunction:  hfFormatHexFromBytes,
 		}
 
+	MethodSignatures["java/util/HexFormat.formatHex([BII)Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  hfFormatHexFromBytes,
+		}
+
 	MethodSignatures["java/util/HexFormat.fromHexDigits(Ljava/lang/CharSequence;)V"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/HexFormat.fromHexDigit(I)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  hfFromHexDigit,
 		}
 
 	MethodSignatures["java/util/HexFormat.fromHexDigits(Ljava/lang/CharSequence;II)V"] =
@@ -65,6 +78,30 @@ func Load_Util_HexFormat() {
 			GFunction:  trapFunction,
 		}
 
+	MethodSignatures["java/util/HexFormat.hashCode()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/HexFormat.of()Ljava/util/HexFormat;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  hfOf,
+		}
+
+	MethodSignatures["java/util/HexFormat.ofDelimiter(Ljava/lang/String;)Ljava/util/HexFormat;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  hfOfDelimiter,
+		}
+
+	MethodSignatures["java/util/HexFormat.parseHex([CII)[B"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  trapFunction,
+		}
+
 	MethodSignatures["java/util/HexFormat.parseHex(Ljava/lang/CharSequence;)V"] =
 		GMeth{
 			ParamSlots: 1,
@@ -75,6 +112,18 @@ func Load_Util_HexFormat() {
 		GMeth{
 			ParamSlots: 3,
 			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/HexFormat.prefix()Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  hfPrefix,
+		}
+
+	MethodSignatures["java/util/HexFormat.suffix()Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  hfSuffix,
 		}
 
 	MethodSignatures["java/util/HexFormat.toHexDigits(B)Ljava/lang/String;"] =
@@ -113,10 +162,52 @@ func Load_Util_HexFormat() {
 			GFunction:  hfShortToHexDigits,
 		}
 
+	MethodSignatures["java/util/HexFormat.toHighHexDigit(I)C"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  hfToHighHexDigit,
+		}
+
+	MethodSignatures["java/util/HexFormat.toLowHexDigit(I)C"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  hfToLowHexDigit,
+		}
+
 	MethodSignatures["java/util/HexFormat.toString()Ljava/lang/String;"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  hfToString,
+		}
+
+	MethodSignatures["java/util/HexFormat.withDelimiter(Ljava/lang/String;)Ljava/util/HexFormat;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  hfWithDelimiter,
+		}
+
+	MethodSignatures["java/util/HexFormat.withLowerCase()Ljava/util/HexFormat;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  hfWithLowerCase,
+		}
+
+	MethodSignatures["java/util/HexFormat.withPrefix(Ljava/lang/String;)Ljava/util/HexFormat;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  hfWithPrefix,
+		}
+
+	MethodSignatures["java/util/HexFormat.withSuffix(Ljava/lang/String;)Ljava/util/HexFormat;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  hfWithSuffix,
+		}
+
+	MethodSignatures["java/util/HexFormat.withUpperCase()Ljava/util/HexFormat;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  hfWithUpperCase,
 		}
 
 }
@@ -141,47 +232,49 @@ func hexFormatClinit(params []interface{}) interface{} {
 		255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
 		255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
 	}
-	sDigits := statics.Static{Type: "[B", Value: DIGITS}
+	sDigits := statics.Static{Type: types.ByteArray, Value: DIGITS}
 	statics.AddStatic("java/util/HexFormat.DIGITS", sDigits)
 
 	UPPERCASE_DIGITS := []uint8{
 		'0', '1', '2', '3', '4', '5', '6', '7',
 		'8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
 	}
-	sUppercaseDigits := statics.Static{Type: "[B", Value: UPPERCASE_DIGITS}
+	sUppercaseDigits := statics.Static{Type: types.ByteArray, Value: UPPERCASE_DIGITS}
 	statics.AddStatic("java/util/HexFormat.UPPERCASE_DIGITS", sUppercaseDigits)
 
 	LOWERCASE_DIGITS := []uint8{
 		'0', '1', '2', '3', '4', '5', '6', '7',
 		'8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
 	}
-	sLowercaseDigits := statics.Static{Type: "[B", Value: LOWERCASE_DIGITS}
+	sLowercaseDigits := statics.Static{Type: types.ByteArray, Value: LOWERCASE_DIGITS}
 	statics.AddStatic("java/util/HexFormat.LOWERCASE_DIGITS", sLowercaseDigits)
 
-	obj := mkHexFormatObject("", "", "", LOWERCASE_DIGITS, false)
+	obj := mkHexFormatObject([]byte{}, []byte{}, []byte{}, LOWERCASE_DIGITS)
 	sHexFormat := statics.Static{Type: "java/util/HexFormat", Value: obj}
 	statics.AddStatic("java/util/HexFormat.HEX_FORMAT", sHexFormat)
 
-	sEmptyBytes := statics.Static{Type: "[B", Value: []byte{}}
+	sEmptyBytes := statics.Static{Type: types.ByteArray, Value: []byte{}}
 	statics.AddStatic("java/util/HexFormat.EMPTY_BYTES", sEmptyBytes)
+
+	sJavaLangAccess := statics.Static{Type: types.Int, Value: 42}
+	statics.AddStatic("java/util/HexFormat.jla", sJavaLangAccess)
 
 	return nil
 }
 
 // Make a new HexFormat object and return it to caller.
-func mkHexFormatObject(delimiter, prefix, suffix string, digits []byte, flagUpperCase bool) *object.Object {
+func mkHexFormatObject(delimiter, prefix, suffix, digits []byte) *object.Object {
 	var fld object.Field
 	className := "java/util/HexFormat"
-	ftypeString := "Ljava/lang/String;"
 	obj := object.MakeEmptyObjectWithClassName(&className)
 
-	fld = object.Field{Ftype: ftypeString, Fvalue: object.StringObjectFromGoString(delimiter)}
+	fld = object.Field{Ftype: types.ByteArray, Fvalue: delimiter}
 	obj.FieldTable["delimiter"] = fld
 
-	fld = object.Field{Ftype: ftypeString, Fvalue: object.StringObjectFromGoString(prefix)}
+	fld = object.Field{Ftype: types.ByteArray, Fvalue: prefix}
 	obj.FieldTable["prefix"] = fld
 
-	fld = object.Field{Ftype: ftypeString, Fvalue: object.StringObjectFromGoString(suffix)}
+	fld = object.Field{Ftype: types.ByteArray, Fvalue: suffix}
 	obj.FieldTable["suffix"] = fld
 
 	fld = object.Field{Ftype: types.ByteArray, Fvalue: digits}
@@ -204,6 +297,16 @@ func hfToString(params []interface{}) interface{} {
 func hfDelimiter(params []interface{}) interface{} {
 	obj := params[0].(*object.Object)
 	return object.StringObjectFromByteArray(obj.FieldTable["delimiter"].Fvalue.([]byte))
+}
+
+func hfPrefix(params []interface{}) interface{} {
+	obj := params[0].(*object.Object)
+	return object.StringObjectFromByteArray(obj.FieldTable["prefix"].Fvalue.([]byte))
+}
+
+func hfSuffix(params []interface{}) interface{} {
+	obj := params[0].(*object.Object)
+	return object.StringObjectFromByteArray(obj.FieldTable["suffix"].Fvalue.([]byte))
 }
 
 func hfByteToHexDigits(params []interface{}) interface{} {
@@ -306,20 +409,145 @@ func hfShortToHexDigits(params []interface{}) interface{} {
 }
 
 // Format a hex string from a byte slice.
+// if the fromIndex and toIndex are given in params, use their values.
 func hfFormatHexFromBytes(params []interface{}) interface{} {
 	str := ""
 	this := params[0].(*object.Object)
 	digits := this.FieldTable["digits"].Fvalue.([]byte)
 	delimiter := string(this.FieldTable["delimiter"].Fvalue.([]byte))
+	prefix := string(this.FieldTable["prefix"].Fvalue.([]byte))
+	suffix := string(this.FieldTable["suffix"].Fvalue.([]byte))
 	objBytes := params[1].(*object.Object)
 	bytes := objBytes.FieldTable["value"].Fvalue.([]byte)
-	for ix := 0; ix < len(bytes); ix++ {
+	var fromIndex int
+	var toIndex int
+	if len(params) > 2 {
+		fromIndex = int(params[2].(int64))
+		if fromIndex < 0 || fromIndex > len(bytes) {
+			errMsg := fmt.Sprintf("from index out of range: %d", fromIndex)
+			return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
+		}
+		toIndex = int(params[3].(int64))
+		if toIndex < 0 || toIndex > len(bytes) {
+			errMsg := fmt.Sprintf("to index out of range: %d", fromIndex)
+			return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
+		}
+		if toIndex <= fromIndex {
+			errMsg := fmt.Sprintf("to index <= from index: %d", fromIndex)
+			return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
+		}
+	} else {
+		fromIndex = 0
+		toIndex = len(bytes)
+	}
+	for ix := fromIndex; ix < toIndex; ix++ {
 		if digits[15] == 'F' { // uppercase
-			str += fmt.Sprintf("%02X%s", bytes[ix], delimiter)
+			str += fmt.Sprintf("%s%02X%s%s", prefix, bytes[ix], suffix, delimiter)
 		} else { // lowercase
-			str += fmt.Sprintf("%02x%s", bytes[ix], delimiter)
+			str += fmt.Sprintf("%s%02x%s%s", prefix, bytes[ix], suffix, delimiter)
 		}
 	}
-	str = str[:len(str)-1]
+	str = str[:len(str)-len(delimiter)]
 	return object.StringObjectFromGoString(str)
+}
+
+func hfFromHexDigit(params []interface{}) interface{} {
+	arg := params[0].(int64)
+	if arg < 58 && arg > 47 { // range: '0' to '9'
+		return arg - 48 // arg - '0'
+	}
+	if arg < 71 && arg > 64 { // range: 'A' to 'F'
+		return arg - 55 // arg + 10 - 'A'
+	}
+	if arg < 103 && arg > 96 { // range: 'a' to 'f'
+		return arg - 87 // arg + 10 - 'a'
+	}
+	errMsg := fmt.Sprintf("Out of range: %d", arg)
+	return getGErrBlk(excNames.NumberFormatException, errMsg)
+
+}
+
+func hfOf(params []interface{}) interface{} {
+	return statics.GetStaticValue("java/util/HexFormat", "HEX_FORMAT").(*object.Object)
+}
+
+func hfOfDelimiter(params []interface{}) interface{} {
+	delimiter := params[0].(*object.Object).FieldTable["value"].Fvalue.([]byte)
+	obj := statics.GetStaticValue("java/util/HexFormat", "HEX_FORMAT").(*object.Object)
+	fld := obj.FieldTable["delimiter"]
+	fld.Fvalue = delimiter
+	obj.FieldTable["delimiter"] = fld
+	fld.Fvalue = []byte{}
+	obj.FieldTable["prefix"] = fld
+	obj.FieldTable["suffix"] = fld
+	digits := statics.GetStaticValue("java/util/HexFormat", "LOWERCASE_DIGITS").([]byte)
+	fld = obj.FieldTable["digits"]
+	fld.Fvalue = digits
+	obj.FieldTable["digits"] = fld
+
+	return obj
+}
+
+func hfWithPrefix(params []interface{}) interface{} {
+	obj1 := params[0].(*object.Object)
+	prefix := params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
+	fld := obj1.FieldTable["prefix"]
+	fld.Fvalue = prefix
+	obj2 := object.CopyObject(obj1)
+	obj2.FieldTable["prefix"] = fld
+	return obj2
+}
+
+func hfWithSuffix(params []interface{}) interface{} {
+	obj1 := params[0].(*object.Object)
+	suffix := params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
+	fld := obj1.FieldTable["suffix"]
+	fld.Fvalue = suffix
+	obj2 := object.CopyObject(obj1)
+	obj2.FieldTable["suffix"] = fld
+	return obj2
+}
+
+func hfWithDelimiter(params []interface{}) interface{} {
+	obj1 := params[0].(*object.Object)
+	delimiter := params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
+	fld := obj1.FieldTable["delimiter"]
+	fld.Fvalue = delimiter
+	obj2 := object.CopyObject(obj1)
+	obj2.FieldTable["delimiter"] = fld
+	return obj2
+}
+
+func hfWithUpperCase(params []interface{}) interface{} {
+	obj1 := params[0].(*object.Object)
+	fld := obj1.FieldTable["digits"]
+	digits := statics.GetStaticValue("java/util/HexFormat", "UPPERCASE_DIGITS")
+	fld.Fvalue = digits
+	obj2 := object.CopyObject(obj1)
+	obj2.FieldTable["digits"] = fld
+	return obj2
+}
+
+func hfWithLowerCase(params []interface{}) interface{} {
+	obj1 := params[0].(*object.Object)
+	fld := obj1.FieldTable["digits"]
+	digits := statics.GetStaticValue("java/util/HexFormat", "LOWERCASE_DIGITS")
+	fld.Fvalue = digits
+	obj2 := object.CopyObject(obj1)
+	obj2.FieldTable["digits"] = fld
+	return obj2
+}
+
+func hfToHighHexDigit(params []interface{}) interface{} {
+	obj := params[0].(*object.Object)
+	digits := obj.FieldTable["digits"].Fvalue.([]byte)
+	arg := params[1].(int64) % 256
+	return int64(digits[arg>>4])
+}
+
+func hfToLowHexDigit(params []interface{}) interface{} {
+	obj := params[0].(*object.Object)
+	digits := obj.FieldTable["digits"].Fvalue.([]byte)
+	arg := params[1].(int64) % 256
+	return int64(digits[arg&0x0f])
 }

--- a/src/object/object.go
+++ b/src/object/object.go
@@ -100,6 +100,9 @@ func IsNull(value any) bool {
 
 // Make a replica of an object.
 func CopyObject(oldObject *Object) *Object {
-	newObject := *oldObject
+	var newObject Object
+	newObject.Mark = oldObject.Mark
+	newObject.KlassName = oldObject.KlassName
+	newObject.FieldTable = oldObject.FieldTable
 	return &newObject
 }

--- a/src/object/object.go
+++ b/src/object/object.go
@@ -97,3 +97,9 @@ func IsNull(value any) bool {
 	}
 	return value == nil
 }
+
+// Make a replica of an object.
+func CopyObject(oldObject *Object) *Object {
+	newObject := *oldObject
+	return &newObject
+}

--- a/src/object/object.go
+++ b/src/object/object.go
@@ -100,9 +100,9 @@ func IsNull(value any) bool {
 
 // Make a replica of an object.
 func CopyObject(oldObject *Object) *Object {
-	var newObject Object
+	newObject := MakeEmptyObject()
 	newObject.Mark = oldObject.Mark
 	newObject.KlassName = oldObject.KlassName
 	newObject.FieldTable = oldObject.FieldTable
-	return &newObject
+	return newObject
 }


### PR DESCRIPTION
All but this:
* java/lang/CharSequence - bah!
* hashCode()
* java/util/HexFormat.parseHex([CII)[B

Everything works except equals(), not that I think that many folks are really comparing  2 HexFormat objects.
I think the trouble lies with the HEX_FORMAT static object because functions of() and ofDelimiter() needed extra field assignments that should not have been necessary. Hexxed?

@platypusguy  PLEASE review. 
