### PR TITLE
JACOBIN-619 Initialisation needs a notes file, new: javaIoFilterInputStream

### DIFF
--- a/notes/Initialisation.txt
+++ b/notes/Initialisation.txt
@@ -1,0 +1,86 @@
+Initialisation Steps
+====================
+
+[1] jvm/jvmStart.go JVMrun
+
+    * trace.init()
+    * Not a unit test:
+        - [2] globals.InitGlobals(os.Args[0])
+        - Call stringPool.PreloadArrayClassesToStringPool() to load simple types into the string pool.
+    * Set up global "Func" function pointers to avoid Golang circularity issues.
+    * Call statics.PreloadStatics() to load commonly-referenced static variables.
+    * Call LoadOptionsTable(...) to load Global.Options with all possible jacobin options with their processing function addresses.
+    * Call HandleCli(os.Args, ...) to parse the command-line options based on Global.Options.
+    * Check for early exit after HandleCli.
+    * [3] classloader.Init()
+    * classloader.LoadBaseClasses()
+    * If running from a jar file, process jar initialisation.
+    * If -ea set, add main.$assertionsDisabled = types.JavaBoolFalse to statics.
+    * Initialise classloader.MTable to an empty state.
+    * Load all the G-functions into classloader.MTable.
+    * Create the main thread (0) and add it to the global thread table.
+    * Call StartExec to begin executing the main class method "main".
+    * Exit to O/S normally.
+
+[2] globals/globals.go InitGlobals
+
+    * Set the Globals struct to initial values.
+    * Set the Trace parameters to false.
+    * InitStringPool()
+    * InitJavaHome()
+    * InitJacobinHome()
+    * Validate JAVA_HOME, JACOBIN_HOME
+    * InitArrayAddressList() <---- returns a new list that is currently thrown away!
+    * Set up global.FileEncoding depending on O/S.
+    * Set global.Headless = java.awt.headless flag set/absent in environment.
+    * Initialise global thread table to an empty state.
+    
+[3] classloader/classloader.go Init
+
+    * Initialise the three classloaders BootstrapCL, ExtensionCL, and AppCL.
+    * [4] JmodMapInit()
+    * Call GetBaseJmodBytes() to load global.JmodBaseBytes with the contents of the java.base.jmod file.
+    * [5] InitMethodArea() 
+
+[4] classloader/jmodMap.go JmodMapInit
+
+    * JMODMAP :: contains class-to-Jmod-File relationships for all installed jmod files. No class information is stored. Initially, nil.
+    * Gob file name = (v.v.v.gob) for the JAVA_HOME in use (version v.v.v).
+    * Assume that the gob file will not be found i.e. jmodMapFoundGob = false.
+    * For each file in the JacobinHome directory, try to find the matching gob file.
+    * If found,
+        - Call buildMapFromGob() to build JMODMAP from the gob file.
+        - If that call was unsuccessful (E.g. file corruption), force rebuilding.
+        - Return to JmodMapInit caller.
+    * Not found or forced rebuild: Call buildMapFromJmods() to build JMODMAP from the Java jmod files.
+    * Call saveMapToGob() to save JMODMAP to the gob file.
+
+[5] classloader/methArea.go InitMethodArea, MethAreaPreload
+
+    * MethArea :: sync.Map containing all the loaded classes. Key is the class name in java/lang/Object format. Initially, nil.
+    * Load all the types for primitive arrays (E.g. types.ByteArray). Each entry having a Klass structure like this:
+        - Status: 'N', // N = instantiated
+		- Loader: "bootstrap"
+		- Data.Name: type value (E.g. types.ByteArray)
+		- Data.NameIndex: string pool index of the type value
+		- Data.SuperclassIndex: string pool index of "java/lang/Object"
+
+
+Special Notes about MTable
+==========================
+
+FQN :: combination of class name, method name, and method type (input parameters and output)
+
+MTable :: holds the cached information of every method that the Jacobin interpreter encounters, keyed by FQN. As far as initialisation is concerned, MTable is nil. 
+Post-initialisation, the opcodes INVOKEVIRTUAL, INVOKESPECIAL, and INVOKESTATIC requests MTable entries for methods specified in the current frame.
+The Jacobin function which satisfies these requests is classloader/classes.go FetchMethodAndCP().
+
+The first time a new method is requested by the interpreter, FetchMethodAndCP will not find the FQN in MTable. The entry for that method will be constructed and added to MTable.
+Then, the MTable entry is returned to the interpreter. 
+
+The interpreter uses the MTable entry to execute the new method in one of two ways:
+    - J function: in a new frame.
+    - G function: within the existing frame through gfunctions/gfunctionExec.go RunGfunction().
+
+The second time the same method is requested (same FQN), it is found in MTable by FetchMethodAndCP and passed back to the interpreter. Method execution proceeds as described before.
+

