### PR TITLE
JACOBIN-660 SecureRandom and accompaniments

### DIFF
--- a/src/gfunction/javaSecuritySecureRandom.go
+++ b/src/gfunction/javaSecuritySecureRandom.go
@@ -7,12 +7,12 @@
 package gfunction
 
 import (
-	"crypto/rand"
 	"fmt"
 	"jacobin/excNames"
 	"jacobin/object"
 	"jacobin/types"
-	"runtime"
+	"math/rand"
+	"time"
 )
 
 func Load_Security_SecureRandom() {
@@ -26,19 +26,19 @@ func Load_Security_SecureRandom() {
 	MethodSignatures["java/security/SecureRandom.<init>()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  SecureRandom_Init,
+			GFunction:  SecureRandomInit,
 		}
 
 	MethodSignatures["java/security/SecureRandom.<init>([B)V"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  SecureRandom_Init,
+			GFunction:  SecureRandomInit,
 		}
 
 	MethodSignatures["java/security/SecureRandom.<init>(Ljava/security/SecureRandomSpi;Ljava/security/Provider;)V"] =
 		GMeth{
 			ParamSlots: 2,
-			GFunction:  SecureRandom_Init,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/security/SecureRandom.generateSeed(I)[B"] =
@@ -56,37 +56,37 @@ func Load_Security_SecureRandom() {
 	MethodSignatures["java/security/SecureRandom.getInstance(Ljava/lang/String;)Ljava/security/SecureRandom;"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  SecureRandom_Init,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/security/SecureRandom.getInstance(Ljava/lang/String;Ljava/lang/String;)Ljava/security/SecureRandom;"] =
 		GMeth{
 			ParamSlots: 2,
-			GFunction:  SecureRandom_Init,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/security/SecureRandom.getInstance(Ljava/lang/String;Ljava/security/SecureRandomParameters;)Ljava/security/SecureRandom;"] =
 		GMeth{
 			ParamSlots: 2,
-			GFunction:  SecureRandom_Init,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/security/SecureRandom.getInstance(Ljava/lang/String;Ljava/security/SecureRandomParameters;Ljava/lang/String;)Ljava/security/SecureRandom;"] =
 		GMeth{
 			ParamSlots: 3,
-			GFunction:  SecureRandom_Init,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/security/SecureRandom.getInstance(Ljava/lang/String;Ljava/security/SecureRandomParameters;Ljava/security/Provider;)Ljava/security/SecureRandom;"] =
 		GMeth{
 			ParamSlots: 3,
-			GFunction:  SecureRandom_Init,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/security/SecureRandom.getInstanceStrong()Ljava/security/SecureRandom;"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  SecureRandom_Init,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/security/SecureRandom.getParameters()Ljava/security/SecureRandomParameters;"] =
@@ -104,13 +104,13 @@ func Load_Security_SecureRandom() {
 	MethodSignatures["java/security/SecureRandom.getSeed(I)[B"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  SecureRandomNextBytes,
+			GFunction:  SecureRandomGetSeed,
 		}
 
 	MethodSignatures["java/security/SecureRandom.next(I)I"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  SecureRandomNext,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/security/SecureRandom.nextBytes([B)V"] =
@@ -164,25 +164,25 @@ func Load_Security_SecureRandom() {
 	MethodSignatures["java/security/SecureRandom.reseed()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  justReturn,
+			GFunction:  SecureRandomReseed,
 		}
 
 	MethodSignatures["java/security/SecureRandom.reseed(Ljava/security/SecureRandomParameters;)V"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  justReturn,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/security/SecureRandom.setSeed([B)V"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  justReturn,
+			GFunction:  SecureRandomSetSeed,
 		}
 
 	MethodSignatures["java/security/SecureRandom.setSeed(J)V"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  justReturn,
+			GFunction:  SecureRandomSetSeed,
 		}
 
 	MethodSignatures["java/security/SecureRandom.toString()Ljava/lang/String;"] =
@@ -193,24 +193,136 @@ func Load_Security_SecureRandom() {
 
 }
 
-var secureRandomClassName = "java/security/SecureRandom"
+var secureRandomClassName = "java.security.SecureRandom"
 
-// SecureRandom.<init> or SecureRandom.getInstance() with a dummy seed
-// "java/security/SecureRandom.<init>()V"
-func SecureRandom_Init(params []interface{}) interface{} {
+// Return a byte array holding a generated seed of the specified byte size (count).
+func genSeed(count int64) []byte {
+	seed := time.Now().UnixNano()
+	byteArray := types.Int64ToBytesBE(seed)
+	if count < 0 {
+		count = 0
+	}
+	return byteArray[:count]
+}
 
-	// Create dummy seed.
-	dummySeed := []byte{0}
+// Re-seed and update rng of a SecureRandom object with the specified new seed expressed as an int64.
+func reSeedObject(obj *object.Object, newSeed int64) {
 
-	// Create SecureRandom object with dummy seed value.
-	obj := object.MakeEmptyObjectWithClassName(&secureRandomClassName)
+	// New random number generator based on the specified seed.
+	rng := rand.New(rand.NewSource(newSeed))
+
+	// Update the seed field.
 	obj.FieldTable["seed"] = object.Field{
-		Ftype:  types.ByteArray,
-		Fvalue: dummySeed,
+		Ftype:  types.Int,
+		Fvalue: newSeed,
 	}
 
+	// Update the rng field.
+	obj.FieldTable["rng"] = object.Field{
+		Ftype:  types.RNG,
+		Fvalue: rng,
+	}
+
+}
+
+// SecureRandomInit - instantiate a SecureRandom object.
+func SecureRandomInit(params []interface{}) interface{} {
+	var seed int64
+	switch len(params) {
+	case 1: // no parameters furnished - <init>()
+		// Create default seed.
+		seed = time.Now().UnixNano()
+	case 2: // seed byte array was furnished - <init>([B)
+		fld, ok := params[1].(*object.Object).FieldTable["value"]
+		if !ok {
+			errMsg := "SecureRandomInit: in byte array field \"value\" missing"
+			return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+		}
+		var byteArray []byte
+		switch fld.Fvalue.(type) {
+		case []byte:
+			byteArray = fld.Fvalue.([]byte)
+		case []types.JavaByte:
+			byteArray = object.GoByteArrayFromJavaByteArray(fld.Fvalue.([]types.JavaByte))
+		default:
+			errMsg := fmt.Sprintf("SecureRandomInit: unrecognized type for field \"value\", observed: %T", fld.Fvalue)
+			return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+		}
+		seed = types.BytesToInt64BE(byteArray)
+	default:
+		errMsg := fmt.Sprintf("SecureRandomInit: Number of parameters (%d) is not correct", len(params))
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Create SecureRandom object with default seed value.
+	obj := object.MakeEmptyObjectWithClassName(&secureRandomClassName)
+	reSeedObject(obj, seed)
+
+	// Return SecureRandom object to caller.
 	return obj
 
+}
+
+// Re-seed this SecureRandom object.
+func SecureRandomReseed(params []interface{}) interface{} {
+
+	// Validate object.
+	_, ok := params[0].(*object.Object).FieldTable["rng"].Fvalue.([]byte)
+	if !ok {
+		errMsg := "SecureRandomInit: field rng missing"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Re-seed object.
+	reSeedObject(params[0].(*object.Object), time.Now().UnixNano())
+	return nil
+}
+
+// Set the specified seed in this SecureRandom object.
+func SecureRandomSetSeed(params []interface{}) interface{} {
+
+	// Validate object.
+	_, ok := params[0].(*object.Object).FieldTable["rng"].Fvalue.(*rand.Rand)
+	if !ok {
+		errMsg := "SecureRandomInit: field rng missing"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Validate seed parameter.
+	switch params[1].(type) {
+	case int64:
+		reSeedObject(params[0].(*object.Object), params[1].(int64))
+		return nil
+	case *object.Object:
+	default:
+		errMsg := fmt.Sprintf("SecureRandomSetSeed: seed parameter must be int64 or an object, observed: %T", params[1])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Get seed field.
+	fld, ok := params[1].(*object.Object).FieldTable["value"]
+	if !ok {
+		errMsg := "SecureRandomSetSeed: parameter field \"value\" missing"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Use seed to re-seed the object.
+	switch fld.Fvalue.(type) {
+	case []byte:
+		ii := types.BytesToInt64BE(fld.Fvalue.([]byte))
+		reSeedObject(params[0].(*object.Object), ii)
+	case []types.JavaByte:
+		bb := object.GoByteArrayFromJavaByteArray(fld.Fvalue.([]types.JavaByte))
+		ii := types.BytesToInt64BE(bb)
+		reSeedObject(params[0].(*object.Object), ii)
+	case int64:
+		reSeedObject(params[0].(*object.Object), fld.Fvalue.(int64))
+	default:
+		errMsg := fmt.Sprintf("SecureRandomSetSeed: unrecognized type for field \"value\", observed: %T", fld.Fvalue)
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	return nil
 }
 
 // SecureRandomNextBytes generates a specified number of random bytes
@@ -224,66 +336,34 @@ func SecureRandomNextBytes(params []interface{}) interface{} {
 	if !ok {
 		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNextBytes: First parameter must be a SecureRandom object")
 	}
-
-	if secureRandomObj == nil {
-		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNextBytes: SecureRandom object cannot be nil")
+	rng, ok := secureRandomObj.FieldTable["rng"].Fvalue.(*rand.Rand)
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNextBytes: SecureRandom object missing \"rng\" field")
 	}
 
-	size, ok := params[1].(int64)
+	baObject, ok := params[1].(*object.Object)
 	if !ok {
-		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNextBytes: Second parameter must be an int64")
+		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNextBytes: Second parameter must be a byte array")
 	}
 
 	// Generate random bytes
-	bytes := make([]byte, size)
-	_, err := rand.Read(bytes)
-	if err != nil {
-		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("SecureRandomNextBytes: Failed to generate random bytes: %v", err))
-	}
-
-	result := object.JavaByteArrayFromGoByteArray(bytes)
-	return result
-}
-
-// SecureRandomNext generates an integer containing the user-specified number of pseudo-random bits
-// (right justified, with leading zeros).
-func SecureRandomNext(params []interface{}) interface{} {
-	if len(params) != 2 {
-		errMsg := fmt.Sprintf("SecureRandomNext: Expected 2 parameters (SecureRandom object, bit count), observed %d", len(params))
+	fld := baObject.FieldTable["value"]
+	var byteArray []byte
+	switch fld.Fvalue.(type) {
+	case []byte:
+		byteArray = fld.Fvalue.([]byte)
+	case []types.JavaByte:
+		byteArray = object.GoByteArrayFromJavaByteArray(fld.Fvalue.([]types.JavaByte))
+	default:
+		errMsg := fmt.Sprintf("SecureRandomNextBytes: unrecognized type for field \"value\", observed: %T", fld.Fvalue)
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
-
-	secureRandomObj, ok := params[0].(*object.Object)
-	if !ok {
-		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNext: Parameter must be a SecureRandom object")
-	}
-
-	if secureRandomObj == nil {
-		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNext: SecureRandom object cannot be nil")
-	}
-
-	intArg := params[1].(int64)
-	if intArg < 0 || intArg > 32 {
-		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNext: bit count must be >= 0 and <=32 ")
-	}
-
-	// Generate random int64
-	var result int64
-	randBytes := make([]byte, 8) // int64 is 8 bytes
-	_, err := rand.Read(randBytes)
+	_, err := rng.Read(byteArray)
 	if err != nil {
-		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("SecureRandomNext: Failed to generate random int64: %v", err))
+		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("SecureRandomNextBytes: rng.Read(byteArray), err: %v", err))
 	}
 
-	// Convert bytes to int64
-	for i := 0; i < 8; i++ {
-		result = (result << 8) | int64(randBytes[i])
-	}
-
-	// Mask in only the bits requested.
-	mask := 2 ^ intArg
-	result &= mask
-
+	result := object.JavaByteArrayFromGoByteArray(byteArray)
 	return result
 }
 
@@ -299,21 +379,22 @@ func SecureRandomNextInt(params []interface{}) interface{} {
 		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNextInt: Parameter must be a SecureRandom object")
 	}
 
-	if secureRandomObj == nil {
-		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNextInt: SecureRandom object cannot be nil")
+	rng, ok := secureRandomObj.FieldTable["rng"].Fvalue.(*rand.Rand)
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNextNextInt: SecureRandom object missing \"rng\" field")
 	}
 
 	// Generate random int64
 	var result int64
-	randBytes := make([]byte, 8) // int64 is 8 bytes
-	_, err := rand.Read(randBytes)
+	byteArray := make([]byte, 8) // int64 is 8 bytes
+	_, err := rng.Read(byteArray)
 	if err != nil {
 		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("SecureRandomNextInt: Failed to generate random int64: %v", err))
 	}
 
 	// Convert bytes to int64
 	for i := 0; i < 8; i++ {
-		result = (result << 8) | int64(randBytes[i])
+		result = (result << 8) | int64(byteArray[i])
 	}
 
 	return result
@@ -331,21 +412,22 @@ func SecureRandomNextFloat(params []interface{}) interface{} {
 		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNextFloat: Parameter must be a SecureRandom object")
 	}
 
-	if secureRandomObj == nil {
-		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNextFloat: SecureRandom object cannot be nil")
+	rng, ok := secureRandomObj.FieldTable["rng"].Fvalue.(*rand.Rand)
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomNextFloat: SecureRandom object missing \"rng\" field")
 	}
 
 	// Generate random float64 in the range [0, 1)
-	randBytes := make([]byte, 8) // float64 is 8 bytes
-	_, err := rand.Read(randBytes)
+	byteArray := make([]byte, 8) // float64 is 8 bytes
+	_, err := rng.Read(byteArray)
 	if err != nil {
-		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("SecureRandomNextFloat: Failed to generate random float64: %v", err))
+		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("SecureRandomNextFloat: rng.Read(byteArray) failed, err: %v", err))
 	}
 
 	// Convert bytes to a value in [0, 1)
 	var result float64
 	for i := 0; i < 8; i++ {
-		result = result*256 + float64(randBytes[i])
+		result = result*256 + float64(byteArray[i])
 	}
 	result /= 1 << 64
 
@@ -354,53 +436,76 @@ func SecureRandomNextFloat(params []interface{}) interface{} {
 
 // SecureRandomGenerateSeed generates a new seed as a slice of JavaByte
 func SecureRandomGenerateSeed(params []interface{}) interface{} {
+
+	// Validate parameters and set up rng.
 	if len(params) != 2 {
 		errMsg := fmt.Sprintf("SecureRandomGenerateSeed: Expected 2 parameters (SecureRandom object, int64 numBytes), got %d", len(params))
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
-
 	secureRandomObj, ok := params[0].(*object.Object)
 	if !ok {
 		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomGenerateSeed: First parameter must be a SecureRandom object")
 	}
-
-	if secureRandomObj == nil {
-		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomGenerateSeed: SecureRandom object cannot be nil")
+	rng, ok := secureRandomObj.FieldTable["rng"].Fvalue.(*rand.Rand)
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomGenerateSeed: SecureRandom object missing \"rng\" field")
 	}
 
+	// Get seed byte array size.
 	numBytes, ok := params[1].(int64)
 	if !ok || numBytes <= 0 {
 		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomGenerateSeed: Second parameter must be a positive int64")
 	}
 
-	bytes := make([]byte, numBytes)
-	_, err := rand.Read(bytes)
+	// Generate output byte array.
+	byteArray := genSeed(numBytes)
+	_, err := rng.Read(byteArray)
 	if err != nil {
-		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("SecureRandomGenerateSeed: Failed to generate seed: %v", err))
+		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("SecureRandomGenerateSeed: rng.Read(byteArray) failed, err: %v", err))
 	}
 
-	result := object.JavaByteArrayFromGoByteArray(bytes)
+	classStr := "[B"
+	result := object.MakePrimitiveObject(classStr, types.ByteArray, byteArray)
 	return result
 }
 
 // Get PRNG algorithm. This is simply whatever the O/S provides. Reference: Go package crypto/rand.
 func SecureRandomGetAlgorithm(params []interface{}) interface{} {
-	return object.StringObjectFromGoString(runtime.GOOS)
+	return object.StringObjectFromGoString("NativePRNG")
 }
 
 // toString - return the class name string.
 func SecureRandomToString(params []interface{}) interface{} {
-	return object.StringObjectFromGoString(secureRandomClassName)
+	return object.StringObjectFromGoString("NativePRNG")
 }
 
 func SecureRandomNextBoolean(params []interface{}) interface{} {
-	randByte := make([]byte, 1) // float64 is 8 bytes
-	_, err := rand.Read(randByte)
-	if err != nil {
-		return getGErrBlk(excNames.RuntimeException, fmt.Sprintf("SecureRandomNextBoolean: Failed to generate random byte: %v", err))
-	}
-	if randByte[0]&0x01 == 0x01 {
+	rng := params[0].(*object.Object).FieldTable["rng"].Fvalue.(*rand.Rand)
+	ii := rng.Int()
+	if ii&0x01 == 0x01 {
 		return types.JavaBoolTrue
 	}
 	return types.JavaBoolFalse
+}
+
+// SecureRandomGetSeed returns the current seed as a byte array of the specified size
+func SecureRandomGetSeed(params []interface{}) interface{} {
+
+	// Validate parameter count.
+	if len(params) != 1 {
+		errMsg := fmt.Sprintf("SecureRandomGetSeed: Expected 1 parameter (int64 size), got %d", len(params))
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	size, ok := params[0].(int64)
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "SecureRandomGetSeed: Size parameter must be an int64")
+	}
+
+	// Form byte array for return to caller.
+	byteArray := genSeed(size)
+	classStr := "[B"
+	result := object.MakePrimitiveObject(classStr, types.ByteArray, byteArray[:size])
+	return result
+
 }

--- a/src/object/string.go
+++ b/src/object/string.go
@@ -240,6 +240,8 @@ func ObjectFieldToString(obj *Object, fieldName string) string {
 		return "FileHandle"
 	case types.Ref, types.RefArray:
 		return GoStringFromStringPoolIndex(obj.KlassName)
+	case types.RNG:
+		return "RandomNumberGenerator"
 	}
 
 	// None of the above.

--- a/src/object/toString_test.go
+++ b/src/object/toString_test.go
@@ -135,9 +135,18 @@ func TestObjectFieldToStringPos(t *testing.T) {
 	var byteAry = []byte{65, 66, 67}
 	setField(obj, fieldName, types.ByteArray, byteAry)
 	observed = ObjectFieldToString(obj, fieldName)
+	expected = "414243"
+	if observed != expected {
+		t.Errorf("Raw byte array, expected: %s, observed: %s\n", expected, observed)
+	}
+
+	// Java byte array
+	var jbAry = []types.JavaByte{65, 66, 67}
+	setField(obj, fieldName, types.ByteArray, jbAry)
+	observed = ObjectFieldToString(obj, fieldName)
 	expected = "ABC"
 	if observed != expected {
-		t.Errorf("Byte array, expected: %s, observed: %s\n", expected, observed)
+		t.Errorf("Java byte array, expected: %s, observed: %s\n", expected, observed)
 	}
 
 	// Double array

--- a/src/types/javaTypes.go
+++ b/src/types/javaTypes.go
@@ -6,7 +6,11 @@
 
 package types
 
-import "strings"
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+)
 
 // These are the types that are used in an object's field.Ftype and elsewhere.
 
@@ -41,6 +45,7 @@ const StringIndex = "T" // The index into the string pool
 const GolangString = "G"
 const FileHandle = "FH" // The related Fvalue is a Golang *os.File
 const BigInteger = "BI" // The related Fvalue is a Golang *big.Int
+const RNG = "RG"        // RandomNumberGenerator is a Golang *rand.Rand
 
 const Static = "X"
 const StaticDouble = "XD"
@@ -114,4 +119,20 @@ func ConvertGoBoolToJavaBool(goBool bool) int64 {
 	} else {
 		return JavaBoolFalse
 	}
+}
+
+// Convert an int64 to a byte array in network byte order (BigEndian).
+func Int64ToBytesBE(arg int64) []byte {
+	buf := new(bytes.Buffer)
+	binary.Write(buf, binary.BigEndian, arg)
+	return buf.Bytes()
+}
+
+// Convert a byte array in network byte order (BigEndian) to an int64.
+func BytesToInt64BE(arg []byte) int64 {
+	sum := int64(0)
+	for ix := 0; ix < len(arg); ix++ {
+		sum += int64(arg[ix])
+	}
+	return sum
 }


### PR DESCRIPTION
* gfunction/javaSecuritySecureRandom.go:
   - fixed bugs
   - trap unsupported functions
   - added user seed support
* gfunction/javaUtilHexFormat.go: support both []byte and []types.JavaByte.
* object/string.go: amended ObjectFieldToString switch fld.Ftype to accept 
                         case types.RNG: return "RandomNumberGenerator"
* types/javaTypes.go: added:
   - const RNG = "RG"        // RandomNumberGenerator is a Golang *rand.Rand
   - func Int64ToBytesBE(arg int64) []byte // Convert an int64 to a byte array in network byte order (BigEndian)
   - func BytesToInt64BE(arg []byte) int64 // Convert a byte array in network byte order (BigEndian) to an int64
