### PR TITLE
JACOBIN-622 traps cleanups, added traps, jvm/interpreter_LL-end_testgo fun!, global.FileEncoding = name of character set

### DIFF
--- a/src/classloader/mTable.go
+++ b/src/classloader/mTable.go
@@ -7,6 +7,9 @@
 package classloader
 
 import (
+	"fmt"
+	"os"
+	"sort"
 	"sync"
 )
 
@@ -70,4 +73,25 @@ func AddEntry(tbl *MT, key string, mte MTentry) {
 	MTmutex.Lock()
 	mt[key] = mte
 	MTmutex.Unlock()
+}
+
+// DumpMTable dumps the contents of MTable in sorted order to stderr
+func DumpMTable() {
+	_, _ = fmt.Fprintln(os.Stderr, "\n===== DumpMTable BEGIN")
+	// Create an array of keys.
+	keys := make([]string, 0, len(MTable))
+	for key := range MTable {
+		keys = append(keys, key)
+	}
+
+	// Sort the keys (FQNs).
+	// All the upper case entries precede all the lower case entries.
+	sort.Strings(keys)
+
+	// In key sequence order, display the key and its value.
+	for _, key := range keys {
+		entry := MTable[key]
+		_, _ = fmt.Fprintf(os.Stderr, "%s   %s\n", string(entry.MType), key)
+	}
+	_, _ = fmt.Fprintln(os.Stderr, "===== DumpMTable END")
 }

--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -120,34 +120,16 @@ func Load_Traps() {
 			GFunction:  trapDeprecated,
 		}
 
-	MethodSignatures["java/nio/charset/Charset.<clinit>()V"] =
+	MethodSignatures["java/nio/ByteBuffer.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  trapFunction,
-		}
-
-	MethodSignatures["java/nio/charset/Charset.defaultCharset()Ljava/nio/charset/Charset;"] =
-		GMeth{
-			ParamSlots: 0,
-			GFunction:  trapFunction,
+			GFunction:  trapClass,
 		}
 
 	MethodSignatures["java/nio/charset/StandardCharsets.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  trapFunction,
-		}
-
-	MethodSignatures["java/rmi/RMISecurityManager.<clinit>()V"] =
-		GMeth{
-			ParamSlots: 0,
-			GFunction:  trapDeprecated,
-		}
-
-	MethodSignatures["java/rmi/RMISecurityManager.<init>()V"] =
-		GMeth{
-			ParamSlots: 0,
-			GFunction:  trapDeprecated,
+			GFunction:  trapClass,
 		}
 
 	MethodSignatures["java/nio/channels/AsynchronousFileChannel.<clinit>()V"] =
@@ -162,28 +144,46 @@ func Load_Traps() {
 			GFunction:  trapClass,
 		}
 
