### PR TITLE
JACOBIN-668 Fill out class Boolean in the gfunction package

### DIFF
--- a/src/gfunction/javaLangBoolean.go
+++ b/src/gfunction/javaLangBoolean.go
@@ -7,6 +7,8 @@
 package gfunction
 
 import (
+	"fmt"
+	"jacobin/excNames"
 	"jacobin/object"
 	"jacobin/types"
 )
@@ -19,7 +21,77 @@ func Load_Lang_Boolean() {
 			GFunction:  clinitGeneric,
 		}
 
+	MethodSignatures["java/lang/Boolean.<init>(Z)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures["java/lang/Boolean.<init>(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures["java/lang/Boolean.booleanValue()Z"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  booleanBooleanValue,
+		}
+
+	// The JVM library Boolean.compare and Boolean.compareTo functions work.
+
+	MethodSignatures["java/lang/Boolean.describeConstable()Ljava.util.Optional;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	// The JVM library Boolean.equals function works.
+
+	MethodSignatures["java/lang/Boolean.getBoolean(Ljava/lang/String;)Z"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  booleanGetBoolean,
+		}
+
+	MethodSignatures["java/lang/Boolean.hashCode()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  booleanHashCode,
+		}
+
+	MethodSignatures["java/lang/Boolean.hashCode(Z)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  booleanHashCode,
+		}
+
+	// The JVM library Boolean.logicalAnd function works.
+	// The JVM library Boolean.logicalOr function works.
+	// The JVM library Boolean.logicalXor function works.
+
+	MethodSignatures["java/lang/Boolean.parseBoolean(Ljava/lang/String;)Z"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  booleanParseBoolean,
+		}
+
+	MethodSignatures["java/lang/Boolean.parseBoolean(Ljava/lang/String;)Z"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  booleanParseBoolean,
+		}
+
+	// The JVM library Boolean.toString function works.
+
 	MethodSignatures["java/lang/Boolean.valueOf(Z)Ljava/lang/Boolean;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  booleanValueOf,
+		}
+
+	MethodSignatures["java/lang/Boolean.valueOf(Ljava/lang/String;)Ljava/lang/Boolean;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  booleanValueOf,
@@ -27,9 +99,170 @@ func Load_Lang_Boolean() {
 
 }
 
-// java/lang/Boolean.valueOf(Z)Ljava/lang/Boolean;
+// Return the value of this Boolean object as a boolean primitive.
+func booleanBooleanValue(params []interface{}) interface{} {
+	// Try for a Boolean object.
+	obj, ok := params[0].(*object.Object)
+	if !ok {
+		errMsg := fmt.Sprintf("booleanBooleanValue: The parameter is neither String nor boolean: %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Get the value field.
+	fld, ok := obj.FieldTable["value"]
+	if !ok {
+		errMsg := "booleanBooleanValue: Missing the \"value\" field"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	var zz int64
+	switch fld.Fvalue.(type) {
+	case int64:
+		zz = fld.Fvalue.(int64)
+	default:
+		errMsg := fmt.Sprintf("booleanBooleanValue: The \"value\" field has the wrong type: %T", fld.Fvalue)
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// inObj should be a String object.
+	switch zz {
+	case types.JavaBoolTrue, types.JavaBoolFalse:
+		return zz
+	}
+
+	// Return exception.
+	errMsg := fmt.Sprintf("booleanBooleanValue: The \"value\" field value is neither true nor false: %d", zz)
+	return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+
+}
+
+// Returns true if and only if the system property named by the argument exists
+// and is equal to, ignoring case, the string "true".
+// Else, return false.
+// If neither true nor false, return an exception.
+func booleanGetBoolean(params []interface{}) interface{} {
+
+	// Get the property name and validate it.
+	obj := params[0].(*object.Object)
+	fld, ok := obj.FieldTable["value"]
+	if !ok {
+		errMsg := "booleanGetBoolean: Missing the \"value\" field"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	var propName string
+	switch fld.Fvalue.(type) {
+	case []byte:
+		propName = string(obj.FieldTable["value"].Fvalue.([]byte))
+	case []types.JavaByte:
+		propName = object.GoStringFromJavaByteArray(obj.FieldTable["value"].Fvalue.([]types.JavaByte))
+	default:
+		errMsg := fmt.Sprintf("booleanGetBoolean: The \"value\" field has invalid type: %T", fld.Ftype)
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Call getProperty() to get the property value.
+	var sysParams []interface{}
+	sysParams = append(sysParams, object.StringObjectFromGoString(propName))
+	propObj := getProperty(sysParams).(*object.Object)
+	propStr := object.GoStringFromStringObject(propObj)
+	switch propStr {
+	case "true":
+		return types.JavaBoolTrue
+	case "false":
+		return types.JavaBoolFalse
+	}
+
+	// Neither true nor false ==> exception.
+	errMsg := fmt.Sprintf("booleanGetBoolean: getProperty returned neither \"true\" nor \"false\": %v", propStr)
+	return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+}
+
+// Returns a Boolean object instance, based on the parameter type: boolean or String.
 func booleanValueOf(params []interface{}) interface{} {
-	zz := params[0].(int64)
-	objPtr := object.MakePrimitiveObject("java/lang/Boolean", types.Bool, zz)
-	return objPtr
+
+	// Try for a String object.
+	inObj, ok := params[0].(*object.Object)
+	if !ok {
+		inBool, ok := params[0].(int64)
+		if !ok {
+			errMsg := fmt.Sprintf("booleanValueOf: The parameter is neither String nor boolean: %T", params[0])
+			return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+		}
+		obj := object.MakePrimitiveObject("java/lang/Boolean", types.Bool, inBool)
+		return obj
+	}
+
+	// inObj should be a String object.
+	zz := _booleanStringParser(inObj)
+	switch zz {
+	case types.JavaBoolTrue, types.JavaBoolFalse:
+		return object.MakePrimitiveObject("java/lang/Boolean", types.Bool, zz)
+	}
+
+	// Return exception.
+	return zz
+}
+
+// Given a Boolean object, return one of the following:
+// types.JavaBoolTrue
+// types.JavaBoolFalse
+// an exception
+func _booleanStringParser(obj *object.Object) interface{} {
+	// Get the String argument value.
+	fld, ok := obj.FieldTable["value"]
+	if !ok {
+		errMsg := "_booleanStringParser: Missing the \"value\" field"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	var strValue string
+	switch fld.Fvalue.(type) {
+	case []byte:
+		strValue = string(obj.FieldTable["value"].Fvalue.([]byte))
+	case []types.JavaByte:
+		strValue = object.GoStringFromJavaByteArray(obj.FieldTable["value"].Fvalue.([]types.JavaByte))
+	default:
+		errMsg := fmt.Sprintf("_booleanStringParser: The \"value\" field has invalid type: %T", fld.Ftype)
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	switch strValue {
+	case "true":
+		return types.JavaBoolTrue
+	case "false":
+		return types.JavaBoolFalse
+	}
+
+	// Neither true nor false ==> exception.
+	errMsg := fmt.Sprintf("_booleanStringParser: The \"value\" field is neither \"true\" nor \"false\": %v", strValue)
+	return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+}
+
+// Parse the string argument as a boolean and return true, false, or an exception.
+func booleanParseBoolean(params []interface{}) interface{} {
+	obj := params[0].(*object.Object)
+	return _booleanStringParser(obj)
+}
+
+// Return a hash code for this Boolean object.
+func booleanHashCode(params []interface{}) interface{} {
+	var zz interface{}
+	if len(params) == 0 {
+		obj := params[0].(*object.Object)
+		zz = _booleanStringParser(obj)
+	} else {
+		zz = params[1].(int64)
+		switch zz {
+		case types.JavaBoolTrue, types.JavaBoolFalse:
+		default:
+			errMsg := fmt.Sprintf("booleanHashCode: The argument is neither \"true\" nor \"false\": %v", zz)
+			return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+		}
+	}
+	switch zz {
+	case types.JavaBoolTrue:
+		return int64(1231)
+	case types.JavaBoolFalse:
+		return int64(1237)
+	}
+
+	// Return exception from _booleanStringParser.
+	return zz
 }

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -1619,6 +1619,9 @@ func valueOfObject(params []interface{}) interface{} {
 	case *object.Object:
 		inObj := params[0].(*object.Object)
 		str = object.ObjectFieldToString(inObj, "value")
+		if str == "null" {
+			str = object.ObjectFieldToString(inObj, "name")
+		}
 	default:
 		errMsg := fmt.Sprintf("valueOfObject: Unsupported parameter type: %T", params[0])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)

--- a/src/object/string.go
+++ b/src/object/string.go
@@ -209,7 +209,7 @@ func ObjectFieldToString(obj *Object, fieldName string) string {
 		return str
 	case types.Byte, types.Char, types.Int, types.Long, types.Rune, types.Short:
 		return fmt.Sprintf("%d", fld.Fvalue.(int64))
-	case types.ByteArray:
+	case types.ByteArray, "Ljava/lang/String;":
 		switch fld.Fvalue.(type) {
 		case []byte:
 			return fmt.Sprintf("%x", fld.Fvalue.([]byte))


### PR DESCRIPTION
- 668 modified: javaLangBoolean.go - filled out. Note that quite a few of the JVM library routines intermingle just fine.
- 643 modified:   gfunction/javaLangString.go - valueOfObject() is using field "name" if field "value" is not present.
- 643 modified:   object/string.go - ObjectFieldToString() is allowing "LjavaLangString;" as a field name.
