### PR TITLE
JACOBIN-667 return the class name, field name, and the field type with a prefix when the field type is unrecognised

### DIFF
--- a/src/object/string.go
+++ b/src/object/string.go
@@ -20,8 +20,6 @@ package object
 
 import (
 	"fmt"
-	"jacobin/excNames"
-	"jacobin/globals"
 	"jacobin/stringPool"
 	"jacobin/types"
 	"strconv"
@@ -244,10 +242,9 @@ func ObjectFieldToString(obj *Object, fieldName string) string {
 		return "RandomNumberGenerator"
 	}
 
-	// None of the above.
-	errMsg := fmt.Sprintf("ObjectFieldToString: field \"%s\" Ftype \"%s\" not yet supported. Returning the class name",
-		fieldName, fld.Ftype)
-	globals.GetGlobalRef().FuncThrowException(excNames.UnsupportedOperationException, errMsg)
-	// trace.Error(errMsg)
-	return GoStringFromStringPoolIndex(obj.KlassName)
+	// None of the above!
+	// Just return the class name, field name, and the field type.
+	result := fmt.Sprintf("UNRECOGNISED: %s.%s(Ftype: %s)", GoStringFromStringPoolIndex(obj.KlassName), fieldName, fld.Ftype)
+	return result
+
 }

--- a/src/object/string_test.go
+++ b/src/object/string_test.go
@@ -291,30 +291,22 @@ func TestObjectFieldToStringForUnknownType(t *testing.T) {
 		return false
 	}
 
-	// to inspect usage message, redirect stderr
-	normalStderr := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-
 	obj := StringObjectFromGoString("allo!")
-	obj.FieldTable["testField"] = Field{
-		Ftype:  "..",
+	obj.FieldTable["testFieldName"] = Field{
+		Ftype:  "testFieldType",
 		Fvalue: nil,
 	}
-	ret := ObjectFieldToString(obj, "testField")
+	ret := ObjectFieldToString(obj, "testFieldName")
 
 	if !strings.Contains(ret, "java/lang/String") {
 		t.Errorf("Expected different return string, got %s", ret)
 	}
 
-	// restore stderr to what it was before
-	_ = w.Close()
-	out, _ := io.ReadAll(r)
-	os.Stderr = normalStderr
-	msg := string(out[:])
-
-	if !strings.Contains(msg, "not yet supported") {
-		t.Errorf("Expected different error message, got %s", msg)
+	if !strings.Contains(ret, "testFieldName") { // just the field name
+		t.Errorf("Looking for field name, got %s", ret)
+	}
+	if !strings.Contains(ret, "testFieldType") { // just the field name
+		t.Errorf("Looking for field type, got %s", ret)
 	}
 }
 


### PR DESCRIPTION
	modified:   object/string.go
	modified:   object/string_test.go

When ObjectFieldToString cannot determine field type, return:
`fmt.Sprintf("UNRECOGNISED: %s.%s(Ftype: %s)", GoStringFromStringPoolIndex(obj.KlassName), fieldName, fld.Ftype)`