### PR TITLE
JACOBIN-630, JACOBIN-613 (io)

### DIFF
--- a/src/gfunction/javaIoFileInputStream.go
+++ b/src/gfunction/javaIoFileInputStream.go
@@ -238,11 +238,12 @@ func fisReadByteArray(params []interface{}) interface{} {
 	}
 
 	// Set buffer to the byte array parameter.
-	buffer, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
+	javaBytes, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]types.JavaByte)
 	if !ok {
 		errMsg := "Byte array parameter lacks a \"value\" field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
+	buffer := object.GoByteArrayFromJavaByteArray(javaBytes)
 
 	// Fill the buffer.
 	nbytes, err := osFile.Read(buffer)
@@ -255,7 +256,8 @@ func fisReadByteArray(params []interface{}) interface{} {
 	}
 
 	// All is well - update the supplied buffer.
-	fld := object.Field{Ftype: types.ByteArray, Fvalue: buffer}
+	javaBytes = object.JavaByteArrayFromGoByteArray(buffer[:nbytes])
+	fld := object.Field{Ftype: types.ByteArray, Fvalue: javaBytes}
 	params[1].(*object.Object).FieldTable["value"] = fld
 
 	// Return the number of bytes.
@@ -273,11 +275,12 @@ func fisReadByteArrayOffset(params []interface{}) interface{} {
 	}
 
 	// Set buffer (buf1) to the byte array parameter.
-	buf1, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
+	javaBytes, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]types.JavaByte)
 	if !ok {
 		errMsg := "Byte array parameter lacks a \"value\" field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
+	buf1 := object.GoByteArrayFromJavaByteArray(javaBytes)
 
 	// Collect the offset and length parameter values.
 	offset := params[2].(int64)
@@ -308,7 +311,8 @@ func fisReadByteArrayOffset(params []interface{}) interface{} {
 	copy(buf1[offset:], buf2)
 
 	// Update the parameter buffer.
-	fld := object.Field{Ftype: types.ByteArray, Fvalue: buf1}
+	javaBytes = object.JavaByteArrayFromGoByteArray(buf1)
+	fld := object.Field{Ftype: types.ByteArray, Fvalue: javaBytes}
 	params[1].(*object.Object).FieldTable["value"] = fld
 
 	// Return the number of bytes.

--- a/src/gfunction/javaIoFileOutputStream.go
+++ b/src/gfunction/javaIoFileOutputStream.go
@@ -258,11 +258,12 @@ func fosWriteByteArray(params []interface{}) interface{} {
 	}
 
 	// Set buffer to the byte array parameter.
-	buffer, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
+	javaBytes, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]types.JavaByte)
 	if !ok {
 		errMsg := "Byte array parameter lacks a \"value\" field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
+	buffer := object.GoByteArrayFromJavaByteArray(javaBytes)
 
 	// Write the buffer.
 	_, err := osFile.Write(buffer)
@@ -285,11 +286,12 @@ func fosWriteByteArrayOffset(params []interface{}) interface{} {
 	}
 
 	// Set buffer (buf1) to the byte array parameter.
-	buf1, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
+	javaBytes, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]types.JavaByte)
 	if !ok {
 		errMsg := "Byte array parameter lacks a \"value\" field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
+	buf1 := object.GoByteArrayFromJavaByteArray(javaBytes)
 
 	// Collect the offset and length parameter values.
 	offset := params[2].(int64)

--- a/src/gfunction/javaIoOutputStreamWriter.go
+++ b/src/gfunction/javaIoOutputStreamWriter.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"jacobin/excNames"
 	"jacobin/object"
+	"jacobin/types"
 	"os"
 )
 
@@ -248,11 +249,12 @@ func oswWriteStringBuffer(params []interface{}) interface{} {
 	}
 
 	// Get the parameter string byte array, offset, and length.
-	paramBytes, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte)
+	javaBytes, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]types.JavaByte)
 	if !ok {
 		errMsg := "Trouble with value field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
+	paramBytes := object.GoByteArrayFromJavaByteArray(javaBytes)
 	offset := params[2].(int64)
 	length := params[3].(int64)
 

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -543,7 +543,7 @@ func Load_Lang_String() {
 	MethodSignatures["java/lang/String.replace(Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/lang/String;"] =
 		GMeth{
 			ParamSlots: 2,
-			GFunction:  stringReplaceCC,
+			GFunction:  stringReplaceAllRegex,
 		}
 
 	// Replaces each substring of this string that matches the given regular expression with the given replacement.

--- a/src/object/arrays.go
+++ b/src/object/arrays.go
@@ -172,6 +172,9 @@ func MakeArrayFromRawArray(rawArray interface{}) *Object {
 	case *Object: // if it's a ref to an array object, just return it
 		arr := rawArray.(*Object)
 		return arr
+	case []*Object: // if it's a ref to an array of objects, just return it
+		obj := MakePrimitiveObject("java/lang/Object", "[Ljava/lang/Object", rawArray.([]*Object))
+		return obj
 	case *[]types.JavaByte: // an array of bytes
 		objPtr :=
 			MakePrimitiveObject(types.ByteArray, types.ByteArray, *rawArray.(*[]types.JavaByte))


### PR DESCRIPTION
Source files impacted:
* JACOBIN-630  object/arrays.go MakeArrayFromRawArray missed the array of objects case.
* JACOBIN-630  gfunction/javaLangString.go, `MethodSignatures["java/lang/String.replace(Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/lang/String;"]` was vectored to the wrong function (`stringReplaceCC`). This should have referenced `stringReplaceAllRegex`.

jacotest cases that moved on to "Native method requested: java/lang/Class.isArray()Z":
- array-list-iterator
- playfair
- sieve
- vector-survivor-2

Fixed the JACOBIN-613 gfunction/javaIo*.go files for the file I/O jacotest cases:
* io_fileinputstream
* io_fileoutputstream
* io_filewriter
* io_outputstreamwriter