### PR TITLE
JACOBIN-649 consolidation in javaIoPrintStream.go for Object and String + a bit of JACOBIN-538

### DIFF
--- a/src/gfunction/javaIoConsole.go
+++ b/src/gfunction/javaIoConsole.go
@@ -105,7 +105,7 @@ func Load_Io_Console() {
 func consoleClinit([]interface{}) interface{} {
 	klass := classloader.MethAreaFetch("java/io/Console")
 	if klass == nil {
-		errMsg := "Console <clinit>: Could not find java/io/Console in the MethodArea"
+		errMsg := "consoleClinit: Could not find java/io/Console in the MethodArea"
 		return getGErrBlk(excNames.ClassNotLoadedException, errMsg)
 	}
 	klass.Data.ClInit = types.ClInitRun // just mark that String.<clinit>() has been run
@@ -157,7 +157,7 @@ func consoleReadLine([]interface{}) interface{} {
 			break
 		}
 		if err != nil {
-			errMsg := fmt.Sprintf("stdin.Read error: %s", err.Error())
+			errMsg := fmt.Sprintf("consoleReadLine: stdin.Read error: %s", err.Error())
 			return getGErrBlk(excNames.IOException, errMsg)
 		}
 		if bb[0] == '\n' {
@@ -182,7 +182,7 @@ func consolePrintfReadLine(params []interface{}) interface{} {
 func consoleReadPassword([]interface{}) interface{} {
 	password, err := term.ReadPassword(int(syscall.Stdin))
 	if err != nil {
-		errMsg := fmt.Sprintf("stdin.ReadPassword failed, reason: %s", err.Error())
+		errMsg := fmt.Sprintf("consoleReadPassword: stdin.ReadPassword failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	stdout := statics.GetStaticValue("java/lang/System", "out").(*os.File)

--- a/src/gfunction/javaIoFile.go
+++ b/src/gfunction/javaIoFile.go
@@ -72,26 +72,26 @@ func fileInit(params []interface{}) interface{} {
 		objFile.FieldTable = make(map[string]object.Field)
 	}
 
-	// Initialise the file status as "invalid".
+	// Initialise the file status as "invalid" (=0).
 	fld := object.Field{Ftype: types.Int, Fvalue: int64(0)}
 	objFile.FieldTable[FileStatus] = fld
 
 	// Get the argument path string object.
 	objPath := params[1]
 	if object.IsNull(objPath) {
-		errMsg := "Path object is null"
+		errMsg := "fileInit: Path object is null"
 		return getGErrBlk(excNames.NullPointerException, errMsg)
 	}
 	argPathStr := object.GoStringFromStringObject(objPath.(*object.Object))
 	if argPathStr == "" {
-		errMsg := "String argument for path is empty"
+		errMsg := "fileInit: String argument for path is empty"
 		return getGErrBlk(excNames.NullPointerException, errMsg)
 	}
 
 	// Create an absolute path string.
 	absPathStr, err := filepath.Abs(argPathStr)
 	if err != nil {
-		errMsg := fmt.Sprintf("filepath.Abs(%s) failed, reason: %s", argPathStr, err.Error())
+		errMsg := fmt.Sprintf("fileInit: filepath.Abs(%s) failed, reason: %s", argPathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -123,7 +123,7 @@ func fileInit(params []interface{}) interface{} {
 func fileGetPath(params []interface{}) interface{} {
 	fld, ok := params[0].(*object.Object).FieldTable[FilePath]
 	if !ok {
-		errMsg := "File object lacks a FilePath field"
+		errMsg := "fileGetPath: File object lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -142,7 +142,7 @@ func fileGetPath(params []interface{}) interface{} {
 func fileIsInvalid(params []interface{}) interface{} {
 	status, ok := params[0].(*object.Object).FieldTable[FileStatus].Fvalue.(int64)
 	if !ok {
-		errMsg := "File object lacks a FileStatus field"
+		errMsg := "fileIsInvalid: File object lacks a FileStatus field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	if status == 0 {
@@ -163,7 +163,7 @@ func fileDelete(params []interface{}) interface{} {
 	// Get file path string.
 	bytes, ok := params[0].(*object.Object).FieldTable[FilePath].Fvalue.([]byte)
 	if !ok {
-		errMsg := "File object lacks a FilePath field"
+		errMsg := "fileDelete: File object lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	pathStr := string(bytes)
@@ -182,7 +182,7 @@ func fileCreate(params []interface{}) interface{} {
 	// Get path string.
 	fld, ok := params[0].(*object.Object).FieldTable[FilePath]
 	if !ok {
-		errMsg := "File object lacks a FilePath field"
+		errMsg := "fileCreate: File object lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	pathStr := string(fld.Fvalue.([]byte))

--- a/src/gfunction/javaIoFileInputStream.go
+++ b/src/gfunction/javaIoFileInputStream.go
@@ -124,7 +124,7 @@ func initFileInputStreamFile(params []interface{}) interface{} {
 	// Get file path field from the File argument.
 	fld, ok := params[1].(*object.Object).FieldTable[FilePath]
 	if !ok {
-		errMsg := "File object argument lacks a FilePath field"
+		errMsg := "initFileInputStreamFile: File object argument lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -134,7 +134,7 @@ func initFileInputStreamFile(params []interface{}) interface{} {
 	// Open the file for read-only, yielding a file handle.
 	osFile, err := os.Open(pathStr)
 	if err != nil {
-		errMsg := fmt.Sprintf("os.Open(%s) failed, reason: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("initFileInputStreamFile: os.Open(%s) failed, reason: %s", pathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -155,7 +155,7 @@ func initFileInputStreamString(params []interface{}) interface{} {
 	pathStr := object.GoStringFromStringObject(params[1].(*object.Object))
 	osFile, err := os.Open(pathStr)
 	if err != nil {
-		errMsg := fmt.Sprintf("os.Open(%s) failed, reason: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("initFileInputStreamString: os.Open(%s) failed, reason: %s", pathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -176,7 +176,7 @@ func fisAvailable(params []interface{}) interface{} {
 	// Get the file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "FileInputStream object lacks a FileHandle field"
+		errMsg := "fisAvailable: FileInputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -184,7 +184,7 @@ func fisAvailable(params []interface{}) interface{} {
 	fileInfo, err := osFile.Stat()
 	if err != nil {
 		path := string(params[0].(*object.Object).FieldTable["path"].Fvalue.([]byte))
-		errMsg := fmt.Sprintf("osFile.Stat(%s) failed, reason: %s", path, err.Error())
+		errMsg := fmt.Sprintf("fisAvailable: osFile.Stat(%s) failed, reason: %s", path, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	fsize := fileInfo.Size()
@@ -192,7 +192,7 @@ func fisAvailable(params []interface{}) interface{} {
 	// Get current file offset.
 	posn, err := osFile.Seek(0, io.SeekCurrent)
 	if err != nil {
-		errMsg := fmt.Sprintf("osFile.Seek() failed, reason: %s", err.Error())
+		errMsg := fmt.Sprintf("fisAvailable: osFile.Seek() failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -206,7 +206,7 @@ func fisReadOne(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "FileInputStream object lacks a FileHandle field"
+		errMsg := "fisReadOne: FileInputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -219,7 +219,7 @@ func fisReadOne(params []interface{}) interface{} {
 		return int64(-1) // return -1 on EOF
 	}
 	if err != nil {
-		errMsg := fmt.Sprintf("osFile.Read failed, reason: %s", err.Error())
+		errMsg := fmt.Sprintf("fisReadOne: osFile.Read failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -233,14 +233,14 @@ func fisReadByteArray(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "FileInputStream object lacks a FileHandle field"
+		errMsg := "fisReadByteArray: FileInputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Set buffer to the byte array parameter.
 	javaBytes, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]types.JavaByte)
 	if !ok {
-		errMsg := "Byte array parameter lacks a \"value\" field"
+		errMsg := "fisReadByteArray: Byte array parameter lacks a \"value\" field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	buffer := object.GoByteArrayFromJavaByteArray(javaBytes)
@@ -251,7 +251,7 @@ func fisReadByteArray(params []interface{}) interface{} {
 		return int64(-1) // return -1 on EOF
 	}
 	if err != nil {
-		errMsg := fmt.Sprintf("osFile.Read failed, reason: %s", err.Error())
+		errMsg := fmt.Sprintf("fisReadByteArray: osFile.Read failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -270,14 +270,14 @@ func fisReadByteArrayOffset(params []interface{}) interface{} {
 	// Get the file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "FileInputStream object lacks a FileHandle field"
+		errMsg := "fisReadByteArrayOffset: FileInputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Set buffer (buf1) to the byte array parameter.
 	javaBytes, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]types.JavaByte)
 	if !ok {
-		errMsg := "Byte array parameter lacks a \"value\" field"
+		errMsg := "fisReadByteArrayOffset: Byte array parameter lacks a \"value\" field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	buf1 := object.GoByteArrayFromJavaByteArray(javaBytes)
@@ -291,7 +291,7 @@ func fisReadByteArrayOffset(params []interface{}) interface{} {
 		return int64(0)
 	}
 	if length < 0 || offset < 0 || length > (int64(len(buf1))-offset) {
-		errMsg := fmt.Sprintf("Error in parameters offset=%d length=%d bytes.length=%d",
+		errMsg := fmt.Sprintf("fisReadByteArrayOffset: Error in parameters offset=%d length=%d bytes.length=%d",
 			offset, length, len(buf1))
 		return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
 	}
@@ -303,7 +303,7 @@ func fisReadByteArrayOffset(params []interface{}) interface{} {
 		return int64(-1) // return -1 on EOF
 	}
 	if err != nil {
-		errMsg := fmt.Sprintf("osFile.Read failed, reason: %s", err.Error())
+		errMsg := fmt.Sprintf("fisReadByteArrayOffset: osFile.Read failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -325,7 +325,7 @@ func fisSkip(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "FileInputStream object lacks a FileHandle field"
+		errMsg := "fisSkip: FileInputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -335,7 +335,7 @@ func fisSkip(params []interface{}) interface{} {
 	// Skip.
 	_, err := osFile.Seek(count, 1)
 	if err != nil {
-		errMsg := fmt.Sprintf("osFile.Seek(%d) failed, reason: %s", count, err.Error())
+		errMsg := fmt.Sprintf("fisSkip: osFile.Seek(%d) failed, reason: %s", count, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -349,14 +349,14 @@ func fisClose(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "FileInputStream object lacks a FileHandle field"
+		errMsg := "fisClose: FileInputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Close the file.
 	err := osFile.Close()
 	if err != nil {
-		errMsg := fmt.Sprintf("osFile.Close() failed, reason: %s", err.Error())
+		errMsg := fmt.Sprintf("fisClose: osFile.Close() failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	return nil

--- a/src/gfunction/javaIoFileOutputStream.go
+++ b/src/gfunction/javaIoFileOutputStream.go
@@ -90,7 +90,7 @@ func initFileOutputStreamFile(params []interface{}) interface{} {
 	// Get the file path.
 	fld, ok := params[1].(*object.Object).FieldTable[FilePath]
 	if !ok {
-		errMsg := "File object lacks a FilePath field"
+		errMsg := "initFileOutputStreamFile: File object lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	pathStr := string(fld.Fvalue.([]byte))
@@ -98,7 +98,7 @@ func initFileOutputStreamFile(params []interface{}) interface{} {
 	// Open the file for write-only, yielding a file handle.
 	osFile, err := os.Create(pathStr)
 	if err != nil {
-		errMsg := fmt.Sprintf("os.Create(%s) failed, reason: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("initFileOutputStreamFile: os.Create(%s) failed, reason: %s", pathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -118,7 +118,7 @@ func initFileOutputStreamFileBoolean(params []interface{}) interface{} {
 	// Get file path field from the File argument.
 	fld, ok := params[1].(*object.Object).FieldTable[FilePath]
 	if !ok {
-		errMsg := "File object lacks a FilePath field"
+		errMsg := "initFileOutputStreamFileBoolean: File object lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -128,7 +128,7 @@ func initFileOutputStreamFileBoolean(params []interface{}) interface{} {
 	// Get the boolean argument.
 	boolarg, ok := params[2].(int64)
 	if !ok {
-		errMsg := "Missing append-boolean argument"
+		errMsg := "initFileOutputStreamFileBoolean: Missing append-boolean argument"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -141,7 +141,8 @@ func initFileOutputStreamFileBoolean(params []interface{}) interface{} {
 		osFile, err = os.Create(pathStr)
 	}
 	if err != nil {
-		errMsg := fmt.Sprintf("os.Create(%s) failed, reason: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("initFileOutputStreamFileBoolean: os.OpenFile|os.Create(%s) failed, reason: %s",
+			pathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -164,7 +165,7 @@ func initFileOutputStreamString(params []interface{}) interface{} {
 	// Open the file for write-only, yielding a file handle.
 	osFile, err := os.Create(pathStr)
 	if err != nil {
-		errMsg := fmt.Sprintf("os.Create(%s) failed, reason: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("initFileOutputStreamString: os.Create(%s) failed, reason: %s", pathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -188,7 +189,7 @@ func initFileOutputStreamStringBoolean(params []interface{}) interface{} {
 	// Get the boolean argument.
 	boolarg, ok := params[2].(int64)
 	if !ok {
-		errMsg := "Missing append-boolean argument"
+		errMsg := "initFileOutputStreamStringBoolean: Missing append-boolean argument"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -201,7 +202,8 @@ func initFileOutputStreamStringBoolean(params []interface{}) interface{} {
 		osFile, err = os.Create(pathStr)
 	}
 	if err != nil {
-		errMsg := fmt.Sprintf("os.Create(%s) failed, reason: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("initFileOutputStreamStringBoolean: os.OpenFile|os.Create(%s) failed, reason: %s",
+			pathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -222,14 +224,14 @@ func fosWriteOne(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "FileOutputStream object lacks a FileHandle field"
+		errMsg := "fosWriteOne: FileOutputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Get the integer argument.
 	wint, ok := params[1].(int64)
 	if !ok {
-		errMsg := "Missing integer argument"
+		errMsg := "fosWriteOne: Missing integer argument"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -240,7 +242,7 @@ func fosWriteOne(params []interface{}) interface{} {
 	// Write one byte.
 	_, err := osFile.Write(buffer)
 	if err != nil {
-		errMsg := fmt.Sprintf("osFile.Write failed, reason: %s", err.Error())
+		errMsg := fmt.Sprintf("fosWriteOne: osFile.Write failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -253,14 +255,14 @@ func fosWriteByteArray(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "FileOutputStream object lacks a FileHandle field"
+		errMsg := "fosWriteByteArray: FileOutputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Set buffer to the byte array parameter.
 	javaBytes, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]types.JavaByte)
 	if !ok {
-		errMsg := "Byte array parameter lacks a \"value\" field"
+		errMsg := "fosWriteByteArray: Byte array parameter lacks a \"value\" field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	buffer := object.GoByteArrayFromJavaByteArray(javaBytes)
@@ -268,7 +270,7 @@ func fosWriteByteArray(params []interface{}) interface{} {
 	// Write the buffer.
 	_, err := osFile.Write(buffer)
 	if err != nil {
-		errMsg := fmt.Sprintf("osFile.Write failed, reason: %s", err.Error())
+		errMsg := fmt.Sprintf("fosWriteByteArray: osFile.Write failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -281,14 +283,14 @@ func fosWriteByteArrayOffset(params []interface{}) interface{} {
 	// Get the file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "FileOutputStream object lacks a FileHandle field"
+		errMsg := "fosWriteByteArrayOffset: FileOutputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Set buffer (buf1) to the byte array parameter.
 	javaBytes, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]types.JavaByte)
 	if !ok {
-		errMsg := "Byte array parameter lacks a \"value\" field"
+		errMsg := "fosWriteByteArrayOffset: Byte array parameter lacks a \"value\" field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	buf1 := object.GoByteArrayFromJavaByteArray(javaBytes)
@@ -302,7 +304,7 @@ func fosWriteByteArrayOffset(params []interface{}) interface{} {
 		return int64(0)
 	}
 	if length < 0 || offset < 0 || length > (int64(len(buf1))-offset) {
-		errMsg := fmt.Sprintf("Error in parameters offset=%d length=%d bytes.length=%d",
+		errMsg := fmt.Sprintf("fosWriteByteArrayOffset: Error in parameters offset=%d length=%d bytes.length=%d",
 			offset, length, len(buf1))
 		return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
 	}
@@ -310,7 +312,7 @@ func fosWriteByteArrayOffset(params []interface{}) interface{} {
 	// Write the byte buffer.
 	_, err := osFile.Write(buf1[offset : offset+length])
 	if err != nil {
-		errMsg := fmt.Sprintf("osFile.Write failed, reason: %s", err.Error())
+		errMsg := fmt.Sprintf("fosWriteByteArrayOffset: osFile.Write failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -323,14 +325,14 @@ func fosClose(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "FileOutputStream object lacks a FileHandle field"
+		errMsg := "fosClose: FileOutputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Close the file.
 	err := osFile.Close()
 	if err != nil {
-		errMsg := fmt.Sprintf("osFile.Close() failed, reason: %s", err.Error())
+		errMsg := fmt.Sprintf("fosClose: osFile.Close() failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 

--- a/src/gfunction/javaIoFileReader.go
+++ b/src/gfunction/javaIoFileReader.go
@@ -62,13 +62,13 @@ func Load_Io_FileReader() {
 func initFileReader(params []interface{}) interface{} {
 	fld1, ok := params[1].(*object.Object).FieldTable[FilePath]
 	if !ok {
-		errMsg := "File object lacks a FilePath field"
+		errMsg := "initFileReader: File object lacks a FilePath field"
 		return getGErrBlk(excNames.InvalidTypeException, errMsg)
 	}
 	inPathStr := string(fld1.Fvalue.([]byte))
 	osFile, err := os.Open(inPathStr)
 	if err != nil {
-		errMsg := fmt.Sprintf("os.Open(%s) failed, reason: %s", inPathStr, err.Error())
+		errMsg := fmt.Sprintf("initFileReader: os.Open(%s) failed, reason: %s", inPathStr, err.Error())
 		return getGErrBlk(excNames.FileNotFoundException, errMsg)
 	}
 
@@ -88,7 +88,7 @@ func initFileReaderString(params []interface{}) interface{} {
 	pathStr := object.GoStringFromStringObject(params[1].(*object.Object))
 	osFile, err := os.Open(pathStr)
 	if err != nil {
-		errMsg := fmt.Sprintf("os.Open(%s) failed, reason: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("initFileReaderString: os.Open(%s) failed, reason: %s", pathStr, err.Error())
 		return getGErrBlk(excNames.FileNotFoundException, errMsg)
 	}
 

--- a/src/gfunction/javaIoFilterInputStream.go
+++ b/src/gfunction/javaIoFilterInputStream.go
@@ -96,7 +96,7 @@ func initFilterInputStreamFile(params []interface{}) interface{} {
 	// Get file path field from the File argument.
 	fld, ok := params[1].(*object.Object).FieldTable[FilePath]
 	if !ok {
-		errMsg := "File object argument lacks a FilePath field"
+		errMsg := "initFilterInputStreamFile: File object argument lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -127,7 +127,7 @@ func initFilterInputStreamString(params []interface{}) interface{} {
 	pathStr := object.GoStringFromStringObject(params[1].(*object.Object))
 	osFile, err := os.Open(pathStr)
 	if err != nil {
-		errMsg := fmt.Sprintf("os.Open(%s) failed, reason: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("initFilterInputStreamString: os.Open(%s) failed, reason: %s", pathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 

--- a/src/gfunction/javaIoInputStreamReader.go
+++ b/src/gfunction/javaIoInputStreamReader.go
@@ -85,14 +85,14 @@ func inputStreamReaderInit(params []interface{}) interface{} {
 	// Get file path field.
 	fldPath, ok := params[1].(*object.Object).FieldTable[FilePath]
 	if !ok {
-		errMsg := "InputStream object lacks a FilePath field"
+		errMsg := "inputStreamReaderInit: InputStream object lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Get file handle field.
 	fldHandle, ok := params[1].(*object.Object).FieldTable[FileHandle]
 	if !ok {
-		errMsg := "InputStream object lacks a FileHandle field"
+		errMsg := "inputStreamReaderInit: InputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	osFile := fldHandle.Fvalue.(*os.File)
@@ -101,7 +101,7 @@ func inputStreamReaderInit(params []interface{}) interface{} {
 	_, err := osFile.Stat()
 	if err != nil {
 		pathStr := string(fldPath.Fvalue.([]byte))
-		errMsg := fmt.Sprintf("os.Stat(%s) failed, reason: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("inputStreamReaderInit: os.Stat(%s) failed, reason: %s", pathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -127,7 +127,7 @@ func isrClose(params []interface{}) interface{} {
 	// Close the file.
 	err := osFile.Close()
 	if err != nil {
-		errMsg := fmt.Sprintf("osFile.Close() failed, reason: %s", err.Error())
+		errMsg := fmt.Sprintf("isrClose: osFile.Close() failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	return nil
@@ -143,7 +143,7 @@ func isrReadOneChar(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := obj.FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "InputStreamReader object lacks a FileHandle field"
+		errMsg := "isrReadOneChar: InputStreamReader object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -157,7 +157,7 @@ func isrReadOneChar(params []interface{}) interface{} {
 		return int64(-1) // return -1 on EOF
 	}
 	if err != nil {
-		errMsg := fmt.Sprintf("osFile.Read failed, reason: %s", err.Error())
+		errMsg := fmt.Sprintf("isrReadOneChar: osFile.Read failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -174,14 +174,14 @@ func isrReadCharBufferSubset(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := obj.FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "InputStreamReader object lacks a FileHandle field"
+		errMsg := "isrReadCharBufferSubset: InputStreamReader object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Get the parameter buffer, offset, and length.
 	intArray, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]int64)
 	if !ok {
-		errMsg := "InputStreamReader trouble with character array buffer"
+		errMsg := "isrReadCharBufferSubset: InputStreamReader trouble with character array buffer"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	offset := params[2].(int64)
@@ -192,7 +192,7 @@ func isrReadCharBufferSubset(params []interface{}) interface{} {
 		return int64(0)
 	}
 	if length < 0 || offset < 0 || length > (int64(len(intArray))-offset) {
-		errMsg := fmt.Sprintf("Error in parameters: offset=%d, length=%d, char.array.length=%d",
+		errMsg := fmt.Sprintf("isrReadCharBufferSubset: Error in parameters: offset=%d, length=%d, char.array.length=%d",
 			offset, length, len(intArray))
 		return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
 	}
@@ -205,7 +205,7 @@ func isrReadCharBufferSubset(params []interface{}) interface{} {
 		return int64(-1) // return -1 on EOF
 	}
 	if err != nil {
-		errMsg := fmt.Sprintf("osFile.Read failed, reason: %s", err.Error())
+		errMsg := fmt.Sprintf("isrReadCharBufferSubset: osFile.Read failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -229,14 +229,14 @@ func isrReady(params []interface{}) interface{} {
 	// Get file path.
 	fldPath, ok := params[1].(*object.Object).FieldTable[FilePath]
 	if !ok {
-		errMsg := "InputStreamReader object lacks a FilePath field"
+		errMsg := "isrReady: InputStreamReader object lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Get file handle.
 	fldHandle, ok := params[1].(*object.Object).FieldTable[FileHandle]
 	if !ok {
-		errMsg := "InputStreamReader object lacks a FileHandle field"
+		errMsg := "isrReady: InputStreamReader object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 

--- a/src/gfunction/javaIoOutputStreamWriter.go
+++ b/src/gfunction/javaIoOutputStreamWriter.go
@@ -94,14 +94,14 @@ func initOutputStreamWriter(params []interface{}) interface{} {
 	// Get file path field.
 	fldPath, ok := params[1].(*object.Object).FieldTable[FilePath]
 	if !ok {
-		errMsg := "OutputStream object lacks a FilePath field"
+		errMsg := "initOutputStreamWriter: OutputStream object lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Get file handle field.
 	fldHandle, ok := params[1].(*object.Object).FieldTable[FileHandle]
 	if !ok {
-		errMsg := "OutputStream object lacks a FileHandle field"
+		errMsg := "initOutputStreamWriter: OutputStream object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	osFile := fldHandle.Fvalue.(*os.File)
@@ -110,7 +110,7 @@ func initOutputStreamWriter(params []interface{}) interface{} {
 	_, err := osFile.Stat()
 	if err != nil {
 		pathStr := string(fldPath.Fvalue.([]byte))
-		errMsg := fmt.Sprintf("os.Stat(%s) failed, reason: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("initOutputStreamWriter: os.Stat(%s) failed, reason: %s", pathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -128,14 +128,14 @@ func oswClose(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "OutputStreamWriter object lacks a FileHandle field"
+		errMsg := "oswClose: OutputStreamWriter object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Close the file.
 	err := osFile.Close()
 	if err != nil {
-		errMsg := fmt.Sprintf("osFile.Close() failed, reason: %s", err.Error())
+		errMsg := fmt.Sprintf("oswClose: osFile.Close() failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	return nil
@@ -146,14 +146,14 @@ func oswFlush(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "OutputStreamWriter object lacks a FileHandle field"
+		errMsg := "oswFlush: OutputStreamWriter object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Flush the file's buffers.
 	err := osFile.Sync()
 	if err != nil {
-		errMsg := fmt.Sprintf("osFile.Sync() failed, reason: %s", err.Error())
+		errMsg := fmt.Sprintf("oswFlush: osFile.Sync() failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	return nil
@@ -168,14 +168,14 @@ func oswWriteOneChar(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := obj.FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "OutputStreamWriter object lacks a FileHandle field"
+		errMsg := "oswWriteOneChar: OutputStreamWriter object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Get the integer argument.
 	wint, ok := params[1].(int64)
 	if !ok {
-		errMsg := "Error in integer argument"
+		errMsg := "oswWriteOneChar: Error in integer argument"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -186,7 +186,7 @@ func oswWriteOneChar(params []interface{}) interface{} {
 	// Write one byte.
 	_, err := osFile.Write(buffer)
 	if err != nil {
-		errMsg := fmt.Sprintf("osFile.Write failed, reason: %s", err.Error())
+		errMsg := fmt.Sprintf("oswWriteOneChar: osFile.Write failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -199,14 +199,14 @@ func oswWriteCharBuffer(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "OutputStreamWriter object lacks a FileHandle field"
+		errMsg := "oswWriteCharBuffer: OutputStreamWriter object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Get the parameter buffer, offset, and length.
 	intArray, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]int64)
 	if !ok {
-		errMsg := "Trouble with value field ([]int64)"
+		errMsg := "oswWriteCharBuffer: Trouble with value field ([]int64)"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	offset := params[2].(int64)
@@ -217,7 +217,7 @@ func oswWriteCharBuffer(params []interface{}) interface{} {
 		return int64(0)
 	}
 	if length < 0 || offset < 0 || length > (int64(len(intArray))-offset) {
-		errMsg := fmt.Sprintf("Error in parameters: offset=%d, length=%d, char.array.length=%d",
+		errMsg := fmt.Sprintf("oswWriteCharBuffer: Error in parameters: offset=%d, length=%d, char.array.length=%d",
 			offset, length, len(intArray))
 		return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
 	}
@@ -231,7 +231,7 @@ func oswWriteCharBuffer(params []interface{}) interface{} {
 	// Write the byte buffer.
 	_, err := osFile.Write(outBytes)
 	if err != nil {
-		errMsg := fmt.Sprintf("osFile.Write failed, reason: %s", err.Error())
+		errMsg := fmt.Sprintf("oswWriteCharBuffer: osFile.Write failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -244,14 +244,14 @@ func oswWriteStringBuffer(params []interface{}) interface{} {
 	// Get file handle.
 	osFile, ok := params[0].(*object.Object).FieldTable[FileHandle].Fvalue.(*os.File)
 	if !ok {
-		errMsg := "OutputStreamWriter object lacks a FileHandle field"
+		errMsg := "oswWriteStringBuffer: OutputStreamWriter object lacks a FileHandle field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
 	// Get the parameter string byte array, offset, and length.
 	javaBytes, ok := params[1].(*object.Object).FieldTable["value"].Fvalue.([]types.JavaByte)
 	if !ok {
-		errMsg := "Trouble with value field"
+		errMsg := "oswWriteStringBuffer: Trouble with value field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	paramBytes := object.GoByteArrayFromJavaByteArray(javaBytes)
@@ -263,7 +263,7 @@ func oswWriteStringBuffer(params []interface{}) interface{} {
 		return int64(0)
 	}
 	if length < 0 || offset < 0 || length > (int64(len(paramBytes))-offset) {
-		errMsg := fmt.Sprintf("Error in parameters: offset=%d, length=%d, char.array.length=%d",
+		errMsg := fmt.Sprintf("oswWriteStringBuffer: Error in parameters: offset=%d, length=%d, char.array.length=%d",
 			offset, length, len(paramBytes))
 		return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
 	}
@@ -277,7 +277,7 @@ func oswWriteStringBuffer(params []interface{}) interface{} {
 	// Write the byte buffer.
 	_, err := osFile.Write(outBytes)
 	if err != nil {
-		errMsg := fmt.Sprintf("osFile.Write failed, reason: %s", err.Error())
+		errMsg := fmt.Sprintf("oswWriteStringBuffer: osFile.Write failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 

--- a/src/gfunction/javaIoPrintStream.go
+++ b/src/gfunction/javaIoPrintStream.go
@@ -250,32 +250,6 @@ func Load_Io_PrintStream() {
 
 }
 
-// "java/io/PrintStream.println(Ljava/lang/String;)V"
-func PrintlnString(params []interface{}) interface{} {
-	param1, ok := params[1].(*object.Object)
-	if !ok {
-		errMsg := fmt.Sprintf("Expected params[1] of type *object.Object but observed type %T\n", params[1])
-		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
-	}
-
-	// Handle null strings as well as []byte.
-	fld := param1.FieldTable["value"]
-	if fld.Fvalue == nil {
-		fmt.Fprintln(params[0].(*os.File), "")
-	} else {
-		var str string
-		switch fld.Fvalue.(type) {
-		case []byte:
-			str = string(fld.Fvalue.([]byte))
-		case []types.JavaByte:
-			str = object.GoStringFromJavaByteArray(fld.Fvalue.([]types.JavaByte))
-		}
-		fmt.Fprintln(params[0].(*os.File), str)
-	}
-
-	return nil
-}
-
 // PrintlnV = java/io/Prinstream.println() -- println() prints a newline (V = void)
 // "java/io/PrintStream.println()V"
 func PrintlnV(params []interface{}) interface{} {
@@ -325,27 +299,6 @@ func PrintlnLong(params []interface{}) interface{} {
 func PrintlnDoubleFloat(params []interface{}) interface{} {
 	doubleToPrint := params[1].(float64) // contains to a float64--the equivalent of a Java double
 	fmt.Fprintf(params[0].(*os.File), getDoubleFormat(doubleToPrint)+"\n", doubleToPrint)
-	return nil
-}
-
-// Println an Object's contents
-// "java/io/PrintStream.println(Ljava/lang/Object;)V"
-func PrintlnObject(params []interface{}) interface{} {
-	var str string
-	switch params[1].(type) {
-	case *object.Object:
-		inObj := params[1].(*object.Object)
-		str = object.ObjectFieldToString(inObj, "FilePath")
-		if str != "null" {
-			str = object.ObjectFieldToString(inObj, "value")
-		}
-	case nil:
-		str = "null"
-	default:
-		errMsg := fmt.Sprintf("Unsupported parameter type: %T", params[1])
-		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
-	}
-	fmt.Fprintln(params[0].(*os.File), str)
 	return nil
 }
 
@@ -406,43 +359,6 @@ func PrintDouble(params []interface{}) interface{} {
 	return nil
 }
 
-// Print string
-// "java/io/PrintStream.print(Ljava/lang/String;)V"
-func PrintString(params []interface{}) interface{} {
-	var str string
-	switch params[1].(type) {
-	case *object.Object:
-		str = object.GoStringFromStringObject(params[1].(*object.Object))
-	default:
-		errMsg := fmt.Sprintf("Expected params[1] of type *object.Object but observed type %T\n", params[1])
-		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
-	}
-
-	fmt.Fprint(params[0].(*os.File), str)
-	return nil
-}
-
-// Print an Object's contents
-// "java/io/PrintStream.print(Ljava/lang/Object;)V"
-func PrintObject(params []interface{}) interface{} {
-	var str string
-	switch params[1].(type) {
-	case *object.Object:
-		inObj := params[1].(*object.Object)
-		str = object.ObjectFieldToString(inObj, "FilePath")
-		if str != "null" {
-			str = object.ObjectFieldToString(inObj, "value")
-		}
-	case nil:
-		str = "null"
-	default:
-		errMsg := fmt.Sprintf("Unsupported parameter type: %T", params[1])
-		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
-	}
-	fmt.Fprint(params[0].(*os.File), str)
-	return nil
-}
-
 // Printf -- handle the variable args and then call golang's own printf function
 // "java/io/PrintStream.printf(Ljava/lang/String;[Ljava/lang/Object;)Ljava/io/PrintStream;"
 func Printf(params []interface{}) interface{} {
@@ -474,4 +390,87 @@ func getDoubleFormat(d float64) string {
 			return "%f"
 		}
 	}
+}
+
+// Called by PrintObject and PrintlnObject
+func _printObject(params []interface{}, newLine bool) interface{} {
+	var str string
+	switch params[1].(type) {
+	case *object.Object:
+		inObj := params[1].(*object.Object)
+		str = object.ObjectFieldToString(inObj, "FilePath")
+		if str != "null" {
+			str = object.ObjectFieldToString(inObj, "value")
+		}
+	case nil:
+		str = "null"
+	default:
+		errMsg := fmt.Sprintf("_printObject: Unsupported parameter type: %T", params[1])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	if newLine {
+		fmt.Fprintln(params[0].(*os.File), str)
+	} else {
+		fmt.Fprint(params[0].(*os.File), str)
+	}
+
+	return nil
+}
+
+// Print an Object's contents
+// "java/io/PrintStream.print(Ljava/lang/Object;)V"
+func PrintObject(params []interface{}) interface{} {
+	return _printObject(params, false)
+}
+
+// Println an Object's contents
+// "java/io/PrintStream.println(Ljava/lang/Object;)V"
+func PrintlnObject(params []interface{}) interface{} {
+	return _printObject(params, true)
+}
+
+// "java/io/PrintStream.println(Ljava/lang/String;)V"
+func _printString(params []interface{}, newLine bool) interface{} {
+	var str string
+	param1, ok := params[1].(*object.Object)
+	if !ok {
+		errMsg := fmt.Sprintf("_printString: Expected params[1] of type *object.Object but observed type %T\n", params[1])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Handle null strings as well as []byte.
+	fld := param1.FieldTable["value"]
+	if fld.Fvalue == nil {
+		str = ""
+	} else {
+		switch fld.Fvalue.(type) {
+		case []byte:
+			str = string(fld.Fvalue.([]byte))
+		case []types.JavaByte:
+			str = object.GoStringFromJavaByteArray(fld.Fvalue.([]types.JavaByte))
+		default:
+			errMsg := fmt.Sprintf("_printString: Expected value field to be type byte but observed type %T\n", fld.Fvalue)
+			return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+		}
+	}
+
+	if newLine {
+		fmt.Fprintln(params[0].(*os.File), str)
+	} else {
+		fmt.Fprint(params[0].(*os.File), str)
+	}
+
+	return nil
+}
+
+// Print string
+// "java/io/PrintStream.print(Ljava/lang/String;)V"
+func PrintString(params []interface{}) interface{} {
+	return _printString(params, false)
+}
+
+// "java/io/PrintStream.println(Ljava/lang/String;)V"
+func PrintlnString(params []interface{}) interface{} {
+	return _printString(params, true)
 }

--- a/src/gfunction/javaIoRandomAccessFile.go
+++ b/src/gfunction/javaIoRandomAccessFile.go
@@ -93,14 +93,14 @@ func rafInitString(params []interface{}) interface{} {
 	case "rw", "rws", "rwd":
 		modeInt = os.O_RDWR | os.O_CREATE | os.O_APPEND
 	default:
-		errMsg := fmt.Sprintf("mode string (%s) invalid", modeStr)
+		errMsg := fmt.Sprintf("rafInitString: mode string (%s) invalid", modeStr)
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
 	// Open the file in the specified mode.
 	osFile, err := os.OpenFile(pathStr, modeInt, CreateFilePermissions)
 	if err != nil {
-		errMsg := fmt.Sprintf("os.OpenFile(%s) failed, reason: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("rafInitString: os.OpenFile(%s) failed, reason: %s", pathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -124,7 +124,7 @@ func rafInitFile(params []interface{}) interface{} {
 	obj := params[1].(*object.Object)
 	fld, ok := obj.FieldTable[FilePath]
 	if !ok {
-		errMsg := "java/io/File object is missing the FilePath field"
+		errMsg := "rafInitFile: java/io/File object is missing the FilePath field"
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	pathStr := string(fld.Fvalue.([]byte))
@@ -138,14 +138,14 @@ func rafInitFile(params []interface{}) interface{} {
 	case "rw", "rws", "rwd":
 		modeInt = os.O_RDWR | os.O_CREATE | os.O_APPEND
 	default:
-		errMsg := fmt.Sprintf("mode string (%s) invalid", modeStr)
+		errMsg := fmt.Sprintf("rafInitFile: mode string (%s) invalid", modeStr)
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
 	// Open the file in the specified mode.
 	osFile, err := os.OpenFile(pathStr, modeInt, CreateFilePermissions)
 	if err != nil {
-		errMsg := fmt.Sprintf("os.Open(%s) failed, reason: %s", pathStr, err.Error())
+		errMsg := fmt.Sprintf("rafInitFile: os.Open(%s) failed, reason: %s", pathStr, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 
@@ -169,7 +169,7 @@ func rafGetFilePointer(params []interface{}) interface{} {
 	obj := params[0].(*object.Object)
 	fld, ok := obj.FieldTable[FileHandle]
 	if !ok {
-		errMsg := "java/io/RandomAccessFile object is missing the FileHandle field"
+		errMsg := "rafGetFilePointer: java/io/RandomAccessFile object is missing the FileHandle field"
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	var osFile *os.File = fld.Fvalue.(*os.File)
@@ -177,7 +177,7 @@ func rafGetFilePointer(params []interface{}) interface{} {
 	// Get the current position relative to the beginning of file.
 	posn, err := osFile.Seek(0, 1)
 	if err != nil {
-		errMsg := fmt.Sprintf("osFile.Seek(0, 1) failed, reason: %s", err.Error())
+		errMsg := fmt.Sprintf("rafGetFilePointer: osFile.Seek(0, 1) failed, reason: %s", err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 

--- a/src/gfunction/javaLangByte.go
+++ b/src/gfunction/javaLangByte.go
@@ -55,7 +55,8 @@ func byteDecode(params []interface{}) interface{} {
 	parmObj := params[0].(*object.Object)
 	strArg := object.GoStringFromStringObject(parmObj)
 	if len(strArg) < 1 {
-		return getGErrBlk(excNames.NumberFormatException, "Byte array length < 1")
+
+		return getGErrBlk(excNames.NumberFormatException, "byteDecode: Byte array length < 1")
 	}
 
 	// Strip off a leading "#" or "0x" in strArg.
@@ -69,11 +70,11 @@ func byteDecode(params []interface{}) interface{} {
 	// Parse the input integer.
 	int64Value, err := strconv.ParseInt(strArg, 16, 64)
 	if err != nil {
-		errMsg := fmt.Sprintf("strconv.ParseInt(%s) failed, reason: %s", strArg, err.Error())
+		errMsg := fmt.Sprintf("byteDecode: strconv.ParseInt(%s) failed, reason: %s", strArg, err.Error())
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 	if int64Value > 255 {
-		errMsg := fmt.Sprintf("Byte value too large: %d", int64Value)
+		errMsg := fmt.Sprintf("byteDecode: Byte value too large: %d", int64Value)
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 

--- a/src/gfunction/javaLangClass.go
+++ b/src/gfunction/javaLangClass.go
@@ -91,7 +91,7 @@ func getPrimitiveClass(params []interface{}) interface{} {
 	if err == nil {
 		return k
 	} else {
-		errMsg := fmt.Sprintf("%s: %s", err.Error(), str)
+		errMsg := fmt.Sprintf("getPrimitiveClass: %s: %s", err.Error(), str)
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 }
@@ -112,7 +112,7 @@ func simpleClassLoadByName(className string) (*classloader.Klass, error) {
 		if className == "" {
 			errClassName = "<empty string>"
 		}
-		errMsg := fmt.Sprintf("Failed to load class %s by name, reason: %s", errClassName, err.Error())
+		errMsg := fmt.Sprintf("simpleClassLoadByName: Failed to load class %s by name, reason: %s", errClassName, err.Error())
 		trace.Error(errMsg)
 		shutdown.Exit(shutdown.APP_EXCEPTION)
 		return nil, errors.New(errMsg) // needed for testing, which does not cause an O/S exit on failure

--- a/src/gfunction/javaLangDouble.go
+++ b/src/gfunction/javaLangDouble.go
@@ -182,13 +182,13 @@ func doubleParseDouble(params []interface{}) interface{} {
 	parmObj := params[0].(*object.Object)
 	strArg := object.GoStringFromStringObject(parmObj)
 	if len(strArg) < 1 {
-		return getGErrBlk(excNames.NumberFormatException, "String length is zero")
+		return getGErrBlk(excNames.NumberFormatException, "doubleParseDouble: String length is zero")
 	}
 
 	// Compute output.
 	output, err := strconv.ParseFloat(strArg, 64)
 	if err != nil {
-		errMsg := fmt.Sprintf("strconv.ParseFloat(%s) failed, reason: %s", strArg, err.Error())
+		errMsg := fmt.Sprintf("doubleParseDouble: strconv.ParseFloat(%s) failed, reason: %s", strArg, err.Error())
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 	return output

--- a/src/gfunction/javaLangInteger.go
+++ b/src/gfunction/javaLangInteger.go
@@ -160,7 +160,7 @@ func integerDecode(params []interface{}) interface{} {
 	parmObj := params[0].(*object.Object)
 	strArg := object.GoStringFromStringObject(parmObj)
 	if len(strArg) < 1 {
-		return getGErrBlk(excNames.NumberFormatException, "Byte array length is zero")
+		return getGErrBlk(excNames.NumberFormatException, "integerDecode: Byte array length is zero")
 	}
 
 	// Replace a leading "#" with "0x" in strArg.
@@ -173,7 +173,7 @@ func integerDecode(params []interface{}) interface{} {
 	// Parse the input integer.
 	int64Value, err := strconv.ParseInt(strArg, wbase, 64)
 	if err != nil {
-		errMsg := fmt.Sprintf("strconv.ParseInt(%s,10,64) failed, failed, reason: %s", strArg, err.Error())
+		errMsg := fmt.Sprintf("integerDecode: strconv.ParseInt(%s,10,64) failed, failed, reason: %s", strArg, err.Error())
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 
@@ -205,7 +205,7 @@ func integerParseInt(params []interface{}) interface{} {
 	parmObj := params[0].(*object.Object)
 	strArg := object.GoStringFromStringObject(parmObj)
 	if len(strArg) < 1 {
-		return getGErrBlk(excNames.NumberFormatException, "String length is zero")
+		return getGErrBlk(excNames.NumberFormatException, "integerParseInt: String length is zero")
 	}
 
 	// Replace a leading "#" with "0x" in strArg.
@@ -216,7 +216,7 @@ func integerParseInt(params []interface{}) interface{} {
 	// Compute output.
 	output, err := strconv.ParseInt(strArg, 10, 64)
 	if err != nil {
-		errMsg := fmt.Sprintf("strconv.ParseInt(%s,10,64) failed, reason: %s", strArg, err.Error())
+		errMsg := fmt.Sprintf("integerParseInt: strconv.ParseInt(%s,10,64) failed, reason: %s", strArg, err.Error())
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 
@@ -230,7 +230,7 @@ func integerParseIntRadix(params []interface{}) interface{} {
 	parmObj := params[0].(*object.Object)
 	strArg := object.GoStringFromStringObject(parmObj)
 	if len(strArg) < 1 {
-		return getGErrBlk(excNames.NumberFormatException, "String length is zero")
+		return getGErrBlk(excNames.NumberFormatException, "integerParseIntRadix: String length is zero")
 	}
 
 	// Replace a leading "#" with "0x" in strArg.
@@ -242,27 +242,27 @@ func integerParseIntRadix(params []interface{}) interface{} {
 	switch params[1].(type) {
 	case int64:
 	default:
-		return getGErrBlk(excNames.NumberFormatException, "Radix is not an integer")
+		return getGErrBlk(excNames.NumberFormatException, "integerParseIntRadix: Radix is not an integer")
 	}
 	rdx := params[1].(int64)
 	if rdx < MinRadix || rdx > MaxRadix {
-		errMsg := fmt.Sprintf("Invalid radix value (%d)", rdx)
+		errMsg := fmt.Sprintf("integerParseIntRadix: Invalid radix value (%d)", rdx)
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 
 	// Compute output.
 	output, err := strconv.ParseInt(strArg, int(rdx), 64)
 	if err != nil {
-		errMsg := fmt.Sprintf("strconv.ParseInt(%s,%d,64) failed, reason: %s", strArg, rdx, err.Error())
+		errMsg := fmt.Sprintf("integerParseIntRadix: strconv.ParseInt(%s,%d,64) failed, reason: %s", strArg, rdx, err.Error())
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 
 	// Check Integer boundaries.
 	if output > MaxIntValue {
-		return getGErrBlk(excNames.NumberFormatException, "Computed integer exceeds upper limit")
+		return getGErrBlk(excNames.NumberFormatException, "integerParseIntRadix: Computed integer exceeds upper limit")
 	}
 	if output < MinIntValue {
-		return getGErrBlk(excNames.NumberFormatException, "Computed integer is less than lower limit")
+		return getGErrBlk(excNames.NumberFormatException, "integerParseIntRadix: Computed integer is less than lower limit")
 	}
 
 	// Return computed value.
@@ -328,12 +328,12 @@ func integerToUnsignedStringRadix(params []interface{}) interface{} {
 	switch params[1].(type) {
 	case int64:
 	default:
-		errMsg := fmt.Sprintf("Invalid radix (%v) format", params[1])
+		errMsg := fmt.Sprintf("integerToUnsignedStringRadix: Invalid radix (%v) format", params[1])
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 	rdx := params[1].(int64)
 	if rdx < MinRadix || rdx > MaxRadix {
-		errMsg := fmt.Sprintf("Invalid radix value (%d)", rdx)
+		errMsg := fmt.Sprintf("integerToUnsignedStringRadix: Invalid radix value (%d)", rdx)
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 

--- a/src/gfunction/javaLangLong.go
+++ b/src/gfunction/javaLangLong.go
@@ -81,7 +81,7 @@ func longParseLong(params []interface{}) interface{} {
 	str := object.GoStringFromStringObject(obj)
 	jj, err := strconv.ParseInt(str, 10, 64)
 	if err != nil {
-		errMsg := fmt.Sprintf("strconv.ParseInt(%s,10,64), failed, reason: %s", str, err.Error())
+		errMsg := fmt.Sprintf("longParseLong: strconv.ParseInt(%s,10,64), failed, reason: %s", str, err.Error())
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 	return jj

--- a/src/gfunction/javaLangMath.go
+++ b/src/gfunction/javaLangMath.go
@@ -10,7 +10,6 @@ import (
 	"jacobin/classloader"
 	"jacobin/excNames"
 	"jacobin/object"
-	"jacobin/trace"
 	"math"
 	"math/big"
 	"math/rand"
@@ -220,8 +219,7 @@ func Load_Lang_Math() {
 func mathClinit([]interface{}) interface{} {
 	klass := classloader.MethAreaFetch("java/lang/Math")
 	if klass == nil {
-		errMsg := "Math<clinit>: Expected java/lang/Math to be in the MethodArea, but it was not"
-		trace.Error(errMsg)
+		errMsg := "mathClinit: Expected java/lang/Math to be in the MethodArea, but it was not"
 		return getGErrBlk(excNames.InternalException, errMsg)
 	}
 	return object.StringObjectFromGoString("mathClinit")
@@ -324,7 +322,7 @@ func floorFloat64(params []interface{}) interface{} {
 // to the algebraic quotient.
 func floorDivInt64(dividend int64, divisor int64) interface{} {
 	if divisor == 0 {
-		return getGErrBlk(excNames.ArithmeticException, "Divide by zero")
+		return getGErrBlk(excNames.ArithmeticException, "floorDivInt64: Divide by zero")
 	}
 	if dividend <= math.MinInt64 && divisor == -1 {
 		return math.MinInt64

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -780,7 +780,7 @@ func Load_Lang_String() {
 func stringClinit([]interface{}) interface{} {
 	klass := classloader.MethAreaFetch(types.StringClassName)
 	if klass == nil {
-		errMsg := fmt.Sprintf("Could not find class %s in the MethodArea", types.StringClassName)
+		errMsg := fmt.Sprintf("stringClinit: Could not find class %s in the MethodArea", types.StringClassName)
 		return getGErrBlk(excNames.ClassNotLoadedException, errMsg)
 	}
 	klass.Data.ClInit = types.ClInitRun // just mark that String.<clinit>() has been run
@@ -834,7 +834,7 @@ func newStringFromBytesSubset(params []interface{}) interface{} {
 	// Validate boundaries.
 	totalLength := int64(len(bytes))
 	if totalLength < 1 || ssStart < 0 || ssEnd < 1 || ssStart > (totalLength-1) || (ssStart+ssEnd) > totalLength {
-		errMsg1 := "Either nil input byte array, invalid substring offset, or invalid substring length"
+		errMsg1 := "newStringFromBytesSubset: Either nil input byte array, invalid substring offset, or invalid substring length"
 		errMsg2 := fmt.Sprintf("\n\twhole='%s' wholelen=%d, offset=%d, sslen=%d\n\n",
 			object.GoStringFromJavaByteArray(bytes), totalLength, ssStart, ssEnd)
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg1+errMsg2)
@@ -870,12 +870,12 @@ func newStringFromCharsSubset(params []interface{}) interface{} {
 	// Return the string.
 	fld, ok := params[0].(*object.Object).FieldTable["value"]
 	if !ok {
-		errMsg := fmt.Sprintf("Missing value field in character array object")
+		errMsg := fmt.Sprintf("newStringFromCharsSubset: Missing value field in character array object")
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	iarray, ok := fld.Fvalue.([]int64)
 	if !ok {
-		errMsg := fmt.Sprintf("Invalid value field type (%s : %T) in character array object", fld.Ftype, fld.Fvalue)
+		errMsg := fmt.Sprintf("newStringFromCharsSubset: Invalid value field type (%s : %T) in character array object", fld.Ftype, fld.Fvalue)
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -886,7 +886,7 @@ func newStringFromCharsSubset(params []interface{}) interface{} {
 	// Validate boundaries.
 	totalLength := int64(len(iarray))
 	if totalLength < 1 || ssStart < 0 || ssEnd < 1 || ssStart > (totalLength-1) || (ssStart+ssEnd) > totalLength {
-		errMsg1 := "Either nil input byte array, invalid substring offset, or invalid substring length"
+		errMsg1 := "newStringFromCharsSubset: Either nil input byte array, invalid substring offset, or invalid substring length"
 		errMsg2 := fmt.Sprintf("\n\twholelen=%d, offset=%d, sslen=%d\n\n", totalLength, ssStart, ssEnd)
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg1+errMsg2)
 	}
@@ -1322,7 +1322,7 @@ func stringMatches(params []any) any {
 
 	regex, err := regexp.Compile(regexString)
 	if err != nil {
-		errMsg := fmt.Sprintf("Invalid regular expression: %s", regexString)
+		errMsg := fmt.Sprintf("stringMatches: Invalid regular expression: %s", regexString)
 		return getGErrBlk(excNames.PatternSyntaxException, errMsg)
 	}
 	if regex.MatchString(baseString) {
@@ -1426,7 +1426,7 @@ func substringToTheEnd(params []interface{}) interface{} {
 	// Validate boundaries.
 	totalLength := int64(len(str))
 	if totalLength < 1 || ssStart < 0 || ssEnd < 1 || ssStart > (totalLength-1) || ssEnd > totalLength {
-		errMsg1 := "Either: nil input byte array, invalid substring offset, or invalid substring length"
+		errMsg1 := "substringToTheEnd: Either nil input byte array, invalid substring offset, or invalid substring length"
 		errMsg2 := fmt.Sprintf("\n\twhole='%s' wholelen=%d, offset=%d, sslen=%d\n\n", str, totalLength, ssStart, ssEnd)
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg1+errMsg2)
 	}
@@ -1454,7 +1454,7 @@ func substringStartEnd(params []interface{}) interface{} {
 	// Validate boundaries.
 	totalLength := int64(len(str))
 	if totalLength < 1 || ssStart < 0 || ssEnd < 1 || ssStart > (totalLength-1) || ssEnd > totalLength {
-		errMsg1 := "Either: nil input byte array, invalid substring offset, or invalid substring length"
+		errMsg1 := "substringStartEnd: Either nil input byte array, invalid substring offset, or invalid substring length"
 		errMsg2 := fmt.Sprintf("\n\twhole='%s' wholelen=%d, offset=%d, sslen=%d\n\n", str, totalLength, ssStart, ssEnd)
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg1+errMsg2)
 	}
@@ -1557,7 +1557,7 @@ func valueOfCharSubarray(params []interface{}) interface{} {
 	// Validate boundaries.
 	wholeLength := int64(len(wholeString))
 	if wholeLength < 1 || ssOffset < 0 || ssCount < 1 || ssOffset > (wholeLength-1) || (ssOffset+ssCount) > wholeLength {
-		errMsg := "Either: nil input byte array, invalid substring offset, or invalid substring length"
+		errMsg := "valueOfCharSubarray: Either nil input byte array, invalid substring offset, or invalid substring length"
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 	}
 
@@ -1620,7 +1620,7 @@ func valueOfObject(params []interface{}) interface{} {
 		inObj := params[0].(*object.Object)
 		str = object.ObjectFieldToString(inObj, "value")
 	default:
-		errMsg := fmt.Sprintf("Unsupported parameter type: %T", params[0])
+		errMsg := fmt.Sprintf("valueOfObject: Unsupported parameter type: %T", params[0])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -1668,7 +1668,7 @@ func stringCheckBoundsBeginEnd(params []interface{}) interface{} {
 	length := params[2].(int64)
 
 	if begin < 0 || begin > end || end > length {
-		errMsg := fmt.Sprintf("checkBoundsBeginEnd: begin: %d, end: %d, length: %d", begin, end, length)
+		errMsg := fmt.Sprintf("stringCheckBoundsBeginEnd: begin: %d, end: %d, length: %d", begin, end, length)
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 	}
 
@@ -1682,7 +1682,7 @@ func stringCheckBoundsOffCount(params []interface{}) interface{} {
 	length := params[2].(int64)
 
 	if offset < 0 || count < 0 || offset > count || offset > (length-count) {
-		errMsg := fmt.Sprintf("checkBoundsOffCount: offset: %d, count: %d, length: %d", offset, count, length)
+		errMsg := fmt.Sprintf("stringCheckBoundsOffCount: offset: %d, count: %d, length: %d", offset, count, length)
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 	}
 
@@ -1710,7 +1710,7 @@ func stringStartsWith(params []interface{}) interface{} {
 	if len(params) == 3 {
 		offset := int(params[2].(int64))
 		if offset < 0 || offset > len(baseStr) {
-			errMsg := fmt.Sprintf("checkBoundsOffCount: base: %s, prefix: %s, offset: %d", baseStr, prefix, offset)
+			errMsg := fmt.Sprintf("stringStartsWith: base: %s, prefix: %s, offset: %d", baseStr, prefix, offset)
 			return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 		}
 		if strings.HasPrefix(baseStr[offset:], prefix) {
@@ -1758,7 +1758,7 @@ func stringGetChars(params []interface{}) interface{} {
 	// Return nil
 	srcFld, ok := params[0].(*object.Object).FieldTable["value"]
 	if !ok {
-		errMsg := fmt.Sprintf("Missing value field in base object")
+		errMsg := fmt.Sprintf("stringGetChars: Missing value field in base object")
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -1769,7 +1769,7 @@ func stringGetChars(params []interface{}) interface{} {
 	case []types.JavaByte:
 		srcBytes = srcFld.Fvalue.([]types.JavaByte)
 	default:
-		errMsg := fmt.Sprintf("Invalid value field type (%s : %T) in base object", srcFld.Ftype, srcFld.Fvalue)
+		errMsg := fmt.Sprintf("stringGetChars: Invalid value field type (%s : %T) in base object", srcFld.Ftype, srcFld.Fvalue)
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -1784,12 +1784,13 @@ func stringGetChars(params []interface{}) interface{} {
 	dstObj := params[3].(*object.Object)
 	dstFld, ok := dstObj.FieldTable["value"]
 	if !ok {
-		errMsg := fmt.Sprintf("Missing value field in char array object")
+		errMsg := fmt.Sprintf("stringGetChars: Missing value field in char array object")
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	dstChars, ok := dstFld.Fvalue.([]int64)
 	if !ok {
-		errMsg := fmt.Sprintf("Invalid value field type (%s : %T) in char array object", dstFld.Ftype, dstFld.Fvalue)
+		errMsg := fmt.Sprintf("stringGetChars: Invalid value field type (%s : %T) in char array object",
+			dstFld.Ftype, dstFld.Fvalue)
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -1801,7 +1802,7 @@ func stringGetChars(params []interface{}) interface{} {
 
 	// Validate boundaries.
 	if srcBegin < 0 || srcEnd < srcBegin || srcEnd > srcLength || dstBegin < 0 || dstBegin+(srcEnd-srcBegin) > dstLength {
-		errMsg1 := "Either nil input byte array, invalid substring offset, or invalid substring length"
+		errMsg1 := "stringGetChars: Either nil input byte array, invalid substring offset, or invalid substring length"
 		errMsg2 := fmt.Sprintf("\n\twholelen=%d, offset=%d, sslen=%d\n\n", srcLength, srcBegin, srcEnd)
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg1+errMsg2)
 	}
@@ -1828,7 +1829,7 @@ func stringIndexOfCh(params []interface{}) interface{} {
 	// Get field of base object.
 	srcFld, ok := params[0].(*object.Object).FieldTable["value"]
 	if !ok {
-		errMsg := fmt.Sprintf("Missing value field in base object")
+		errMsg := fmt.Sprintf("stringIndexOfCh: Missing value field in base object")
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -1840,7 +1841,7 @@ func stringIndexOfCh(params []interface{}) interface{} {
 	case []types.JavaByte:
 		srcBytes = srcFld.Fvalue.([]types.JavaByte)
 	default:
-		errMsg := fmt.Sprintf("Invalid value field type (%s : %T) in base object", srcFld.Ftype, srcFld.Fvalue)
+		errMsg := fmt.Sprintf("stringIndexOfCh: Invalid value field type (%s : %T) in base object", srcFld.Ftype, srcFld.Fvalue)
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -1867,12 +1868,12 @@ func stringIndexOfCh(params []interface{}) interface{} {
 	case 3: // int indexOf(int ch, int beginIndex, int endIndex)
 		beginIndex = params[2].(int64)
 		if beginIndex < 0 || beginIndex >= lenSrcBytes {
-			errMsg := fmt.Sprintf("Base string len: %d, begin index: %d", lenSrcBytes, beginIndex)
+			errMsg := fmt.Sprintf("stringIndexOfCh: Base string len: %d, begin index: %d", lenSrcBytes, beginIndex)
 			return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 		}
 		endIndex = params[3].(int64)
 		if endIndex > lenSrcBytes || beginIndex > endIndex {
-			errMsg := fmt.Sprintf("Base string len: %d, end index: %d", lenSrcBytes, endIndex)
+			errMsg := fmt.Sprintf("stringIndexOfCh: Base string len: %d, end index: %d", lenSrcBytes, endIndex)
 			return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 		}
 	}
@@ -1915,12 +1916,12 @@ func stringIndexOfString(params []interface{}) interface{} {
 	case 3: // int indexOf(String str, int beginIndex, int endIndex)
 		beginIndex = params[2].(int64)
 		if beginIndex < 0 || beginIndex >= lenOrigBaseString {
-			errMsg := fmt.Sprintf("Base string len: %d, begin index: %d", lenOrigBaseString, beginIndex)
+			errMsg := fmt.Sprintf("stringIndexOfString: Base string len: %d, begin index: %d", lenOrigBaseString, beginIndex)
 			return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 		}
 		endIndex = params[3].(int64)
 		if endIndex > lenOrigBaseString || beginIndex > endIndex {
-			errMsg := fmt.Sprintf("Base string len: %d, end index: %d", lenOrigBaseString, endIndex)
+			errMsg := fmt.Sprintf("stringIndexOfString: Base string len: %d, end index: %d", lenOrigBaseString, endIndex)
 			return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 		}
 	}

--- a/src/gfunction/javaLangStringBuffer.go
+++ b/src/gfunction/javaLangStringBuffer.go
@@ -480,7 +480,7 @@ func stringBufferInitString(params []any) any {
 			return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 		}
 	default:
-		errMsg := fmt.Sprintf("Parameter type (%T) is illegal", params[1])
+		errMsg := fmt.Sprintf("StringBufferInitString: Parameter type (%T) is illegal", params[1])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 

--- a/src/gfunction/javaLangStringBuilder.go
+++ b/src/gfunction/javaLangStringBuilder.go
@@ -427,7 +427,7 @@ func stringBuilderInitString(params []any) any {
 			byteArray = object.JavaByteArrayFromGoString(rawArray.(string))
 		}
 	default:
-		errMsg := fmt.Sprintf("Parameter type (%T) is illegal", params[1])
+		errMsg := fmt.Sprintf("stringBuilderInitString: Parameter type (%T) is illegal", params[1])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -482,7 +482,7 @@ func stringBuilderAppend(params []any) any {
 				length := params[3].(int64)
 				end := start + length
 				if start < 0 || start > len64Array || end <= start || end > len64Array {
-					errMsg := fmt.Sprintf("Invalid offset (%d) or length (%d)", start, length)
+					errMsg := fmt.Sprintf("stringBuilderAppend: Invalid offset (%d) or length (%d)", start, length)
 					return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
 				}
 				for ix := start; ix < start+length; ix++ {
@@ -494,7 +494,8 @@ func stringBuilderAppend(params []any) any {
 				}
 			}
 		default:
-			errMsg := fmt.Sprintf("Object value field value type (%T) is not a byte array nor a char array", params[1])
+			errMsg := fmt.Sprintf("stringBuilderAppend: Object value field value type (%T) is not a byte array nor a char array",
+				params[1])
 			return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 		}
 	case int64: // int, long, short
@@ -505,7 +506,7 @@ func stringBuilderAppend(params []any) any {
 		str := strconv.FormatFloat(ff, 'f', -1, 64)
 		parmArray = object.JavaByteArrayFromGoString(str)
 	default:
-		errMsg := fmt.Sprintf("Parameter type (%T) is illegal", params[1])
+		errMsg := fmt.Sprintf("stringBuilderAppend: Parameter type (%T) is illegal", params[1])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -538,7 +539,7 @@ func stringBuilderAppendBoolean(params []any) any {
 		}
 		parmArray = object.JavaByteArrayFromGoString(str)
 	default:
-		errMsg := fmt.Sprintf("Parameter type (%T) is illegal", params[1])
+		errMsg := fmt.Sprintf("stringBuilderAppendBoolean: Parameter type (%T) is illegal", params[1])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -566,7 +567,7 @@ func stringBuilderAppendChar(params []any) any {
 		bb := types.JavaByte(params[1].(int64))
 		parmArray[0] = bb
 	default:
-		errMsg := fmt.Sprintf("Parameter type (%T) is illegal", params[1])
+		errMsg := fmt.Sprintf("stringBuilderAppendChar: Parameter type (%T) is illegal", params[1])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -587,7 +588,7 @@ func stringBuilderCharAt(params []any) any {
 	ix := params[1].(int64)
 	bytes := obj.FieldTable["value"].Fvalue.([]types.JavaByte)
 	if ix >= int64(len(bytes)) {
-		errMsg := fmt.Sprintf("Index value (%d) exceeds the byte array size (%d)", ix, len(bytes))
+		errMsg := fmt.Sprintf("stringBuilderCharAt: Index value (%d) exceeds the byte array size (%d)", ix, len(bytes))
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	return int64(bytes[ix])
@@ -610,11 +611,11 @@ func stringBuilderDelete(params []any) any {
 
 	// Validate start and end.
 	if start < 0 || start > initLen {
-		errMsg := fmt.Sprintf("Start value (%d) < 0 or exceeds the byte array size (%d)", start, initLen)
+		errMsg := fmt.Sprintf("stringBuilderDelete: Start value (%d) < 0 or exceeds the byte array size (%d)", start, initLen)
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 	}
 	if end < start {
-		errMsg := fmt.Sprintf("End value (%d) < Start value (%d)", start, end)
+		errMsg := fmt.Sprintf("stringBuilderDelete: End value (%d) < Start value (%d)", start, end)
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 	}
 	if end > initLen {
@@ -654,7 +655,8 @@ func stringBuilderInsert(params []any) any {
 	// Get the index value.
 	ix := params[1].(int64)
 	if ix < 0 || ix > int64(len(byteArray)) {
-		errMsg := fmt.Sprintf("Index value (%d) is negative or exceeds the byte array size (%d)", ix, len(byteArray))
+		errMsg := fmt.Sprintf("stringBuilderInsert: Index value (%d) is negative or exceeds the byte array size (%d)",
+			ix, len(byteArray))
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 	}
 
@@ -675,7 +677,7 @@ func stringBuilderInsert(params []any) any {
 				length := params[4].(int64)
 				end := start + length
 				if start < 0 || start > len64Array || end <= start || end > len64Array {
-					errMsg := fmt.Sprintf("Invalid offset (%d) or length (%d)", start, length)
+					errMsg := fmt.Sprintf("stringBuilderInsert: Invalid offset (%d) or length (%d)", start, length)
 					return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
 				}
 				for ix := start; ix < start+length; ix++ {
@@ -687,7 +689,8 @@ func stringBuilderInsert(params []any) any {
 				}
 			}
 		default:
-			errMsg := fmt.Sprintf("Object value field value type (%T) is not a byte array nor a char array", params[1])
+			errMsg := fmt.Sprintf("stringBuilderInsert: Object value field value type (%T) is not a byte array nor a char array",
+				params[1])
 			return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 		}
 	case int64: // integer, long
@@ -698,7 +701,7 @@ func stringBuilderInsert(params []any) any {
 		str := strconv.FormatFloat(ff, 'f', -1, 64)
 		parmArray = object.JavaByteArrayFromGoString(str)
 	default:
-		errMsg := fmt.Sprintf("Parameter type (%T) is illegal", params[1])
+		errMsg := fmt.Sprintf("stringBuilderInsert: Parameter type (%T) is illegal", params[1])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -729,7 +732,8 @@ func stringBuilderInsertBoolean(params []any) any {
 	// Get the index value.
 	ix := params[1].(int64)
 	if ix < 0 || ix > int64(len(byteArray)) {
-		errMsg := fmt.Sprintf("Index value (%d) is negative or exceeds the byte array size (%d)", ix, len(byteArray))
+		errMsg := fmt.Sprintf("stringBuilderInsertBoolean: Index value (%d) is negative or exceeds the byte array size (%d)",
+			ix, len(byteArray))
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 	}
 
@@ -744,7 +748,7 @@ func stringBuilderInsertBoolean(params []any) any {
 		}
 		parmArray = object.JavaByteArrayFromGoString(str)
 	default:
-		errMsg := fmt.Sprintf("Parameter type (%T) is illegal", params[1])
+		errMsg := fmt.Sprintf("stringBuilderInsertBoolean: Parameter type (%T) is illegal", params[1])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -775,7 +779,8 @@ func stringBuilderInsertChar(params []any) any {
 	// Get the index value.
 	ix := params[1].(int64)
 	if ix < 0 || ix > int64(len(byteArray)) {
-		errMsg := fmt.Sprintf("Index value (%d) is negative or exceeds the byte array size (%d)", ix, len(byteArray))
+		errMsg := fmt.Sprintf("stringBuilderInsertChar: Index value (%d) is negative or exceeds the byte array size (%d)",
+			ix, len(byteArray))
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 	}
 
@@ -784,7 +789,7 @@ func stringBuilderInsertChar(params []any) any {
 	case int64: // char
 		bb = types.JavaByte(params[2].(int64))
 	default:
-		errMsg := fmt.Sprintf("Parameter type (%T) is illegal", params[1])
+		errMsg := fmt.Sprintf("stringBuilderInsertChar: Parameter type (%T) is illegal", params[1])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -820,11 +825,11 @@ func stringBuilderReplace(params []any) any {
 
 	// Validate start and end.
 	if start < 0 || start > initLen {
-		errMsg := fmt.Sprintf("Start value (%d) < 0 or exceeds the byte array size (%d)", start, initLen)
+		errMsg := fmt.Sprintf("stringBuilderReplace: Start value (%d) < 0 or exceeds the byte array size (%d)", start, initLen)
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 	}
 	if end < start {
-		errMsg := fmt.Sprintf("End value (%d) < Start value (%d)", start, end)
+		errMsg := fmt.Sprintf("stringBuilderReplace: End value (%d) < Start value (%d)", start, end)
 		return getGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 	}
 	if end > initLen {
@@ -883,7 +888,7 @@ func stringBuilderSetCharAt(params []any) any {
 	ix := params[1].(int64)
 	ch := params[2].(int64)
 	if ix < 0 || ix > int64(len(byteArray)) {
-		errMsg := fmt.Sprintf("Index value (%d) is illegal", ix)
+		errMsg := fmt.Sprintf("stringBuilderSetCharAt: Index value (%d) is illegal", ix)
 		return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
 	}
 	byteArray[ix] = types.JavaByte(ch)
@@ -901,7 +906,7 @@ func stringBuilderSetLength(params []any) any {
 	newlen := params[1].(int64)
 	newArray := make([]types.JavaByte, newlen)
 	if newlen < 0 {
-		errMsg := fmt.Sprintf("Length value (%d) is negative", newlen)
+		errMsg := fmt.Sprintf("stringBuilderSetLength: Length value (%d) is negative", newlen)
 		return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
 	}
 	if newlen == oldlen {

--- a/src/gfunction/javaLangSystem.go
+++ b/src/gfunction/javaLangSystem.go
@@ -127,7 +127,7 @@ func Load_Lang_System() {
 func systemClinit([]interface{}) interface{} {
 	klass := classloader.MethAreaFetch("java/lang/System")
 	if klass == nil {
-		errMsg := "System<clinit>: Expected java/lang/System to be in the MethodArea, but it was not"
+		errMsg := "systemClinit: Expected java/lang/System to be in the MethodArea, but it was not"
 		trace.Error(errMsg)
 		return getGErrBlk(excNames.ClassNotLoadedException, errMsg)
 	}
@@ -145,7 +145,7 @@ func systemClinit([]interface{}) interface{} {
 // docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/System.html#arraycopy(java.lang.Object,int,java.lang.Object,int,int)
 func arrayCopy(params []interface{}) interface{} {
 	if len(params) != 5 {
-		errMsg := fmt.Sprintf("Expected 5 parameters, got %d", len(params))
+		errMsg := fmt.Sprintf("arrayCopy: Expected 5 parameters, got %d", len(params))
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -156,13 +156,13 @@ func arrayCopy(params []interface{}) interface{} {
 	length := params[4].(int64)
 
 	if object.IsNull(src) || object.IsNull(dest) {
-		errMsg := fmt.Sprintf("null src or dest")
+		errMsg := fmt.Sprintf("arrayCopy: null src or dest")
 		return getGErrBlk(excNames.NullPointerException, errMsg)
 	}
 
 	if srcPos < 0 || destPos < 0 || length < 0 {
 		errMsg := fmt.Sprintf(
-			"Negative position in: srcPose=%d, destPos=%d, or length=%d", srcPos, destPos, length)
+			"arrayCopy: Negative position in: srcPose=%d, destPos=%d, or length=%d", srcPos, destPos, length)
 		return getGErrBlk(excNames.ArrayIndexOutOfBoundsException, errMsg)
 	}
 
@@ -170,7 +170,7 @@ func arrayCopy(params []interface{}) interface{} {
 	destType := *(stringPool.GetStringPointer(dest.KlassName))
 
 	if !strings.HasPrefix(srcType, types.Array) || !strings.HasPrefix(destType, types.Array) || srcType != destType {
-		errMsg := fmt.Sprintf("java/lang/System.arraycopy: invalid src or dest array")
+		errMsg := fmt.Sprintf("arrayCopy: invalid src or dest array")
 		return getGErrBlk(excNames.ArrayStoreException, errMsg)
 	}
 
@@ -178,7 +178,7 @@ func arrayCopy(params []interface{}) interface{} {
 	destLen := object.ArrayLength(dest)
 
 	if srcPos+length > srcLen || destPos+length > destLen {
-		errMsg := fmt.Sprintf("Array position + length exceeds array size")
+		errMsg := fmt.Sprintf("arrayCopy: Array position + length exceeds array size")
 		return getGErrBlk(excNames.ArrayIndexOutOfBoundsException, errMsg)
 	}
 

--- a/src/gfunction/javaLangThread.go
+++ b/src/gfunction/javaLangThread.go
@@ -47,7 +47,7 @@ func Load_Lang_Thread() {
 func threadSleep(params []interface{}) interface{} {
 	sleepTime, ok := params[0].(int64)
 	if !ok {
-		errMsg := "Parameter must be an int64 (long)"
+		errMsg := "threadSleep: Parameter must be an int64 (long)"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
 	time.Sleep(time.Duration(sleepTime) * time.Millisecond)

--- a/src/gfunction/javaMathBigInteger.go
+++ b/src/gfunction/javaMathBigInteger.go
@@ -399,7 +399,7 @@ func getPrime(bitLength int) (*big.Int, string) {
 		// Generate a random number given the bit length.
 		zz, err := rand.Prime(rand.Reader, bitLength)
 		if err != nil {
-			errMsg := fmt.Sprintf("rand.Reader(bitLength=%d) failed, reason: %s", bitLength, err.Error())
+			errMsg := fmt.Sprintf("getPrime: rand.Reader(bitLength=%d) failed, reason: %s", bitLength, err.Error())
 			return nil, errMsg
 		}
 
@@ -440,7 +440,7 @@ func addStaticBigInteger(argName string, argValue int64) {
 func bigIntegerClinit([]interface{}) interface{} {
 	klass := classloader.MethAreaFetch(bigIntegerClassName)
 	if klass == nil {
-		errMsg := fmt.Sprintf("BigInteger<clinit>: Expected %s to be in the MethodArea, but it was not", bigIntegerClassName)
+		errMsg := fmt.Sprintf("bigIntegerClinit: Expected %s to be in the MethodArea, but it was not", bigIntegerClassName)
 		trace.Error(errMsg)
 		return getGErrBlk(excNames.ClassNotLoadedException, errMsg)
 	}
@@ -562,7 +562,7 @@ func bigIntegerInitRandom(params []interface{}) interface{} {
 	// Get a big.Int in the randge of [0, upperBound].
 	zz, err := rand.Int(rand.Reader, upperBound)
 	if err != nil {
-		errMsg := fmt.Sprintf("rand.Int(numBits=%d) failed, reason: %s", numBits, err.Error())
+		errMsg := fmt.Sprintf("bigIntegerInitRandom: rand.Int(numBits=%d) failed, reason: %s", numBits, err.Error())
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 
@@ -588,7 +588,7 @@ func bigIntegerInitString(params []interface{}) interface{} {
 	var zz = new(big.Int)
 	_, ok := zz.SetString(str, 10)
 	if !ok {
-		errMsg := fmt.Sprintf("<init> string (%s) not all numerics", str)
+		errMsg := fmt.Sprintf("bigIntegerInitString: string (%s) not all numerics", str)
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 
@@ -616,7 +616,7 @@ func bigIntegerInitStringRadix(params []interface{}) interface{} {
 	var zz = new(big.Int)
 	_, ok := zz.SetString(str, int(rdx))
 	if !ok {
-		errMsg := fmt.Sprintf("<init> string (%s) not all numerics or the radix (%d) is invalid", str, rdx)
+		errMsg := fmt.Sprintf("bigIntegerInitStringRadix: string (%s) not all numerics or the radix (%d) is invalid", str, rdx)
 		return getGErrBlk(excNames.NumberFormatException, errMsg)
 	}
 
@@ -769,7 +769,7 @@ func bigIntegerByteValueExact(params []interface{}) interface{} {
 	xx := fld.Fvalue.(*big.Int)
 	ii := xx.Int64()
 	if ii < 0 || ii > 255 {
-		errMsg := fmt.Sprintf("Value (%d) will not fit in a byte", ii)
+		errMsg := fmt.Sprintf("bigIntegerByteValueExact: Value (%d) will not fit in a byte", ii)
 		return getGErrBlk(excNames.ArithmeticException, errMsg)
 	}
 	return ii & 0xFF
@@ -799,7 +799,7 @@ func bigIntegerDivide(params []interface{}) interface{} {
 	yy := objArg.FieldTable["value"].Fvalue.(*big.Int)
 	zero := big.NewInt(int64(0))
 	if yy.Cmp(zero) <= 0 {
-		errMsg := "Divide by zero"
+		errMsg := "bigIntegerDivide: Divide by zero"
 		return getGErrBlk(excNames.ArithmeticException, errMsg)
 	}
 
@@ -830,7 +830,7 @@ func bigIntegerDivideAndRemainder(params []interface{}) interface{} {
 	yy := objArg.FieldTable["value"].Fvalue.(*big.Int)
 	zero := big.NewInt(int64(0))
 	if yy.Cmp(zero) <= 0 {
-		errMsg := "Divide by zero"
+		errMsg := "bigIntegerDivideAndRemainder: Divide by zero"
 		return getGErrBlk(excNames.ArithmeticException, errMsg)
 	}
 
@@ -1013,7 +1013,7 @@ func bigIntegerMod(params []interface{}) interface{} {
 	yy := objArg.FieldTable["value"].Fvalue.(*big.Int)
 	zero := big.NewInt(int64(0))
 	if yy.Cmp(zero) <= 0 {
-		errMsg := "BigInteger: modulus not positive"
+		errMsg := "bigIntegerMod: modulus not positive"
 		return getGErrBlk(excNames.ArithmeticException, errMsg)
 	}
 
@@ -1049,7 +1049,7 @@ func bigIntegerModInverse(params []interface{}) interface{} {
 	mm := objModulus.FieldTable["value"].Fvalue.(*big.Int)
 	zero := big.NewInt(int64(0))
 	if mm.Cmp(zero) <= 0 {
-		errMsg := "BigInteger: modulus not positive"
+		errMsg := "bigIntegerModInverse: modulus not positive"
 		return getGErrBlk(excNames.ArithmeticException, errMsg)
 	}
 
@@ -1057,7 +1057,7 @@ func bigIntegerModInverse(params []interface{}) interface{} {
 	var zz = new(big.Int)
 	ret := zz.ModInverse(xx, mm)
 	if ret == nil {
-		errMsg := "BigInteger not invertible"
+		errMsg := "bigIntegerModInverse: BigInteger not invertible"
 		return getGErrBlk(excNames.ArithmeticException, errMsg)
 	}
 
@@ -1088,7 +1088,7 @@ func bigIntegerModPow(params []interface{}) interface{} {
 	mm := objMM.FieldTable["value"].Fvalue.(*big.Int)
 	zero := big.NewInt(int64(0))
 	if mm.Cmp(zero) <= 0 {
-		errMsg := fmt.Sprintf("Modulus (%d) is negative", mm.Int64())
+		errMsg := fmt.Sprintf("bigIntegerModPow: Modulus (%d) is negative", mm.Int64())
 		return getGErrBlk(excNames.ArithmeticException, errMsg)
 	}
 
@@ -1224,7 +1224,7 @@ func bigIntegerPow(params []interface{}) interface{} {
 	xx := objBase.FieldTable["value"].Fvalue.(*big.Int)
 	pow := params[1].(int64)
 	if pow < 0 {
-		errMsg := fmt.Sprintf("Power (%d) is negative", pow)
+		errMsg := fmt.Sprintf("bigIntegerPow: Power (%d) is negative", pow)
 		return getGErrBlk(excNames.ArithmeticException, errMsg)
 	}
 	yy := big.NewInt(pow)
@@ -1256,7 +1256,7 @@ func bigIntegerRemainder(params []interface{}) interface{} {
 	yy := objArg.FieldTable["value"].Fvalue.(*big.Int)
 	zero := big.NewInt(int64(0))
 	if yy.Cmp(zero) <= 0 {
-		errMsg := "Divide by zero"
+		errMsg := "bigIntegerRemainder: Divide by zero"
 		return getGErrBlk(excNames.ArithmeticException, errMsg)
 	}
 
@@ -1315,7 +1315,7 @@ func bigIntegerSqrt(params []interface{}) interface{} {
 	xx := objBase.FieldTable["value"].Fvalue.(*big.Int)
 	zero := big.NewInt(int64(0))
 	if xx.Cmp(zero) < 0 {
-		errMsg := fmt.Sprintf("Argument (%d) is negative", xx.Int64())
+		errMsg := fmt.Sprintf("bigIntegerSqrt: Argument (%d) is negative", xx.Int64())
 		return getGErrBlk(excNames.ArithmeticException, errMsg)
 	}
 
@@ -1394,7 +1394,7 @@ func bigIntegerToStringRadix(params []interface{}) interface{} {
 	xx := objBase.FieldTable["value"].Fvalue.(*big.Int)
 	rdx := params[1].(int64)
 	if rdx < 2 || rdx > 62 {
-		errMsg := fmt.Sprintf("Invalid radix value (%d)", rdx)
+		errMsg := fmt.Sprintf("bigIntegerToStringRadix: Invalid radix value (%d)", rdx)
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 

--- a/src/gfunction/javaSecuritySecureRandom.go
+++ b/src/gfunction/javaSecuritySecureRandom.go
@@ -44,13 +44,13 @@ func Load_Security_SecureRandom() {
 	MethodSignatures["java/security/SecureRandom.generateSeed(I)[B"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  SecureRandom_GenerateSeed,
+			GFunction:  SecureRandomGenerateSeed,
 		}
 
 	MethodSignatures["java/security/SecureRandom.getAlgorithm()Ljava/lang/String;"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  SecureRandom_GetAlgorithm,
+			GFunction:  SecureRandomGetAlgorithm,
 		}
 
 	MethodSignatures["java/security/SecureRandom.getInstance(Ljava/lang/String;)Ljava/security/SecureRandom;"] =
@@ -104,25 +104,25 @@ func Load_Security_SecureRandom() {
 	MethodSignatures["java/security/SecureRandom.getSeed(I)[B"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  SecureRandom_NextBytes,
+			GFunction:  SecureRandomNextBytes,
 		}
 
 	MethodSignatures["java/security/SecureRandom.next(I)I"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  SecureRandom_Next,
+			GFunction:  SecureRandomNext,
 		}
 
 	MethodSignatures["java/security/SecureRandom.nextBytes([B)V"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  SecureRandom_NextBytes,
+			GFunction:  SecureRandomNextBytes,
 		}
 
 	MethodSignatures["java/security/SecureRandom.nextBoolean()Z"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  SecureRandom_NextBoolean,
+			GFunction:  SecureRandomNextBoolean,
 		}
 
 	MethodSignatures["java/security/SecureRandom.nextBytes([BLjava/security/SecureRandomParameters;)V"] =
@@ -134,13 +134,13 @@ func Load_Security_SecureRandom() {
 	MethodSignatures["java/security/SecureRandom.nextDouble()D"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  SecureRandom_NextFloat,
+			GFunction:  SecureRandomNextFloat,
 		}
 
 	MethodSignatures["java/security/SecureRandom.nextFloat()F"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  SecureRandom_NextFloat,
+			GFunction:  SecureRandomNextFloat,
 		}
 
 	MethodSignatures["java/security/SecureRandom.nextGaussian()D"] =
@@ -152,13 +152,13 @@ func Load_Security_SecureRandom() {
 	MethodSignatures["java/security/SecureRandom.nextInt()I"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  SecureRandom_NextInt,
+			GFunction:  SecureRandomNextInt,
 		}
 
 	MethodSignatures["java/security/SecureRandom.nextLong()J"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  SecureRandom_NextInt,
+			GFunction:  SecureRandomNextInt,
 		}
 
 	MethodSignatures["java/security/SecureRandom.reseed()V"] =
@@ -188,7 +188,7 @@ func Load_Security_SecureRandom() {
 	MethodSignatures["java/security/SecureRandom.toString()Ljava/lang/String;"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  SecureRandom_ToString,
+			GFunction:  SecureRandomToString,
 		}
 
 }
@@ -213,58 +213,58 @@ func SecureRandom_Init(params []interface{}) interface{} {
 
 }
 
-// SecureRandom_NextBytes generates a specified number of random bytes
-func SecureRandom_NextBytes(params []interface{}) interface{} {
+// SecureRandomNextBytes generates a specified number of random bytes
+func SecureRandomNextBytes(params []interface{}) interface{} {
 	if len(params) != 2 {
-		errMsg := fmt.Sprintf("Expected 2 parameters (SecureRandom object, int64 size), got %d", len(params))
+		errMsg := fmt.Sprintf("SecureRandomNextBytes: Expected 2 parameters (SecureRandom object, int64 size), got %d", len(params))
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
 	secureRandomObj, ok := params[0].(*object.Object)
 	if !ok {
-		return getGErrBlk(excNames.IllegalArgumentException, "First parameter must be a SecureRandom object")
+		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNextBytes: First parameter must be a SecureRandom object")
 	}
 
 	if secureRandomObj == nil {
-		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandom object cannot be nil")
+		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNextBytes: SecureRandom object cannot be nil")
 	}
 
 	size, ok := params[1].(int64)
 	if !ok {
-		return getGErrBlk(excNames.IllegalArgumentException, "Second parameter must be an int64")
+		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNextBytes: Second parameter must be an int64")
 	}
 
 	// Generate random bytes
 	bytes := make([]byte, size)
 	_, err := rand.Read(bytes)
 	if err != nil {
-		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("Failed to generate random bytes: %v", err))
+		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("SecureRandomNextBytes: Failed to generate random bytes: %v", err))
 	}
 
 	result := object.JavaByteArrayFromGoByteArray(bytes)
 	return result
 }
 
-// SecureRandom_Next generates an integer containing the user-specified number of pseudo-random bits
+// SecureRandomNext generates an integer containing the user-specified number of pseudo-random bits
 // (right justified, with leading zeros).
-func SecureRandom_Next(params []interface{}) interface{} {
+func SecureRandomNext(params []interface{}) interface{} {
 	if len(params) != 2 {
-		errMsg := fmt.Sprintf("SecureRandom_Next: Expected 2 parameters (SecureRandom object, bit count), observed %d", len(params))
+		errMsg := fmt.Sprintf("SecureRandomNext: Expected 2 parameters (SecureRandom object, bit count), observed %d", len(params))
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
 	secureRandomObj, ok := params[0].(*object.Object)
 	if !ok {
-		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandom_Next: Parameter must be a SecureRandom object")
+		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNext: Parameter must be a SecureRandom object")
 	}
 
 	if secureRandomObj == nil {
-		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandom_Next: SecureRandom object cannot be nil")
+		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNext: SecureRandom object cannot be nil")
 	}
 
 	intArg := params[1].(int64)
 	if intArg < 0 || intArg > 32 {
-		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandom_Next: bit count must be >= 0 and <=32 ")
+		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNext: bit count must be >= 0 and <=32 ")
 	}
 
 	// Generate random int64
@@ -272,7 +272,7 @@ func SecureRandom_Next(params []interface{}) interface{} {
 	randBytes := make([]byte, 8) // int64 is 8 bytes
 	_, err := rand.Read(randBytes)
 	if err != nil {
-		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("Failed to generate random int64: %v", err))
+		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("SecureRandomNext: Failed to generate random int64: %v", err))
 	}
 
 	// Convert bytes to int64
@@ -287,20 +287,20 @@ func SecureRandom_Next(params []interface{}) interface{} {
 	return result
 }
 
-// SecureRandom_NextInt generates a random int64
-func SecureRandom_NextInt(params []interface{}) interface{} {
+// SecureRandomNextInt generates a random int64
+func SecureRandomNextInt(params []interface{}) interface{} {
 	if len(params) != 1 {
-		errMsg := fmt.Sprintf("SecureRandom_NextInt: Expected 1 parameter (SecureRandom object), got %d", len(params))
+		errMsg := fmt.Sprintf("SecureRandomNextInt: Expected 1 parameter (SecureRandom object), got %d", len(params))
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
 	secureRandomObj, ok := params[0].(*object.Object)
 	if !ok {
-		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandom_NextInt: Parameter must be a SecureRandom object")
+		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNextInt: Parameter must be a SecureRandom object")
 	}
 
 	if secureRandomObj == nil {
-		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandom_NextInt: SecureRandom object cannot be nil")
+		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNextInt: SecureRandom object cannot be nil")
 	}
 
 	// Generate random int64
@@ -308,7 +308,7 @@ func SecureRandom_NextInt(params []interface{}) interface{} {
 	randBytes := make([]byte, 8) // int64 is 8 bytes
 	_, err := rand.Read(randBytes)
 	if err != nil {
-		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("SecureRandom_NextInt: Failed to generate random int64: %v", err))
+		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("SecureRandomNextInt: Failed to generate random int64: %v", err))
 	}
 
 	// Convert bytes to int64
@@ -319,27 +319,27 @@ func SecureRandom_NextInt(params []interface{}) interface{} {
 	return result
 }
 
-// SecureRandom_NextFloat generates a random float64
-func SecureRandom_NextFloat(params []interface{}) interface{} {
+// SecureRandomNextFloat generates a random float64
+func SecureRandomNextFloat(params []interface{}) interface{} {
 	if len(params) != 1 {
-		errMsg := fmt.Sprintf("Expected 1 parameter (SecureRandom object), got %d", len(params))
+		errMsg := fmt.Sprintf("SecureRandomNextFloat: Expected 1 parameter (SecureRandom object), got %d", len(params))
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
 	secureRandomObj, ok := params[0].(*object.Object)
 	if !ok {
-		return getGErrBlk(excNames.IllegalArgumentException, "Parameter must be a SecureRandom object")
+		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNextFloat: Parameter must be a SecureRandom object")
 	}
 
 	if secureRandomObj == nil {
-		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandom object cannot be nil")
+		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNextFloat: SecureRandom object cannot be nil")
 	}
 
 	// Generate random float64 in the range [0, 1)
 	randBytes := make([]byte, 8) // float64 is 8 bytes
 	_, err := rand.Read(randBytes)
 	if err != nil {
-		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("Failed to generate random float64: %v", err))
+		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("SecureRandomNextFloat: Failed to generate random float64: %v", err))
 	}
 
 	// Convert bytes to a value in [0, 1)
@@ -352,31 +352,31 @@ func SecureRandom_NextFloat(params []interface{}) interface{} {
 	return result
 }
 
-// SecureRandom_GenerateSeed generates a new seed as a slice of JavaByte
-func SecureRandom_GenerateSeed(params []interface{}) interface{} {
+// SecureRandomGenerateSeed generates a new seed as a slice of JavaByte
+func SecureRandomGenerateSeed(params []interface{}) interface{} {
 	if len(params) != 2 {
-		errMsg := fmt.Sprintf("Expected 2 parameters (SecureRandom object, int64 numBytes), got %d", len(params))
+		errMsg := fmt.Sprintf("SecureRandomGenerateSeed: Expected 2 parameters (SecureRandom object, int64 numBytes), got %d", len(params))
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
 	secureRandomObj, ok := params[0].(*object.Object)
 	if !ok {
-		return getGErrBlk(excNames.IllegalArgumentException, "First parameter must be a SecureRandom object")
+		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomGenerateSeed: First parameter must be a SecureRandom object")
 	}
 
 	if secureRandomObj == nil {
-		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandom object cannot be nil")
+		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomGenerateSeed: SecureRandom object cannot be nil")
 	}
 
 	numBytes, ok := params[1].(int64)
 	if !ok || numBytes <= 0 {
-		return getGErrBlk(excNames.IllegalArgumentException, "Second parameter must be a positive int64")
+		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomGenerateSeed: Second parameter must be a positive int64")
 	}
 
 	bytes := make([]byte, numBytes)
 	_, err := rand.Read(bytes)
 	if err != nil {
-		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("Failed to generate seed: %v", err))
+		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("SecureRandomGenerateSeed: Failed to generate seed: %v", err))
 	}
 
 	result := object.JavaByteArrayFromGoByteArray(bytes)
@@ -384,20 +384,20 @@ func SecureRandom_GenerateSeed(params []interface{}) interface{} {
 }
 
 // Get PRNG algorithm. This is simply whatever the O/S provides. Reference: Go package crypto/rand.
-func SecureRandom_GetAlgorithm(params []interface{}) interface{} {
+func SecureRandomGetAlgorithm(params []interface{}) interface{} {
 	return object.StringObjectFromGoString(runtime.GOOS)
 }
 
 // toString - return the class name string.
-func SecureRandom_ToString(params []interface{}) interface{} {
+func SecureRandomToString(params []interface{}) interface{} {
 	return object.StringObjectFromGoString(secureRandomClassName)
 }
 
-func SecureRandom_NextBoolean(params []interface{}) interface{} {
+func SecureRandomNextBoolean(params []interface{}) interface{} {
 	randByte := make([]byte, 1) // float64 is 8 bytes
 	_, err := rand.Read(randByte)
 	if err != nil {
-		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("SecureRandom_NextBoolean: Failed to generate random byte: %v", err))
+		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("SecureRandomNextBoolean: Failed to generate random byte: %v", err))
 	}
 	if randByte[0]&0x01 == 0x01 {
 		return types.JavaBoolTrue

--- a/src/gfunction/javaUtilArrays.go
+++ b/src/gfunction/javaUtilArrays.go
@@ -24,12 +24,12 @@ func Load_Util_Arrays() {
 // Copy the specified array of pointers, truncating or padding with nulls so the copy has the specified length.
 func copyOfObjectPointers(params []interface{}) interface{} {
 	if len(params) < 2 {
-		return getGErrBlk(excNames.IllegalArgumentException, "copyOf: too few arguments")
+		return getGErrBlk(excNames.IllegalArgumentException, "copyOfObjectPointers: too few arguments")
 	}
 
 	// Check for a null array.
 	if params[0] == nil {
-		return getGErrBlk(excNames.NullPointerException, "copyOf: null array argument")
+		return getGErrBlk(excNames.NullPointerException, "copyOfObjectPointers: null array argument")
 	}
 
 	// Extract the array and the new length.
@@ -38,7 +38,7 @@ func copyOfObjectPointers(params []interface{}) interface{} {
 
 	// Check for a negative length.
 	if newLen < 0 {
-		return getGErrBlk(excNames.NegativeArraySizeException, "copyOf: negative array length")
+		return getGErrBlk(excNames.NegativeArraySizeException, "copyOfObjectPointers: negative array length")
 	}
 
 	// Get the array length.

--- a/src/gfunction/javaUtilArrays_test.go
+++ b/src/gfunction/javaUtilArrays_test.go
@@ -16,14 +16,14 @@ import (
 
 func TestCopyOfObjectPointers_TooFewArguments(t *testing.T) {
 	result := *(copyOfObjectPointers([]interface{}{}).(*GErrBlk))
-	if result.ExceptionType != excNames.IllegalArgumentException || result.ErrMsg != "copyOf: too few arguments" {
+	if result.ExceptionType != excNames.IllegalArgumentException || result.ErrMsg != "copyOfObjectPointers: too few arguments" {
 		t.Errorf("Expected IllegalArgumentException for too few arguments")
 	}
 }
 
 func TestCopyOfObjectPointers_NullArray(t *testing.T) {
 	result := *(copyOfObjectPointers([]interface{}{nil, int64(5)}).(*GErrBlk))
-	if result.ExceptionType != excNames.NullPointerException || result.ErrMsg != "copyOf: null array argument" {
+	if result.ExceptionType != excNames.NullPointerException || result.ErrMsg != "copyOfObjectPointers: null array argument" {
 		t.Errorf("Expected NullPointerException for null array argument")
 	}
 }
@@ -31,7 +31,7 @@ func TestCopyOfObjectPointers_NullArray(t *testing.T) {
 func TestCopyOfObjectPointers_NegativeLength(t *testing.T) {
 	obj := &object.Object{}
 	result := *(copyOfObjectPointers([]interface{}{obj, int64(-1)}).(*GErrBlk))
-	if result.ExceptionType != excNames.NegativeArraySizeException || result.ErrMsg != "copyOf: negative array length" {
+	if result.ExceptionType != excNames.NegativeArraySizeException || result.ErrMsg != "copyOfObjectPointers: negative array length" {
 		// if result != getGErrBlk(excNames.NegativeArraySizeException, "copyOf: negative array length") {
 		t.Errorf("Expected NegativeArraySizeException for negative array length")
 	}

--- a/src/gfunction/javaUtilHexFormat.go
+++ b/src/gfunction/javaUtilHexFormat.go
@@ -461,16 +461,16 @@ func hfFormatHexFromBytes(params []interface{}) interface{} {
 	if len(params) > 2 {
 		fromIndex = int(params[2].(int64))
 		if fromIndex < 0 || fromIndex > len(bytes) {
-			errMsg := fmt.Sprintf("from index out of range: %d", fromIndex)
+			errMsg := fmt.Sprintf("hfFormatHexFromBytes: from index out of range: %d", fromIndex)
 			return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
 		}
 		toIndex = int(params[3].(int64))
 		if toIndex < 0 || toIndex > len(bytes) {
-			errMsg := fmt.Sprintf("to index out of range: %d", fromIndex)
+			errMsg := fmt.Sprintf("hfFormatHexFromBytes: to index out of range: %d", fromIndex)
 			return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
 		}
 		if toIndex <= fromIndex {
-			errMsg := fmt.Sprintf("to index <= from index: %d", fromIndex)
+			errMsg := fmt.Sprintf("hfFormatHexFromBytes: to index <= from index: %d", fromIndex)
 			return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
 		}
 	} else {
@@ -499,7 +499,7 @@ func hfFromHexDigit(params []interface{}) interface{} {
 	if arg < 103 && arg > 96 { // range: 'a' to 'f'
 		return arg - 87 // arg + 10 - 'a'
 	}
-	errMsg := fmt.Sprintf("Out of range: %d", arg)
+	errMsg := fmt.Sprintf("hfFromHexDigit: Out of range: %d", arg)
 	return getGErrBlk(excNames.NumberFormatException, errMsg)
 
 }

--- a/src/gfunction/javaUtilRandom.go
+++ b/src/gfunction/javaUtilRandom.go
@@ -257,7 +257,7 @@ func randomNextIntBound(params []interface{}) interface{} {
 	r := GetStructFromRandomObject(obj)
 	bound := params[1].(int64)
 	if bound < 1 {
-		errMsg := fmt.Sprintf("Bound must be positive, observed: %d", bound)
+		errMsg := fmt.Sprintf("randomNextIntBound: Bound must be positive, observed: %d", bound)
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	output := r.rand.Int63n(bound)

--- a/src/gfunction/jdkInternalMiscUnsafe.go
+++ b/src/gfunction/jdkInternalMiscUnsafe.go
@@ -81,7 +81,7 @@ var classUnsafeName = "jdk/internal/misc/Unsafe"
 func arrayBaseOffset(params []interface{}) interface{} {
 	p := params[0]
 	if p == nil || p == object.Null {
-		errMsg := "Object is a null pointer"
+		errMsg := "arrayBaseOffset: Object is a null pointer"
 		return getGErrBlk(excNames.NullPointerException, errMsg)
 	}
 	return int64(0) // this should work...


### PR DESCRIPTION
JACOBIN-649 modified: javaIoPrintStream.go (Object and String consolidations)

JACOBIN-538  error message clean up (mostly, add prefix = name of function where diagnosis occurred):
* javaIoConsole.go
* javaIoFile.go
* javaIoFileInputStream.go
* javaIoFileOutputStream.go
* javaIoFileReader.go
* javaIoFilterInputStream.go
* javaIoFileInputStreamReader.go
* javaIoFileOutputStreamWriter.go
* javaIoRandomAccessFile.go
* javaLangByte.go
* javaLangClass.go
* javaLangDouble.go
* javaLangInteger.go
* javaLangLong.go
* javaLangMath.go
* javaLangString.go
* javaLangStringBuffer.go
* javaLangStringBuilder.go
* javaLangSystem.go
* javaLangThread.go
* javaLangMathBigInteger.go
* javaSecuritySecureRandom.go
* javaUtilArrays.go
* javaUtilArrays_test.go
* javaUtilHexFormat.go
* javaUtilRandom.go
* jdkInternalMiscUnsafe.go

