### PR TITLE
JACOBIN-656 IsFilePartOfJDK should call ConvertInternalClassNameToUserFormat

### DIFF
--- a/src/statics/statics.go
+++ b/src/statics/statics.go
@@ -12,11 +12,15 @@ import (
 	"jacobin/excNames"
 	"jacobin/globals"
 	"jacobin/types"
+	"jacobin/util"
 	"os"
 	"runtime/debug"
 	"strings"
 	"sync"
+	"testing"
 )
+
+const flagTraceStatics = false
 
 // Statics is a fast-lookup map of static variables and functions. The int64 value
 // contains the index into the statics array where the entry is stored.
@@ -59,6 +63,11 @@ func AddStatic(name string, s Static) error {
 	staticsMutex.RLock()
 	Statics[name] = s
 	staticsMutex.RUnlock()
+	if flagTraceStatics && util.IsFilePartOfJDK(&name) {
+		if !testing.Testing() {
+			_, _ = fmt.Fprintf(os.Stderr, ">>>trace>>>AddStatic: Adding static entry with name=%s, value=%v\n", name, s.Value)
+		}
+	}
 	return nil
 }
 

--- a/src/util/filenameUtils.go
+++ b/src/util/filenameUtils.go
@@ -53,9 +53,11 @@ func ConvertToPlatformPathSeparators(pathIn string) string {
 // IsFilePartOfJDK accepts a filename and returns true if the filename
 // is part of the JDK distribution
 func IsFilePartOfJDK(filename *string) bool {
-	return strings.HasPrefix(*filename, "java") ||
-		strings.HasPrefix(*filename, "jdk") ||
-		strings.HasPrefix(*filename, "sun")
+	str := ConvertInternalClassNameToUserFormat(*filename)
+	return strings.HasPrefix(str, "java") ||
+		strings.HasPrefix(str, "jdk") ||
+		strings.HasPrefix(str, "com.sun") ||
+		strings.HasPrefix(str, "sun")
 }
 
 // SearchDirByFileExtension searches a directory and its subdirectories for


### PR DESCRIPTION
	modified:   statics/statics.go - call IsFilePartOfJDK
	modified:   util/filenameUtils.go - call ConvertInternalClassNameToUserFormat to normalise class name
