### PR TITLE
JACOBIN-623 locateExceptionFrame: Treat G-functions like a simple exception w/o a catch

### DIFF
--- a/src/exceptions/catchFrame.go
+++ b/src/exceptions/catchFrame.go
@@ -69,8 +69,7 @@ func locateExceptionFrame(f *frames.Frame, excName string, pc int) (*frames.Fram
 	}
 
 	if methEntry.MType != 'J' {
-		errMsg := fmt.Sprintf("locateExceptionFrame: Method %s is a native method", fullMethName)
-		minimalAbort(excNames.InternalException, errMsg)
+		return nil, -1 // G-functions have no exception handlers
 	}
 
 	method := methEntry.Meth.(classloader.JmEntry)

--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -156,10 +156,16 @@ func Load_Traps() {
 			GFunction:  trapDeprecated,
 		}
 
-	MethodSignatures["sun/security/util/Debug.<clinit>()V"] =
+	MethodSignatures["sun/security/util/Debug.getInstance(Ljava/lang/String;)Lsun/security/util/Debug;"] =
 		GMeth{
-			ParamSlots: 0,
-			GFunction:  trapClass,
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["sun/security/util/Debug.getInstance(Ljava/lang/String;Ljava/lang/String;)Lsun/security/util/Debug;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
 		}
 
 }

--- a/src/gfunction/otherMethods.go
+++ b/src/gfunction/otherMethods.go
@@ -116,4 +116,10 @@ func Load_Other_methods() {
 			GFunction:  clinitGeneric,
 		}
 
+	MethodSignatures["sun/security/util/Debug.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  clinitGeneric,
+		}
+
 }

--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -1924,8 +1924,17 @@ func doGetfield(fr *frames.Frame, _ int64) int {
 		break
 	default:
 		globals.GetGlobalRef().ErrorGoStack = string(debug.Stack())
-		errMsg := fmt.Sprintf("GETFIELD: Invalid type of object ref: %T, fieldName: %s", ref, fieldName)
+		errMsg := fmt.Sprintf("GETFIELD: Invalid type of object ref: %T, fieldName: %s.%s", ref, fr.ClName, fieldName)
 		status := exceptions.ThrowEx(excNames.IllegalArgumentException, errMsg, fr)
+		if status != exceptions.Caught {
+			return exceptions.ERROR_OCCURRED // applies only if in test
+		}
+	}
+
+	// Check reference for a nil pointer.
+	if ref.(*object.Object) == nil {
+		errMsg := fmt.Sprintf("GETFIELD: Invalid (null) reference to a field: %s.%s", fr.ClName, fieldName)
+		status := exceptions.ThrowEx(excNames.NullPointerException, errMsg, fr)
 		if status != exceptions.Caught {
 			return exceptions.ERROR_OCCURRED // applies only if in test
 		}

--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -1806,7 +1806,7 @@ func doPutStatic(fr *frames.Frame, _ int64) int {
 	// containing class, something is wrong so get out of here.
 	if !ok {
 		globals.GetGlobalRef().ErrorGoStack = string(debug.Stack())
-		errMsg := fmt.Sprintf("PUTSTATIC: could not find static field %s", fieldName)
+		errMsg := fmt.Sprintf("PUTSTATIC: could not find static field %s.%s", className, fieldName)
 		trace.Error(errMsg)
 		return exceptions.ERROR_OCCURRED
 	}
@@ -1881,7 +1881,7 @@ func doPutStatic(fr *frames.Frame, _ int64) int {
 			}
 		default:
 			globals.GetGlobalRef().ErrorGoStack = string(debug.Stack())
-			errMsg := fmt.Sprintf("PUTSTATIC: field %s, type unrecognized: %v", fieldName, value)
+			errMsg := fmt.Sprintf("PUTSTATIC: field %s, type unrecognized for %s.%s: %T %v", className, fieldName, value, value)
 			trace.Error(errMsg)
 			return exceptions.ERROR_OCCURRED
 		}

--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -1881,7 +1881,7 @@ func doPutStatic(fr *frames.Frame, _ int64) int {
 			}
 		default:
 			globals.GetGlobalRef().ErrorGoStack = string(debug.Stack())
-			errMsg := fmt.Sprintf("PUTSTATIC: field %s, type unrecognized for %s.%s: %T %v", className, fieldName, value, value)
+			errMsg := fmt.Sprintf("PUTSTATIC: field %s.%s, type unrecognized: %T %v", className, fieldName, value, value)
 			trace.Error(errMsg)
 			return exceptions.ERROR_OCCURRED
 		}


### PR DESCRIPTION
- src/exceptions/catchFrame.go:locateExceptionFrame - If servicing a G-function exception, simply indicate that there are no exception handlers.
- src/gfunction/Traps.go - inconsequential
- src/gfunction/otherMethods.go - inconsequential
- src/jvm/interpreter.go[GETFIELD] - doGetfield() should avoid a go runtime exception due to a nil pointer. Include class and field name in error message.
- src/jvm/interpreter.go[PUTSTATIC] - add class names in field diagnostics for doPutStatic()