### PR TITLE
JACOBIN-604 verified partial solution

### DIFF
--- a/src/classloader/parser.go
+++ b/src/classloader/parser.go
@@ -9,6 +9,7 @@ package classloader
 import (
 	"errors"
 	"jacobin/globals"
+	"jacobin/statics"
 	"jacobin/stringPool"
 	"jacobin/types"
 	"strconv"
@@ -440,8 +441,22 @@ func parseFields(bytes []byte, loc int, klass *ParsedClass) (int, error) {
 			if attrName == "ConstantValue" {
 				desc := klass.utf8Refs[f.description].content
 				switch desc {
-				case types.Ref, types.Bool: // TODO: Find out how to process these
+				case types.Ref: // TODO: Find out how to process references
 					f.constValue = nil
+				case types.Bool: // TODO: Is this working booleans?
+					indexIntoCP := int(attribute.attrContent[0])*256 +
+						int(attribute.attrContent[1])
+					entryInCp := klass.cpIndex[indexIntoCP]
+					if entryInCp.entryType != IntConst {
+						return pos, cfe("error: wrong type of constant value for boolean " +
+							klass.utf8Refs[f.name].content)
+					}
+					f.constValue = klass.intConsts[entryInCp.slot]
+					if f.isStatic {
+						staticField := statics.Static{Type: types.Bool, Value: f.constValue}
+						staticName := klass.className + "." + klass.utf8Refs[f.name].content
+						statics.AddStatic(staticName, staticField)
+					}
 				case types.Byte: // byte--same logic as for types.Int, only error message is different
 					indexIntoCP := int(attribute.attrContent[0])*256 +
 						int(attribute.attrContent[1])
@@ -451,6 +466,11 @@ func parseFields(bytes []byte, loc int, klass *ParsedClass) (int, error) {
 							klass.utf8Refs[f.name].content)
 					}
 					f.constValue = klass.intConsts[entryInCp.slot]
+					if f.isStatic {
+						staticField := statics.Static{Type: types.Byte, Value: f.constValue}
+						staticName := klass.className + "." + klass.utf8Refs[f.name].content
+						statics.AddStatic(staticName, staticField)
+					}
 				case types.Char: // char--same logic as for types.Int, only error message is different
 					indexIntoCP := int(attribute.attrContent[0])*256 +
 						int(attribute.attrContent[1])
@@ -460,6 +480,11 @@ func parseFields(bytes []byte, loc int, klass *ParsedClass) (int, error) {
 							klass.utf8Refs[f.name].content)
 					}
 					f.constValue = klass.intConsts[entryInCp.slot]
+					if f.isStatic {
+						staticField := statics.Static{Type: types.Char, Value: f.constValue}
+						staticName := klass.className + "." + klass.utf8Refs[f.name].content
+						statics.AddStatic(staticName, staticField)
+					}
 				case types.Double: // double
 					indexIntoCP := int(attribute.attrContent[0])*256 +
 						int(attribute.attrContent[1])
@@ -469,6 +494,11 @@ func parseFields(bytes []byte, loc int, klass *ParsedClass) (int, error) {
 							klass.utf8Refs[f.name].content)
 					}
 					f.constValue = klass.doubles[entryInCp.slot]
+					if f.isStatic {
+						staticField := statics.Static{Type: types.Double, Value: f.constValue}
+						staticName := klass.className + "." + klass.utf8Refs[f.name].content
+						statics.AddStatic(staticName, staticField)
+					}
 				case types.Float: // float
 					indexIntoCP := int(attribute.attrContent[0])*256 +
 						int(attribute.attrContent[1])
@@ -478,6 +508,11 @@ func parseFields(bytes []byte, loc int, klass *ParsedClass) (int, error) {
 							klass.utf8Refs[f.name].content)
 					}
 					f.constValue = klass.floats[entryInCp.slot]
+					if f.isStatic {
+						staticField := statics.Static{Type: types.Float, Value: f.constValue}
+						staticName := klass.className + "." + klass.utf8Refs[f.name].content
+						statics.AddStatic(staticName, staticField)
+					}
 				case types.Int: // integer
 					indexIntoCP := int(attribute.attrContent[0])*256 +
 						int(attribute.attrContent[1])
@@ -487,6 +522,11 @@ func parseFields(bytes []byte, loc int, klass *ParsedClass) (int, error) {
 							klass.utf8Refs[f.name].content)
 					}
 					f.constValue = klass.intConsts[entryInCp.slot]
+					if f.isStatic {
+						staticField := statics.Static{Type: types.Int, Value: f.constValue}
+						staticName := klass.className + "." + klass.utf8Refs[f.name].content
+						statics.AddStatic(staticName, staticField)
+					}
 				case types.Long: // long
 					indexIntoCP := int(attribute.attrContent[0])*256 +
 						int(attribute.attrContent[1])
