### PR TITLE
JACOBIN-645 throw.go, frames.go, interpreter.go

### DIFF
--- a/src/frames/frames.go
+++ b/src/frames/frames.go
@@ -9,6 +9,7 @@ package frames
 import (
 	"container/list"
 	"fmt"
+	"jacobin/util"
 	"unsafe"
 )
 
@@ -119,4 +120,9 @@ func PeekFrame(fs *list.List, which int) *Frame {
 		}
 	}
 	return e.Value.(*Frame)
+}
+
+// From the given frame, return the FQN as a formatted string.
+func FormatFQN(fr *Frame) string {
+	return fmt.Sprintf("%s.%s%s", util.ConvertInternalClassNameToUserFormat(fr.ClName), fr.MethName, fr.MethType)
 }

--- a/src/gfunction/gfunctionExec.go
+++ b/src/gfunction/gfunctionExec.go
@@ -127,8 +127,7 @@ func RunGfunction(mt classloader.MTentry, fs *list.List,
 		} else {
 			threadName = fmt.Sprintf("%d", f.Thread)
 		}
-		errMsg := fmt.Sprintf("%s in thread: %s, method: %s",
-			errBlk.ErrMsg, threadName, fullMethName)
+		errMsg := fmt.Sprintf("%s in thread: %s", errBlk.ErrMsg, threadName)
 		status := exceptions.ThrowEx(errBlk.ExceptionType, errMsg, f)
 		if status != exceptions.Caught {
 			return errors.New(errMsg + " " + errBlk.ErrMsg) // applies only if in test

--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -289,7 +289,7 @@ func interpret(fs *list.List) {
 
 	// Don't allow a nil code segment (E.g. mishandled abstract).
 	if len(fr.Meth) < 1 {
-		errMsg := fmt.Sprintf("Empty code segment for %s.%s%s", fr.ClName, fr.MethName, fr.MethType)
+		errMsg := "Empty code segment"
 		status := exceptions.ThrowEx(excNames.VirtualMachineError, errMsg, fr)
 		if status != exceptions.Caught { // will only happen in test
 			globals.InitGlobals("test")
@@ -1989,8 +1989,7 @@ func doGetfield(fr *frames.Frame, _ int64) int {
 
 	objField, ok := obj.FieldTable[fieldName]
 	if !ok {
-		errMsg := fmt.Sprintf("GETFIELD PC=%d: Missing field (%s) in FieldTable for %s.%s%s",
-			fr.PC, fieldName, fr.ClName, fr.MethName, fr.MethType)
+		errMsg := fmt.Sprintf("GETFIELD PC=%d: Missing field (%s) in FieldTable", fr.PC, fieldName)
 		status := exceptions.ThrowEx(excNames.IllegalArgumentException, errMsg, fr)
 		if status != exceptions.Caught {
 			return exceptions.ERROR_OCCURRED // applies only if in test
@@ -2097,8 +2096,7 @@ func doPutfield(fr *frames.Frame, _ int64) int {
 
 		objField, ok := obj.FieldTable[fieldName]
 		if !ok {
-			errMsg := fmt.Sprintf("PUTFIELD: In trying for a superclass field, %s referenced by %s.%s is not present",
-				fieldName, fr.ClName, fr.MethName)
+			errMsg := fmt.Sprintf("PUTFIELD: In trying for a superclass field, %s is not present", fieldName)
 			status := exceptions.ThrowEx(excNames.NoSuchFieldException, errMsg, fr)
 			if status != exceptions.Caught {
 				return exceptions.ERROR_OCCURRED // applies only if in test
@@ -2108,8 +2106,7 @@ func doPutfield(fr *frames.Frame, _ int64) int {
 		// PUTFIELD is not used to update statics. That's for PUTSTATIC to do.
 		if strings.HasPrefix(objField.Ftype, types.Static) {
 			globals.GetGlobalRef().ErrorGoStack = string(debug.Stack())
-			errMsg := fmt.Sprintf("PUTFIELD: invalid attempt to update a static variable in %s.%s",
-				fr.ClName, fr.MethName)
+			errMsg := "PUTFIELD: invalid attempt to update a static variable"
 			status := exceptions.ThrowEx(excNames.InvalidTypeException, errMsg, fr)
 			if status != exceptions.Caught {
 				return exceptions.ERROR_OCCURRED // applies only if in test

--- a/src/native/nativeFuncExec.go
+++ b/src/native/nativeFuncExec.go
@@ -136,8 +136,7 @@ func RunNativeFunction(fs *list.List, className, nativeFunctionName, methodType 
 		}
 
 		// Build the exception message and return it.
-		errMsg := fmt.Sprintf("%s in thread: %s, method: %s",
-			errBlk.ErrMsg, threadName, fullMethName)
+		errMsg := fmt.Sprintf("%s in thread: %s", errBlk.ErrMsg, threadName)
 		status := exceptions.ThrowEx(errBlk.ExceptionType, errMsg, frame)
 		if status != exceptions.Caught {
 			return errors.New(errMsg + " " + errBlk.ErrMsg) // applies only if in test


### PR DESCRIPTION
frames.FormatFQN:
```
// From the given frame, return the FQN as a formatted string.
func FormatFQN(fr *Frame) string {
	return fmt.Sprintf("%s.%s%s", util.ConvertInternalClassNameToUserFormat(fr.ClName), fr.MethName, fr.MethType)
}
```

throw.go: amended to use ```FormatFQN``` consistently.

interpreter.go: amended to rely on ```ThrowEx``` to supply FQN information.

Also, remove redundant FQN announcement in:
* gfunction/gfunctionExec.go
* native/nativeFuncExec.go

NOTE: run.go ```runThread``` untrapped panic handling has not yet been addressed.