### PR TITLE
JACOBIN-626 : new DumpStatics and DumpObject

### DIFF
--- a/src/gfunction/jj.go
+++ b/src/gfunction/jj.go
@@ -27,6 +27,12 @@ func Load_jj() {
 			ParamSlots: 3,
 			GFunction:  jjDumpStatics,
 		}
+
+	MethodSignatures["jj._dumpObject(Ljava/lang/Object;Ljava/lang/String;I)V"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  jjDumpObject,
+		}
 }
 
 func jjDumpStatics(params []interface{}) interface{} {
@@ -41,5 +47,14 @@ func jjDumpStatics(params []interface{}) interface{} {
 	className := object.ObjectFieldToString(classNameObj, "value")
 
 	statics.DumpStatics(from, selection, className)
+	return nil
+}
+
+func jjDumpObject(params []interface{}) interface{} {
+	this := params[0].(*object.Object)
+	objTitle := params[1].(*object.Object)
+	title := object.ObjectFieldToString(objTitle, "value")
+	indent := params[2].(int64)
+	this.DumpObject(title, int(indent))
 	return nil
 }

--- a/src/gfunction/jj.go
+++ b/src/gfunction/jj.go
@@ -12,7 +12,6 @@ import (
 	"jacobin/object"
 	"jacobin/statics"
 	"jacobin/types"
-	"os"
 )
 
 // jj (Jacobin JVM) functions are functions that can be inserted inside Java programs
@@ -23,22 +22,24 @@ import (
 
 func Load_jj() {
 
-	MethodSignatures["jj._dumpStatics(Ljava/lang/String;)V"] =
+	MethodSignatures["jj._dumpStatics(Ljava/lang/String;ILjava/lang/String;)V"] =
 		GMeth{
-			ParamSlots: 1,
+			ParamSlots: 3,
 			GFunction:  jjDumpStatics,
 		}
 }
 
 func jjDumpStatics(params []interface{}) interface{} {
-	objPtr := params[0].(*object.Object)
-	if objPtr == nil || objPtr.KlassName == types.InvalidStringIndex {
+	fromObj := params[0].(*object.Object)
+	if fromObj == nil || fromObj.KlassName == types.InvalidStringIndex {
 		errMsg := fmt.Sprintf("Invalid object in objectGetClass(): %T", params[0])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
+	from := object.ObjectFieldToString(fromObj, "value")
+	selection := params[1].(int64)
+	classNameObj := params[2].(*object.Object)
+	className := object.ObjectFieldToString(classNameObj, "value")
 
-	str := object.ObjectFieldToString(objPtr, "value")
-	fmt.Fprintf(os.Stderr, "%s: non-JDK statics:\n", str)
-	statics.DumpStatics()
+	statics.DumpStatics(from, selection, className)
 	return nil
 }

--- a/src/globals/globals.go
+++ b/src/globals/globals.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -347,6 +348,15 @@ func InitStringPool() {
 	StringPoolLock.Unlock()
 }
 
+// Get the character set name.
 func GetCharsetName() string {
 	return global.FileEncoding
+}
+
+// Case-insensitive sort.
+// Golang should have provided this!
+func SortCaseInsensitive(ptrSlice *[]string) {
+	slices.SortFunc(*ptrSlice, func(a, b string) int {
+		return strings.Compare(strings.ToLower(a), strings.ToLower(b))
+	})
 }

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -92,7 +92,7 @@ func StartExec(className string, mainThread *thread.ExecThread, globalStruct *gl
 	err = runThread(&MainThread)
 
 	if globals.TraceVerbose {
-		statics.DumpStatics()
+		statics.DumpStatics("StartExec end", statics.SelectUser, "")
 		_ = config.DumpConfig(os.Stderr)
 	}
 }

--- a/src/object/format.go
+++ b/src/object/format.go
@@ -8,6 +8,7 @@ package object
 
 import (
 	"fmt"
+	"jacobin/globals"
 	"jacobin/statics"
 	"jacobin/stringPool"
 	"jacobin/types"
@@ -213,7 +214,14 @@ func (objPtr *Object) DumpObject(title string, indent int) {
 	nflds := len(obj.FieldTable)
 	if nflds > 0 {
 		output += fmt.Sprintf("\tField Table (%d):\n", nflds)
-		for fieldName := range obj.FieldTable {
+		// Create a sorted slice of keys.
+		keys := make([]string, 0, len(obj.FieldTable))
+		for key := range obj.FieldTable {
+			keys = append(keys, key)
+		}
+		globals.SortCaseInsensitive(&keys)
+
+		for _, fieldName := range keys {
 			if indent > 0 {
 				output += strings.Repeat(" ", indent)
 			}

--- a/src/object/format_test.go
+++ b/src/object/format_test.go
@@ -58,12 +58,6 @@ func TestDumpObjectFieldTable(t *testing.T) {
 	}
 	obj.FieldTable["myByte"] = myByteField
 
-	myStaticTrueField := Field{
-		Ftype:  types.Static + types.Bool,
-		Fvalue: true,
-	}
-	obj.FieldTable["myStaticTrue"] = myStaticTrueField
-
 	myFalseField := Field{
 		Ftype:  types.Bool,
 		Fvalue: false,
@@ -128,12 +122,6 @@ func TestFormatField(t *testing.T) {
 		Fvalue: 0x61,
 	}
 	obj.FieldTable["myByte"] = myByteField
-
-	myStaticTrueField := Field{
-		Ftype:  types.Static + types.Bool,
-		Fvalue: true,
-	}
-	obj.FieldTable["myStaticTrue"] = myStaticTrueField
 
 	myFalseField := Field{
 		Ftype:  types.Bool,

--- a/src/shutdown/exit.go
+++ b/src/shutdown/exit.go
@@ -53,7 +53,7 @@ func Exit(errorCondition ExitStatus) int {
 	}
 
 	if errorCondition != OK {
-		statics.DumpStatics()
+		statics.DumpStatics("exit.Exit", statics.SelectUser, "")
 		config.DumpConfig(os.Stderr)
 	}
 	os.Exit(errorCondition)

--- a/src/statics/statics_test.go
+++ b/src/statics/statics_test.go
@@ -3,7 +3,6 @@ package statics
 import (
 	"fmt"
 	"io"
-	// "jacobin/classloader"
 	"jacobin/globals"
 	"jacobin/trace"
 	"jacobin/types"


### PR DESCRIPTION
* gfunction/jj.go - jjDumpStatics(), jjDumpObject()
* globals/globals.go - sort string slice case-insensitive
* jvm/run.go - use new DumpStatics()
* object/format.go - new DumpObject()
* object/format_test.go[TestDumpObjectFieldTable] - avoid static definitions, use new DumpObject()
* shutdown/exit.go - use new DumpStatics()
* statics/statics.go - new DumpStatics()
* statics/statics_test.go - test new DumpStatics()
