### PR TITLE
JACOBIN-654 name the G thing being trapped

### DIFF
--- a/src/gfunction/gfunctionExec.go
+++ b/src/gfunction/gfunctionExec.go
@@ -127,7 +127,7 @@ func RunGfunction(mt classloader.MTentry, fs *list.List,
 		} else {
 			threadName = fmt.Sprintf("%d", f.Thread)
 		}
-		errMsg := fmt.Sprintf("%s in thread: %s", errBlk.ErrMsg, threadName)
+		errMsg := fmt.Sprintf("%s in thread: %s, G-function: %s", errBlk.ErrMsg, threadName, fullMethName)
 		status := exceptions.ThrowEx(errBlk.ExceptionType, errMsg, f)
 		if status != exceptions.Caught {
 			return errors.New(errMsg + " " + errBlk.ErrMsg) // applies only if in test


### PR DESCRIPTION
The caller's FQN is important for knowing the context of the call to a G-function.
Upon return to RunGfunction, the FQN of the attempted G-function needs to be added to the error text.
Then, we know which function made the call and which class or function was trapped because of the call.

This is a minor change to gfunctionExec.go RunGfunction.