### PR TITLE
JACOBIN-613: created object.JavaByteSliceToGoString and types.JavaByteSlice

### DIFF
--- a/src/object/string.go
+++ b/src/object/string.go
@@ -202,6 +202,15 @@ func JavaByteSliceToGoString(vector types.JavaByteSlice) string {
 	return string(uint8Slice)
 }
 
+func GoStringToJavaByteSlice(arg string) types.JavaByteSlice {
+	byteSlice := []byte(arg)
+	javaByteSlice := make(types.JavaByteSlice, len(byteSlice))
+	for ix, bb := range byteSlice {
+		javaByteSlice[ix] = types.JavaByte(bb)
+	}
+	return javaByteSlice
+}
+
 // With the specified object and field, return a string representing the field value.
 func ObjectFieldToString(obj *Object, fieldName string) string {
 	// If null, return "null".

--- a/src/object/string_test.go
+++ b/src/object/string_test.go
@@ -388,3 +388,16 @@ func TestJavaByteArrayFromGoString(t *testing.T) {
 		t.Errorf("Expected [0x4d, 0x61, 0x72, 0x79], got %v", jba)
 	}
 }
+
+func TestJavaByteSliceCases(t *testing.T) {
+	str1 := "Off with her head, said the Red Queen"
+	jbs := GoStringToJavaByteSlice(str1)
+	t.Log(jbs)
+	if jbs[0] != 79 || jbs[len(jbs)-1] != 110 {
+		t.Errorf("expected jbs[0]=79 and jbs[last]=110")
+	}
+	str2 := JavaByteSliceToGoString(jbs)
+	if str1 != str2 {
+		t.Errorf("Expected %s, observed %s", str1, str2)
+	}
+}

--- a/src/types/javaTypes.go
+++ b/src/types/javaTypes.go
@@ -89,6 +89,7 @@ func IsError(t string) bool {
 
 // bytes in Go are uint8, whereas in Java they are int8. Hence this type alias.
 type JavaByte = int8
+type JavaByteSlice = []int8
 
 // booleans in Java are defined as integer values of 0 and 1
 // in arrays, they're stored as bytes, everywhere else as 32-bit ints.


### PR DESCRIPTION
modified:   object/string.go
* new: JavaByteSliceToGoString()
* new: GoStringToJavaByteSlice()
* updated case types.ByteArray in ObjectFieldToString()
* updated string_test.go - added a unit test for conversion between JavaByteSlice and string

modified:   types/javaTypes.go
* type JavaByteSlice = []int8

Hopefully, it will contribute to modularity.