### PR TITLE
JACOBIN-650 correctly format character variables with %c

### DIFF
--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -1198,8 +1198,8 @@ func StringFormatter(params []interface{}) interface{} {
 				}
 				valuesOut = append(valuesOut, zz)
 			case types.Char:
-				cc := fmt.Sprint(fld.Fvalue.(int64))
-				valuesOut = append(valuesOut, cc)
+				rooney := rune(fld.Fvalue.(int64))
+				valuesOut = append(valuesOut, rooney)
 			case types.Double:
 				valuesOut = append(valuesOut, fld.Fvalue.(float64))
 			case types.Float:


### PR DESCRIPTION
modified:   gfunction/javaLangString.go

See https://jacobin.myjetbrains.com/youtrack/issue/JACOBIN-650/javaLangString.go-StringFormatter-muffs-line-1200-case-types.Char