--- a/src/classloader/jmodMap.go
+++ b/src/classloader/jmodMap.go
@@ -99,10 +99,11 @@ func JmodMapInit() {
 	}
 
 	// For each JacobinHome file, try to find a matching gob file
+	jmodMapFoundGob = false
 	for ix := range names {
 		name := names[ix]
 		if strings.HasSuffix(name, ".gob") { // Gob file?
-			version := strings.TrimSuffix(name, ".gob") // get rid of trailing .gom
+			version := strings.TrimSuffix(name, ".gob") // get rid of trailing .gob
 			if version == global.JavaVersion {
 				// Got a match!  Build map from it.
 				gobFullPath := global.JacobinHome + string(os.PathSeparator) + name
@@ -119,8 +120,7 @@ func JmodMapInit() {
 		}
 	}
 
-	// No matching gob file
-	jmodMapFoundGob = false
+	// No matching gob file or had gob file trouble (force re-creation).
 	buildMapFromJmods()
 	if jmodMapSize == 0 {
 		return

--- a/src/classloader/jmodMap_test.go
+++ b/src/classloader/jmodMap_test.go
@@ -96,6 +96,7 @@ func TestJmodMapHomeDefault(t *testing.T) {
 	t.Logf("Map size is %d\n", mapSize)
 
 	checkMap(t, types.StringClassName, "java.base.jmod")
+	checkMap(t, "java/util/zip/ZipUtils", "java.base.jmod")
 	checkMap(t, "com/sun/accessibility/internal/resources/accessibility", "java.desktop.jmod")
 
 }

--- a/src/classloader/mTable.go
+++ b/src/classloader/mTable.go
@@ -22,7 +22,7 @@ import (
 //
 // When a function is invoked, the lookup mechanism first checks the MTable, and
 // if an entry is found, that entry is what is executed. If no entry is found,
-// the search goes to the class and faiing that to the superclass, etc. Once the
+// the search goes to the class and failing that to the superclass, etc. Once the
 // method is located, it's added to the MTable so that all future invocations will
 // result in fast look-ups in the MTable.
 var MTable = make(MT)

--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -72,18 +72,6 @@ func Load_Traps() {
 			GFunction:  trapClass,
 		}
 
-	MethodSignatures["java/io/FilterInputStream.<clinit>()V"] =
-		GMeth{
-			ParamSlots: 0,
-			GFunction:  trapClass,
-		}
-
-	MethodSignatures["java/io/FilterInputStream.<init>(Ljava/io/InputStream;)V"] =
-		GMeth{
-			ParamSlots: 1,
-			GFunction:  trapFunction,
-		}
-
 	MethodSignatures["java/io/FilterOutputStream.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,

--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -91,6 +91,7 @@ func MTableLoadGFunctions(MTable *classloader.MT) {
 	Load_Io_FileOutputStream()
 	Load_Io_FileReader()
 	Load_Io_FileWriter()
+	Load_Io_FilterInputStream()
 	Load_Io_InputStreamReader()
 	Load_Io_OutputStreamWriter()
 	Load_Io_PrintStream()

--- a/src/gfunction/javaIoFilterInputStream.go
+++ b/src/gfunction/javaIoFilterInputStream.go
@@ -1,0 +1,143 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2024 by  the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package gfunction
+
+import (
+	"fmt"
+	"jacobin/excNames"
+	"jacobin/object"
+	"jacobin/types"
+	"os"
+)
+
+func Load_Io_FilterInputStream() {
+
+	MethodSignatures["java/io/FilterInputStream.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  clinitGeneric,
+		}
+
+	MethodSignatures["java/io/FilterInputStream.<init>(Ljava.io.InputStream;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  initFilterInputStreamFile,
+		}
+
+	MethodSignatures["java/io/FilterInputStream.<init>(Ljava.lang.String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  initFilterInputStreamString,
+		}
+
+	MethodSignatures["java/io/FilterInputStream.available()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  fisAvailable,
+		}
+
+	MethodSignatures["java/io/FilterInputStream.close()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  fisClose,
+		}
+
+	MethodSignatures["java/io/FilterInputStream.mark(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/io/FilterInputStream.markSupported()Z"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  bufferedReaderMarkSupported,
+		}
+
+	MethodSignatures["java/io/FilterInputStream.read()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  fisReadOne,
+		}
+
+	MethodSignatures["java/io/FilterInputStream.read([B)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  fisReadByteArray,
+		}
+
+	MethodSignatures["java/io/FilterInputStream.read([BII)I"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  fisReadByteArrayOffset,
+		}
+
+	MethodSignatures["java/io/FilterInputStream.reset()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/io/FilterInputStream.skip(J)J"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  fisSkip,
+		}
+
+}
+
+// "java/io/FilterInputStream.<init>(Ljava/io/File;])V"
+func initFilterInputStreamFile(params []interface{}) interface{} {
+
+	// Get file path field from the File argument.
+	fld, ok := params[1].(*object.Object).FieldTable[FilePath]
+	if !ok {
+		errMsg := "File object argument lacks a FilePath field"
+		return getGErrBlk(excNames.IOException, errMsg)
+	}
+
+	// Get the file path.
+	pathStr := string(fld.Fvalue.([]byte))
+
+	// Open the file for read-only, yielding a file handle.
+	osFile, err := os.Open(pathStr)
+	if err != nil {
+		errMsg := fmt.Sprintf("os.Open(%s) failed, reason: %s", pathStr, err.Error())
+		return getGErrBlk(excNames.IOException, errMsg)
+	}
+
+	// Copy the file path field into the FilterInputStream object.
+	params[0].(*object.Object).FieldTable[FilePath] = fld
+
+	// Copy the file handle into the FilterInputStream object.
+	fld = object.Field{Ftype: types.FileHandle, Fvalue: osFile}
+	params[0].(*object.Object).FieldTable[FileHandle] = fld
+
+	return nil
+}
+
+// "java/io/FilterInputStream.<init>(Ljava/lang/String;])V"
+func initFilterInputStreamString(params []interface{}) interface{} {
+
+	// Using the argument path string, open the file for read-only.
+	pathStr := object.GoStringFromStringObject(params[1].(*object.Object))
+	osFile, err := os.Open(pathStr)
+	if err != nil {
+		errMsg := fmt.Sprintf("os.Open(%s) failed, reason: %s", pathStr, err.Error())
+		return getGErrBlk(excNames.IOException, errMsg)
+	}
+
+	// Copy the file path field into the FilterInputStream object.
+	fld := object.Field{Ftype: types.ByteArray, Fvalue: []byte(pathStr)}
+	params[0].(*object.Object).FieldTable[FilePath] = fld
+
+	// Copy the file handle into the FilterInputStream object.
+	fld = object.Field{Ftype: types.FileHandle, Fvalue: osFile}
+	params[0].(*object.Object).FieldTable[FileHandle] = fld
+
+	return nil
+}

--- a/src/jvm/initializerBlock.go
+++ b/src/jvm/initializerBlock.go
@@ -94,6 +94,7 @@ func runJavaInitializer(m classloader.MData, k *classloader.Klass, fs *list.List
 		f.Thread = parentFrame.Thread
 	}
 	f.MethName = "<clinit>"
+	f.MethType = "()V"
 	f.ClName = k.Data.Name
 	f.CP = meth.Cp                        // add its pointer to the class CP
 	f.Meth = append(f.Meth, meth.Code...) // copy the bytecodes over

--- a/src/jvm/instantiate.go
+++ b/src/jvm/instantiate.go
@@ -174,7 +174,7 @@ runInitializer:
 	if ok && k.Data.ClInit == types.ClInitNotRun {
 		err := runInitializationBlock(k, superclasses, frameStack)
 		if err != nil {
-			errMsg := fmt.Sprintf("InstantiateClass: runInitializationBlock failed with %s.<clinit>()", classname)
+			errMsg := fmt.Sprintf("InstantiateClass: runInitializationBlock failed with %s.<clinit>()V", classname)
 			trace.Error(errMsg)
 			return nil, err
 		}

--- a/src/jvm/jvmStart.go
+++ b/src/jvm/jvmStart.go
@@ -56,7 +56,6 @@ func JVMrun() int {
 		// Not a test!
 		_ = globals.InitGlobals(os.Args[0])
 		stringPool.PreloadArrayClassesToStringPool()
-		trace.Init()
 	}
 	globPtr = globals.GetGlobalRef()
 


### PR DESCRIPTION
New: 
* notes/Initialisation.txt
* src/gfunction/javaIoFilterInputStream.go (trying to move jacotest case zippy along)

Modified:   
* src/gfunction/Traps.go - removed javaIoFilterInputStream 
* src/gfunction/gfunction.go - added load of method signatures for javaIoFilterInputStream
* src/jvm/jvmStart.go - removed redundant trace.Init call

Minor nonfunctional fixes:
* src/classloader/jmodMap.go
* src/classloader/jmodMap_test.go
* src/classloader/mTable.go

JACOBIN-620 fix: jvm/initializerBlock.go
