### PR TITLE
JACOBIN-614, JACOBIN-615, and JACOBIN-601 fixes

### DIFF
--- a/src/gfunction/javaLangDouble.go
+++ b/src/gfunction/javaLangDouble.go
@@ -87,6 +87,18 @@ func Load_Lang_Double() {
 			GFunction:  longBitsToDouble,
 		}
 
+	MethodSignatures["java/lang/Double.valueOf(Ljava/lang/String;)Ljava/lang/Double;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  doubleValueOf,
+		}
+
+	MethodSignatures["java/lang/Double.valueOf(D)Ljava/lang/Double;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  doubleValueOf,
+		}
+
 }
 
 // "java/lang/Double.byteValue()B"
@@ -215,4 +227,28 @@ func doubleToLongBits(params []interface{}) interface{} {
 func longBitsToDouble(params []interface{}) interface{} {
 	bits := params[0].(int64)
 	return math.Float64frombits(uint64(bits))
+}
+
+func doubleValueOf(params []interface{}) interface{} {
+	className := "java/lang/Double"
+	obj := object.MakeEmptyObjectWithClassName(&className)
+	switch params[0].(type) {
+	case float64:
+		obj.FieldTable["value"] = object.Field{Ftype: types.Double, Fvalue: params[0].(float64)}
+	case *object.Object:
+		that := params[0].(*object.Object)
+		str := string(that.FieldTable["value"].Fvalue.([]byte))
+		if len(str) < 1 {
+			return getGErrBlk(excNames.NullPointerException, "doubleValueOf: nil string argument")
+		}
+		dbl, err := strconv.ParseFloat(str, 64)
+		if err != nil {
+			return getGErrBlk(excNames.NumberFormatException, "doubleValueOf: "+err.Error())
+		}
+		obj.FieldTable["value"] = object.Field{Ftype: types.Double, Fvalue: dbl}
+	default:
+		errMsg := fmt.Sprintf("doubleValueOf: unrecognizable parameter type: %T", params[0])
+		return getGErrBlk(excNames.NumberFormatException, errMsg)
+	}
+	return obj
 }

--- a/src/gfunction/javaLangStringBuilder.go
+++ b/src/gfunction/javaLangStringBuilder.go
@@ -463,14 +463,10 @@ func stringBuilderAppend(params []any) any {
 	objBase := params[0].(*object.Object)
 	byteArray := objBase.FieldTable["value"].Fvalue.([]byte)
 
-	// Initialise the output object.
-	objOut := object.MakeEmptyObjectWithClassName(&classStringBuilder)
-	objOut.FieldTable = objBase.FieldTable
-
 	// Resolved parameter byte array, regardless of parameters:
 	var parmArray []byte
 
-	// Process based primarily on the params[0] type.
+	// Process based primarily on the params[1] type.
 	switch params[1].(type) {
 	case *object.Object: // char array, Object, String, StringBuffer, or StringBuilder
 		fvalue := params[1].(*object.Object).FieldTable["value"].Fvalue
@@ -516,11 +512,11 @@ func stringBuilderAppend(params []any) any {
 	// Set the byte count.
 	byteArray = append(byteArray, parmArray...)
 	count := int64(len(byteArray))
-	objOut.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
-	objOut.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
-	expandCapacity(objOut, count)
+	objBase.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
+	objBase.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
+	expandCapacity(objBase, count)
 
-	return objOut
+	return objBase
 }
 
 // Append the second parameter (boolean) to the bytes in the StringBuilder that is
@@ -529,10 +525,6 @@ func stringBuilderAppendBoolean(params []any) any {
 	// Get base object and its value field, byteArray.
 	objBase := params[0].(*object.Object)
 	byteArray := objBase.FieldTable["value"].Fvalue.([]byte)
-
-	// Initialise the output object.
-	objOut := object.MakeEmptyObjectWithClassName(&classStringBuilder)
-	objOut.FieldTable = objBase.FieldTable
 
 	var parmArray []byte
 	switch params[1].(type) {
@@ -553,11 +545,11 @@ func stringBuilderAppendBoolean(params []any) any {
 	// Set the byte count.
 	byteArray = append(byteArray, parmArray...)
 	count := int64(len(byteArray))
-	objOut.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
-	objOut.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
-	expandCapacity(objOut, count)
+	objBase.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
+	objBase.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
+	expandCapacity(objBase, count)
 
-	return objOut
+	return objBase
 }
 
 // Append the second parameter (char) to the bytes in the StringBuilder that is
@@ -566,10 +558,6 @@ func stringBuilderAppendChar(params []any) any {
 	// Get base object and its value field, byteArray.
 	objBase := params[0].(*object.Object)
 	byteArray := objBase.FieldTable["value"].Fvalue.([]byte)
-
-	// Initialise the output object.
-	objOut := object.MakeEmptyObjectWithClassName(&classStringBuilder)
-	objOut.FieldTable = objBase.FieldTable
 
 	var parmArray = make([]byte, 1)
 	switch params[1].(type) {
@@ -585,11 +573,11 @@ func stringBuilderAppendChar(params []any) any {
 	// Set the byte count.
 	byteArray = append(byteArray, parmArray...)
 	count := int64(len(byteArray))
-	objOut.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
-	objOut.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
-	expandCapacity(objOut, count)
+	objBase.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
+	objBase.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
+	expandCapacity(objBase, count)
 
-	return objOut
+	return objBase
 }
 
 // Extract a character at the given index.
@@ -647,16 +635,12 @@ func stringBuilderDelete(params []any) any {
 	// New length of byte array --> count.
 	count := int64(len(newArray))
 
-	// Initialise the output object.
-	objOut := object.MakeEmptyObjectWithClassName(&classStringBuilder)
-	objOut.FieldTable = objBase.FieldTable
-
 	// Finalize output object.
-	objOut.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: newArray}
-	objOut.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
-	expandCapacity(objOut, count)
+	objBase.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: newArray}
+	objBase.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
+	expandCapacity(objBase, count)
 
-	return objOut
+	return objBase
 }
 
 // Insert the second parameter to the bytes into the StringBuilder
@@ -672,10 +656,6 @@ func stringBuilderInsert(params []any) any {
 		errMsg := fmt.Sprintf("Index value (%d) is negative or exceeds the byte array size (%d)", ix, len(byteArray))
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 	}
-
-	// Initialise the output object.
-	objOut := object.MakeEmptyObjectWithClassName(&classStringBuilder)
-	objOut.FieldTable = objBase.FieldTable
 
 	var parmArray []byte
 	switch params[2].(type) {
@@ -729,11 +709,11 @@ func stringBuilderInsert(params []any) any {
 	newArray = append(newArray, byteArray[ix:]...)
 	count := int64(len(newArray))
 
-	objOut.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: newArray}
-	objOut.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
-	expandCapacity(objOut, count)
+	objBase.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: newArray}
+	objBase.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
+	expandCapacity(objBase, count)
 
-	return objOut
+	return objBase
 }
 
 // Insert the boolean parameter into the bytes into the StringBuilder
@@ -749,10 +729,6 @@ func stringBuilderInsertBoolean(params []any) any {
 		errMsg := fmt.Sprintf("Index value (%d) is negative or exceeds the byte array size (%d)", ix, len(byteArray))
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 	}
-
-	// Initialise the output object.
-	objOut := object.MakeEmptyObjectWithClassName(&classStringBuilder)
-	objOut.FieldTable = objBase.FieldTable
 
 	var parmArray []byte
 	switch params[2].(type) {
@@ -779,11 +755,11 @@ func stringBuilderInsertBoolean(params []any) any {
 	newArray = append(newArray, byteArray[ix:]...)
 	count := int64(len(newArray))
 
-	objOut.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: newArray}
-	objOut.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
-	expandCapacity(objOut, count)
+	objBase.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: newArray}
+	objBase.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
+	expandCapacity(objBase, count)
 
-	return objOut
+	return objBase
 }
 
 // Insert the char parameter into the bytes into the StringBuilder
@@ -799,10 +775,6 @@ func stringBuilderInsertChar(params []any) any {
 		errMsg := fmt.Sprintf("Index value (%d) is negative or exceeds the byte array size (%d)", ix, len(byteArray))
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 	}
-
-	// Initialise the output object.
-	objOut := object.MakeEmptyObjectWithClassName(&classStringBuilder)
-	objOut.FieldTable = objBase.FieldTable
 
 	var bb byte
 	switch params[2].(type) {
@@ -823,18 +795,18 @@ func stringBuilderInsertChar(params []any) any {
 	newArray = append(newArray, byteArray[ix:]...)
 	count := int64(len(newArray))
 
-	objOut.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: newArray}
-	objOut.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
-	expandCapacity(objOut, count)
+	objBase.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: newArray}
+	objBase.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
+	expandCapacity(objBase, count)
 
-	return objOut
+	return objBase
 }
 
 // Replace the characters in a substring of this StringBuilder object with characters in the specified String.
 func stringBuilderReplace(params []any) any {
 	// Get byteArray.
-	objIn := params[0].(*object.Object)
-	fld := objIn.FieldTable["value"]
+	objBase := params[0].(*object.Object)
+	fld := objBase.FieldTable["value"]
 	initBytes := fld.Fvalue.([]byte)
 	initLen := int64(len(initBytes))
 
@@ -858,7 +830,7 @@ func stringBuilderReplace(params []any) any {
 
 	// If start = end, return object as-is.
 	if start == end {
-		return objIn
+		return objBase
 	}
 
 	// Copy the left-most retained bytes to a new byte array.
@@ -876,21 +848,18 @@ func stringBuilderReplace(params []any) any {
 	newArray = append(newArray, initBytes[end:]...)
 	newlen := int64(len(newArray))
 
-	// Initialise the output object.
-	objOut := object.MakeEmptyObjectWithClassName(&classStringBuilder)
-	objOut.FieldTable = objIn.FieldTable
-	objOut.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: newArray}
-	objOut.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: newlen}
-	expandCapacity(objOut, newlen)
+	objBase.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: newArray}
+	objBase.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: newlen}
+	expandCapacity(objBase, newlen)
 
-	return objOut
+	return objBase
 }
 
 // Reverse the order of the byte array.
 func stringBuilderReverse(params []any) any {
 	// Get byteArray.
-	objIn := params[0].(*object.Object)
-	fld := objIn.FieldTable["value"]
+	objBase := params[0].(*object.Object)
+	fld := objBase.FieldTable["value"]
 	byteArray := fld.Fvalue.([]byte)
 
 	// Reverse the bytes in byteArray.
@@ -898,12 +867,9 @@ func stringBuilderReverse(params []any) any {
 		byteArray[ii], byteArray[jj] = byteArray[jj], byteArray[ii]
 	}
 
-	// Initialise the output object.
-	objOut := object.MakeEmptyObjectWithClassName(&classStringBuilder)
-	objOut.FieldTable = objIn.FieldTable
-	objOut.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
+	objBase.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
 
-	return objOut
+	return objBase
 }
 
 // Set the char parameter into the bytes into the StringBuilder