@@ -496,6 +536,11 @@ func parseFields(bytes []byte, loc int, klass *ParsedClass) (int, error) {
 							klass.utf8Refs[f.name].content)
 					}
 					f.constValue = klass.longConsts[entryInCp.slot]
+					if f.isStatic {
+						staticField := statics.Static{Type: types.Long, Value: f.constValue}
+						staticName := klass.className + "." + klass.utf8Refs[f.name].content
+						statics.AddStatic(staticName, staticField)
+					}
 				case types.Short: // short--same logic as int, only message is different
 					indexIntoCP := int(attribute.attrContent[0])*256 +
 						int(attribute.attrContent[1])
@@ -505,6 +550,11 @@ func parseFields(bytes []byte, loc int, klass *ParsedClass) (int, error) {
 							klass.utf8Refs[f.name].content)
 					}
 					f.constValue = klass.intConsts[entryInCp.slot]
+					if f.isStatic {
+						staticField := statics.Static{Type: types.Short, Value: f.constValue}
+						staticName := klass.className + "." + klass.utf8Refs[f.name].content
+						statics.AddStatic(staticName, staticField)
+					}
 				}
 			} else { // append the attribute only if it's not ConstantValue
 				f.attributes = append(f.attributes, attribute)

--- a/src/jvm/instantiate.go
+++ b/src/jvm/instantiate.go
@@ -123,18 +123,21 @@ func InstantiateClass(classname string, frameStack *list.List) (any, error) {
 			// prepare the static fields, by inserting them w/ default values in Statics table
 			// See (https://docs.oracle.com/javase/specs/jvms/se21/html/jvms-5.html#jvms-5.4.2)
 			if fld.IsStatic {
-				var fldValue any
-				fldType := []byte(k.Data.CP.Utf8Refs[fld.Desc])
-				switch fldType[0] {
-				case 'B', 'C', 'S', 'I', 'J', 'Z':
-					fldValue = int64(0)
-				case 'F', 'D':
-					fldValue = float64(0.00)
-				case 'L', '[':
-					fldValue = object.Null
+				staticName := classname + "." + fldName
+				_, ok := statics.Statics[staticName]
+				if !ok {
+					var fldValue any
+					fldType := []byte(k.Data.CP.Utf8Refs[fld.Desc])
+					switch fldType[0] {
+					case 'B', 'C', 'S', 'I', 'J', 'Z':
+						fldValue = int64(0)
+					case 'F', 'D':
+						fldValue = float64(0.00)
+					case 'L', '[':
+						fldValue = object.Null
+					}
+					statics.AddStatic(staticName, statics.Static{Type: string(fldType[0]), Value: fldValue}) // CURR
 				}
-				statics.AddStatic(classname+"."+fldName,
-					statics.Static{Type: string(fldType[0]), Value: fldValue}) // CURR
 			}
 		} // loop through the fields if any
 		goto runInitializer

--- a/src/statics/statics.go
+++ b/src/statics/statics.go
@@ -200,7 +200,21 @@ func DumpStatics(from string, selection int64, className string) {
 		if (strings.HasPrefix(st.Type, "L") || strings.HasPrefix(st.Type, "[")) && st.Value == nil {
 			value = "<null>"
 		} else {
-			value = fmt.Sprintf("%v", st.Value)
+			switch st.Type {
+			case types.Bool:
+				if st.Value.(int64) == 1 {
+					value = "true"
+				} else {
+					value = "false"
+				}
+			case types.Char, types.Rune:
+				value = fmt.Sprintf("'%c'", st.Value)
+			case "Ljava/lang/String;":
+				value = "\"It's a string but I cannot get its value due to Go statics/object circularity\""
+			default:
+				value = fmt.Sprintf("%v", st.Value)
+			}
+
 		}
 
 		// Prefix name with statics designation (X).

--- a/src/statics/statics.go
+++ b/src/statics/statics.go
@@ -202,10 +202,19 @@ func DumpStatics(from string, selection int64, className string) {
 		} else {
 			switch st.Type {
 			case types.Bool:
-				if st.Value.(int64) == 1 {
-					value = "true"
-				} else {
-					value = "false"
+				switch st.Value.(type) {
+				case bool:
+					if st.Value.(bool) {
+						value = "true"
+					} else {
+						value = "false"
+					}
+				default:
+					if st.Value.(int64) == 1 {
+						value = "true"
+					} else {
+						value = "false"
+					}
 				}
 			case types.Char, types.Rune:
 				value = fmt.Sprintf("'%c'", st.Value)


### PR DESCRIPTION
	modified:   classloader/parser.go
	modified:   jvm/instantiate.go

- In parser.go parseFields(): If the field is static, add it to the statics table.
- In instantiate.go InstantiateClass(): If the field is not yet in the statics table, add it with current dummy values; else leave the existing statics table entry alone.

@platypusguy 
I do not yet have a solution for static String variables, other arrays ([), and  references (L) BUT the I, J, F, D, S, and Z cases seem to be solved.