### PR TITLE
JACOBIN-626 fix for DumpObject where a field is static

### DIFF
--- a/src/gfunction/jj_test.go
+++ b/src/gfunction/jj_test.go
@@ -1,0 +1,58 @@
+package gfunction
+
+import (
+	"io"
+	"jacobin/globals"
+	"jacobin/object"
+	"jacobin/statics"
+	"jacobin/trace"
+	"jacobin/types"
+	"os"
+	"strings"
+	"testing"
+)
+
+func fnTestJjDumpStatics(t *testing.T, selection int64, className string, threesome []string) {
+	// Re-direct stderr.
+	originalStderr := os.Stderr
+	rerr, werr, _ := os.Pipe()
+	os.Stderr = werr
+
+	// Dump statics.
+	objTitle := object.StringObjectFromGoString("TestDumpStatics")
+	objClassName := object.StringObjectFromGoString(className)
+	params := make([]interface{}, 3)
+	params[0] = objTitle
+	params[1] = selection
+	params[2] = objClassName
+	jjDumpStatics(params)
+
+	// Close the working stderr, capture its contents, and restore the original stderr.
+	_ = werr.Close()
+	bytes, _ := io.ReadAll(rerr)
+	contents := string(bytes[:])
+	os.Stderr = originalStderr
+
+	if !strings.Contains(contents, threesome[0]) || !strings.Contains(contents, threesome[1]) || !strings.Contains(contents, threesome[2]) {
+		t.Errorf("fnTestDumpStatics(%d, \"%s\"): looking for these: %v", selection, className, threesome)
+		t.Errorf("fnTestDumpStatics(%d, \"%s\"): didn't see them in DumpStatics output: %s", selection, className, contents)
+	}
+
+}
+
+func TestJjDumpStatics(t *testing.T) {
+	globals.InitGlobals("test")
+	trace.Init()
+	statics.Statics = make(map[string]statics.Static)
+
+	err1 := statics.AddStatic("test.f1", statics.Static{Type: types.Byte, Value: 'B'})
+	err2 := statics.AddStatic("test.f2", statics.Static{Type: types.Int, Value: int(42)})
+	err3 := statics.AddStatic("test.f3", statics.Static{Type: types.Double, Value: 24.0})
+	if err1 != nil || err2 != nil || err3 != nil {
+		t.Errorf("TestIntConversions: got unexpected error adding statics for testing")
+	}
+
+	fnTestJjDumpStatics(t, statics.SelectAll, "", []string{"test.f1", "test.f2", "test.f3"})
+	fnTestJjDumpStatics(t, statics.SelectUser, "", []string{"test.f1", "test.f2", "test.f3"})
+	fnTestJjDumpStatics(t, statics.SelectClass, "test", []string{"test.f1", "test.f2", "test.f3"})
+}

--- a/src/object/format.go
+++ b/src/object/format.go
@@ -189,6 +189,7 @@ func (objPtr *Object) DumpObject(title string, indent int) {
 	obj := *objPtr
 	output := ""
 	var klassString string
+	var className string
 
 	// Emit BEGIN
 	if indent > 0 {
@@ -201,7 +202,8 @@ func (objPtr *Object) DumpObject(title string, indent int) {
 		output += strings.Repeat(" ", indent)
 	}
 	if obj.KlassName != types.InvalidStringIndex {
-		klassString = "\tClass: " + *(stringPool.GetStringPointer(obj.KlassName))
+		className = *(stringPool.GetStringPointer(obj.KlassName))
+		klassString = "\tClass: " + className
 	} else {
 		klassString = "\t<class MISSING>"
 	}
@@ -229,7 +231,7 @@ func (objPtr *Object) DumpObject(title string, indent int) {
 			if !ok {
 				output += fmt.Sprintf("\t\t<ERROR nil FieldTable[%s] ptr>\n", fieldName)
 			} else {
-				str := fmtHelper(obj.FieldTable[fieldName], klassString, fieldName)
+				str := fmtHelper(obj.FieldTable[fieldName], className, fieldName)
 				output += fmt.Sprintf("\t\tFld %s: (%s) %s\n", fieldName, obj.FieldTable[fieldName].Ftype, str)
 			}
 		}


### PR DESCRIPTION
That was a formatting bug in `object/format.go` function `fmtHelper`.