--- a/src/gfunction/javaUtilHexFormat.go
+++ b/src/gfunction/javaUtilHexFormat.go
@@ -470,15 +470,6 @@ func hfFromHexDigit(params []interface{}) interface{} {
 func hfOf(params []interface{}) interface{} {
 	template := statics.GetStaticValue("java/util/HexFormat", "HEX_FORMAT").(*object.Object)
 	obj := object.CloneObject(template)
-	fld := obj.FieldTable["delimiter"]
-	fld.Fvalue = []byte{}
-	obj.FieldTable["delimiter"] = fld
-	obj.FieldTable["prefix"] = fld
-	obj.FieldTable["suffix"] = fld
-	digits := statics.GetStaticValue("java/util/HexFormat", "LOWERCASE_DIGITS").([]byte)
-	fld = obj.FieldTable["digits"]
-	fld.Fvalue = digits
-	obj.FieldTable["digits"] = fld
 	return obj
 }
 
@@ -489,13 +480,6 @@ func hfOfDelimiter(params []interface{}) interface{} {
 	fld := obj.FieldTable["delimiter"]
 	fld.Fvalue = delimiter
 	obj.FieldTable["delimiter"] = fld
-	fld.Fvalue = []byte{}
-	obj.FieldTable["prefix"] = fld
-	obj.FieldTable["suffix"] = fld
-	digits := statics.GetStaticValue("java/util/HexFormat", "LOWERCASE_DIGITS").([]byte)
-	fld = obj.FieldTable["digits"]
-	fld.Fvalue = digits
-	obj.FieldTable["digits"] = fld
 
 	return obj
 }
@@ -503,9 +487,9 @@ func hfOfDelimiter(params []interface{}) interface{} {
 func hfWithPrefix(params []interface{}) interface{} {
 	obj1 := params[0].(*object.Object)
 	prefix := params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
-	fld := obj1.FieldTable["prefix"]
-	fld.Fvalue = prefix
 	obj2 := object.CloneObject(obj1)
+	fld := obj2.FieldTable["prefix"]
+	fld.Fvalue = prefix
 	obj2.FieldTable["prefix"] = fld
 	return obj2
 }
@@ -513,9 +497,9 @@ func hfWithPrefix(params []interface{}) interface{} {
 func hfWithSuffix(params []interface{}) interface{} {
 	obj1 := params[0].(*object.Object)
 	suffix := params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
-	fld := obj1.FieldTable["suffix"]
-	fld.Fvalue = suffix
 	obj2 := object.CloneObject(obj1)
+	fld := obj2.FieldTable["suffix"]
+	fld.Fvalue = suffix
 	obj2.FieldTable["suffix"] = fld
 	return obj2
 }
@@ -523,29 +507,29 @@ func hfWithSuffix(params []interface{}) interface{} {
 func hfWithDelimiter(params []interface{}) interface{} {
 	obj1 := params[0].(*object.Object)
 	delimiter := params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
-	fld := obj1.FieldTable["delimiter"]
-	fld.Fvalue = delimiter
 	obj2 := object.CloneObject(obj1)
+	fld := obj2.FieldTable["delimiter"]
+	fld.Fvalue = delimiter
 	obj2.FieldTable["delimiter"] = fld
 	return obj2
 }
 
 func hfWithUpperCase(params []interface{}) interface{} {
 	obj1 := params[0].(*object.Object)
-	fld := obj1.FieldTable["digits"]
-	digits := statics.GetStaticValue("java/util/HexFormat", "UPPERCASE_DIGITS")
-	fld.Fvalue = digits
 	obj2 := object.CloneObject(obj1)
+	fld := obj2.FieldTable["digits"]
+	digits := statics.GetStaticValue("java/util/HexFormat", "UPPERCASE_DIGITS").([]byte)
+	fld.Fvalue = digits
 	obj2.FieldTable["digits"] = fld
 	return obj2
 }
 
 func hfWithLowerCase(params []interface{}) interface{} {
 	obj1 := params[0].(*object.Object)
-	fld := obj1.FieldTable["digits"]
-	digits := statics.GetStaticValue("java/util/HexFormat", "LOWERCASE_DIGITS")
-	fld.Fvalue = digits
 	obj2 := object.CloneObject(obj1)
+	fld := obj2.FieldTable["digits"]
+	digits := statics.GetStaticValue("java/util/HexFormat", "LOWERCASE_DIGITS").([]byte)
+	fld.Fvalue = digits
 	obj2.FieldTable["digits"] = fld
 	return obj2
 }
@@ -570,8 +554,11 @@ func hfEqualsHelper(this, that *object.Object, fieldName string) bool {
 	if !ok {
 		return false
 	}
-	f2, ok := this.FieldTable[fieldName].Fvalue.([]byte)
+	f2, ok := that.FieldTable[fieldName].Fvalue.([]byte)
 	if !ok {
+		return false
+	}
+	if len(f1) != len(f2) {
 		return false
 	}
 	if string(f1) != string(f2) {

--- a/src/object/object.go
+++ b/src/object/object.go
@@ -115,3 +115,16 @@ func CloneObject(oldObject *Object) *Object {
 	}
 	return newObject
 }
+
+// Merge all the fields from a source object to a destination object.
+func MergeFields(srcObj, dstObj *Object) {
+	// Get a slice of keys from the old FieldTable.
+	keys := make([]string, 0, len(srcObj.FieldTable))
+	for key := range srcObj.FieldTable {
+		keys = append(keys, key)
+	}
+	// For each key in the old FieldTable, copy that entry into the new FieldTable.
+	for _, key := range keys {
+		dstObj.FieldTable[key] = srcObj.FieldTable[key]
+	}
+}

--- a/src/object/object_test.go
+++ b/src/object/object_test.go
@@ -65,3 +65,111 @@ func TestMakeValidPrimitiveDouble(t *testing.T) {
 		t.Errorf("Value should be 0x42.0, got 0x%f", value)
 	}
 }
+
+func TestCloneObject_1(t *testing.T) {
+	globals.InitGlobals("test")
+	obj1 := MakePrimitiveObject("java/lang/Double", types.Double, 42.0)
+	obj2 := CloneObject(obj1)
+
+	// Make sure that the class identifiers are identical.
+	if obj2.KlassName != obj1.KlassName {
+		t.Errorf("KlassName should be the same. obj1: %v, obj2: %v", obj1.KlassName, obj2.KlassName)
+	}
+
+	// Make sure that their hashes are different.
+	if obj2.Mark.Hash == obj1.Mark.Hash {
+		t.Errorf("Mark.Hash should be different. obj1: %v, obj2: %v", obj1.Mark.Hash, obj2.Mark.Hash)
+	}
+
+	// Capture values for both obj1 and obj2.
+	// Then, make sure they are identical.
+	value1 := obj1.FieldTable["value"].Fvalue.(float64)
+	value2 := obj2.FieldTable["value"].Fvalue.(float64)
+	if value2 != value1 {
+		t.Errorf("value2 should equal value1, expected %f, observed %f", value1, value2)
+		return
+	}
+
+	// Change just the obj2 value.
+	fld := obj2.FieldTable["value"]
+	fld.Fvalue = 43.0
+	obj2.FieldTable["value"] = fld
+
+	// Capture values for both obj1 and obj2.
+	// Then, make sure they differ in the expected manner.
+	value1 = obj1.FieldTable["value"].Fvalue.(float64)
+	value2 = obj2.FieldTable["value"].Fvalue.(float64)
+	if value1 != 42.0 || value2 != 43.0 {
+		t.Errorf("Expected value1=42.0 and value2=43.0 but observed value1=%f and value2=%f", 42.0, 43.0)
+		return
+	}
+
+}
+
+func TestCloneObject_2(t *testing.T) {
+	globals.InitGlobals("test")
+	obj1 := MakePrimitiveObject("flying/purple/PeopleEater", types.Int, 1958)
+	jthing := [3]int64{1, 2, 3}
+	fthing := [3]float64{4, 5, 6}
+	obj1.FieldTable["jane"] = Field{Ftype: types.LongArray, Fvalue: jthing}
+	obj1.FieldTable["felice"] = Field{Ftype: types.FloatArray, Fvalue: fthing}
+
+	obj2 := CloneObject(obj1)
+
+	// Make sure that the class identifiers are identical.
+	if obj2.KlassName != obj1.KlassName {
+		t.Errorf("KlassName should be the same. obj1: %v, obj2: %v", obj1.KlassName, obj2.KlassName)
+	}
+
+	// Make sure that their hashes are different.
+	if obj2.Mark.Hash == obj1.Mark.Hash {
+		t.Errorf("Mark.Hash should be different. obj1: %v, obj2: %v", obj1.Mark.Hash, obj2.Mark.Hash)
+	}
+
+	// Capture values for both obj1 and obj2.
+	// Then, make sure they are identical.
+	jane1 := obj1.FieldTable["jane"].Fvalue.([3]int64)
+	jane2 := obj2.FieldTable["jane"].Fvalue.([3]int64)
+	if jane2 != jane1 {
+		t.Errorf("jane2 should equal jane1, expected %v, observed %v", jane1, jane2)
+		return
+	}
+
+	// Change just the obj2 value for jane.
+	fld := obj2.FieldTable["jane"]
+	fld.Fvalue = [3]int64{7, 8, 9}
+	obj2.FieldTable["jane"] = fld
+
+	// Capture values for both obj1 and obj2.
+	// Then, make sure they differ in the expected manner.
+	jane1 = obj1.FieldTable["jane"].Fvalue.([3]int64)
+	jane2 = obj2.FieldTable["jane"].Fvalue.([3]int64)
+	if jane1 != [3]int64{1, 2, 3} || jane2 != [3]int64{7, 8, 9} {
+		t.Errorf("Expected jane1=[3]int64{1, 2, 3} and jane2=[3]int64{7, 8, 9} but observed jane1=%v and jane2=%v", jane1, jane2)
+		return
+	}
+
+	// Capture values for both obj1 and obj2.
+	// Then, make sure they are identical.
+	felice1 := obj1.FieldTable["felice"].Fvalue.([3]float64)
+	felice2 := obj2.FieldTable["felice"].Fvalue.([3]float64)
+	if felice2 != felice1 {
+		t.Errorf("felice: felice2 should equal felice1, expected %v, observed %v", felice1, felice2)
+		return
+	}
+
+	// Change just the obj2 value for felice.
+	fld = obj2.FieldTable["felice"]
+	fld.Fvalue = [3]float64{7, 8, 9}
+	obj2.FieldTable["felice"] = fld
+
+	// Capture values for both obj1 and obj2.
+	// Then, make sure they differ in the expected manner.
+	felice1 = obj1.FieldTable["felice"].Fvalue.([3]float64)
+	felice2 = obj2.FieldTable["felice"].Fvalue.([3]float64)
+	if felice1 != [3]float64{4, 5, 6} || felice2 != [3]float64{7, 8, 9} {
+		t.Errorf("felice: Expected felice1=[3]float64{1, 2, 3} and felice2=[3]float64{7, 8, 9} but observed felice1=%v and felice2=%v", felice1, felice2)
+		return
+	}
+
+}


### PR DESCRIPTION
* Added unit tests for CloneObject.
* Found resolution for HexFormat.equals() issue.
* Removed unnecessary work-arounds in HexFormat.of() and HexFormat.ofDelimiter() code.
* StringBuilder and StringBuffer follow the API.
* The Java library Double.valueOf() functions (2) cannot handle a G-function exception; flow gets lost somewhere. Implemented as G-functions.