+	MethodSignatures["java/rmi/RMISecurityManager.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures["java/rmi/RMISecurityManager.<init>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures["sun/security/util/Debug.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapClass,
+		}
+
 }
 
 // Generic trap for classes
 func trapClass([]interface{}) interface{} {
-	errMsg := "The requested class is not yet supported"
+	errMsg := "TRAP: The requested class is not yet supported"
 	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
 // Generic trap for deprecated classes and functions
 func trapDeprecated([]interface{}) interface{} {
-	errMsg := "The requested class or function is deprecated and, therefore, not supported"
+	errMsg := "TRAP: The requested class or function is deprecated and, therefore, not supported"
 	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
 // Generic trap for deprecated classes and functions
 func trapUndocumented([]interface{}) interface{} {
-	errMsg := "The requested class or function is undocumented and, therefore, not supported"
+	errMsg := "TRAP: The requested class or function is undocumented and, therefore, not supported"
 	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }
 
 // Generic trap for functions
 func trapFunction([]interface{}) interface{} {
-	errMsg := "The requested function is not yet supported"
+	errMsg := "TRAP: The requested function is not yet supported"
 	return getGErrBlk(excNames.UnsupportedOperationException, errMsg)
 }

--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -11,6 +11,7 @@ import (
 	"jacobin/classloader"
 	"jacobin/excNames"
 	"jacobin/exceptions"
+	"jacobin/globals"
 	"jacobin/object"
 	"jacobin/trace"
 	"jacobin/types"
@@ -73,6 +74,10 @@ func clinitGeneric([]interface{}) interface{} {
 // do-nothing Go function shared by several source files
 func justReturn([]interface{}) interface{} {
 	return object.StringObjectFromGoString("justReturn")
+}
+
+func returnCharsetName([]interface{}) interface{} {
+	return object.StringObjectFromGoString(globals.GetCharsetName())
 }
 
 // MTableLoadGFunctions loads the Go methods from files that contain them. It does this

--- a/src/gfunction/javaIoConsole.go
+++ b/src/gfunction/javaIoConsole.go
@@ -29,7 +29,7 @@ func Load_Io_Console() {
 			GFunction:  consoleClinit,
 		}
 
-	// Flushes the console and forces any buffered output to be written immediately.
+	// Returns the Charset object used for the Console.
 	MethodSignatures["java/io/Console.charset()Ljava/nio/charset/Charset;"] =
 		GMeth{
 			ParamSlots: 0,

--- a/src/gfunction/javaIoInputStreamReader.go
+++ b/src/gfunction/javaIoInputStreamReader.go
@@ -29,10 +29,34 @@ func Load_Io_InputStreamReader() {
 			GFunction:  inputStreamReaderInit,
 		}
 
+	MethodSignatures["java/io/InputStreamReader.<init>(Ljava/io/InputStream;Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/io/InputStreamReader.<init>(Ljava/io/InputStream;Ljava/nio/charset/Charset;)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/io/InputStreamReader.<init>(Ljava/io/InputStream;Ljava/nio/charset/CharsetDecoder;)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
 	MethodSignatures["java/io/InputStreamReader.close()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  isrClose,
+		}
+
+	MethodSignatures["java/io/InputStreamReader.getEncoding()Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  returnCharsetName,
 		}
 
 	MethodSignatures["java/io/InputStreamReader.read()I"] =
@@ -51,34 +75,6 @@ func Load_Io_InputStreamReader() {
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  isrReady,
-		}
-
-	// -----------------------------------------
-	// Traps that do nothing but return an error
-	// -----------------------------------------
-
-	MethodSignatures["java/io/InputStreamReader.<init>(Ljava/io/InputStream;Ljava/lang.String;)V"] =
-		GMeth{
-			ParamSlots: 2,
-			GFunction:  trapFunction,
-		}
-
-	MethodSignatures["java/io/InputStreamReader.<init>(Ljava/io/InputStream;Ljava/nio/charset/Charset;)V"] =
-		GMeth{
-			ParamSlots: 2,
-			GFunction:  trapFunction,
-		}
-
-	MethodSignatures["java/io/InputStreamReader.<init>(Ljava/io/InputStream;Ljava/nio/charset/CharsetDecoder;)Ljava/lang.String;"] =
-		GMeth{
-			ParamSlots: 2,
-			GFunction:  trapFunction,
-		}
-
-	MethodSignatures["java/io/InputStreamReader.getEncoding()V"] =
-		GMeth{
-			ParamSlots: 0,
-			GFunction:  trapFunction,
 		}
 
 }

--- a/src/gfunction/javaLangObject.go
+++ b/src/gfunction/javaLangObject.go
@@ -18,10 +18,30 @@ import (
 
 func Load_Lang_Object() {
 
+	MethodSignatures["java/lang/Object.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  clinitGeneric,
+		}
+
 	MethodSignatures["java/lang/Object.<init>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  justReturn,
+		}
+
+	// "java/lang/Object.clone(Ljava/lang/Object;)Ljava/lang/Object;" is PROTECTED
+
+	MethodSignatures["java/lang/Object.equals(Ljava/lang/Object;)Z"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Object.finalize()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
 		}
 
 	MethodSignatures["java/lang/Object.getClass()Ljava/lang/Class;"] =
@@ -30,11 +50,47 @@ func Load_Lang_Object() {
 			GFunction:  objectGetClass,
 		}
 
+	MethodSignatures["java/lang/Object.hashCode()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Object.notify()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Object.notifyAll()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
 	MethodSignatures["java/lang/Object.toString()Ljava/lang/String;"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  objectToString,
 		}
+
+	MethodSignatures["java/lang/Object.wait()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Object.wait(J)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	/*MethodSignatures["java/lang/Object.wait(JI)V"] =
+	GMeth{
+		ParamSlots: 2,
+		GFunction:  trapFunction,
+	}*/
 
 }
 

--- a/src/gfunction/javaLangSystem.go
+++ b/src/gfunction/javaLangSystem.go
@@ -363,8 +363,8 @@ func getProperty(params []interface{}) interface{} {
 		} else {
 			value = "\\n"
 		}
-	case "native.encoding": // hard to find out what this is, so hard-coding to UTF8
-		value = "UTF8"
+	case "native.encoding":
+		value = globals.GetCharsetName()
 	case "os.arch":
 		value = runtime.GOARCH
 	case "os.name":

--- a/src/gfunction/otherMethods.go
+++ b/src/gfunction/otherMethods.go
@@ -68,6 +68,24 @@ func Load_Other_methods() {
 			GFunction:  clinitGeneric,
 		}
 
+	MethodSignatures["java/nio/charset/Charset.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  clinitGeneric,
+		}
+
+	MethodSignatures["java/nio/charset/Charset.defaultCharset()Ljava/nio/charset/Charset;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  returnCharsetName,
+		}
+
+	MethodSignatures["java/nio/charset/Charset.name()Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  returnCharsetName,
+		}
+
 	MethodSignatures["java/util/Locale$Category.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,

--- a/src/globals/globals.go
+++ b/src/globals/globals.go
@@ -346,3 +346,7 @@ func InitStringPool() {
 
 	StringPoolLock.Unlock()
 }
+
+func GetCharsetName() string {
+	return global.FileEncoding
+}


### PR DESCRIPTION
*  classloader/mTable.go - added a dump MTable function (useful for debugging)
*  gfunction/Traps.go - more traps!
*  gfunction/gfunction.go - added returnCharsetName() from globals FileEncoding for the G-functions
*  gfunction/javaIoConsole.go - minor cleanup
*  gfunction/javaIoInputStreamReader.go - filled out with traps
*  gfunction/javaLangObject.go - filled out with traps
*  gfunction/javaLangSystem.go - get the "native.encoding" from globals FileEncoding
*  gfunction/otherMethods.go - misc changes
*  globals/globals.go - added func GetCharsetName()
*  jvm/interpreter_LL-end_test.go - Traded `java/lang/Object.wait(JI)V` for `java/lang/Double.hashCode()I`. 

More details in JACOBIN-622.