### PR TITLE
JACOBIN-666 - mostly, a modest javaLangRuntime.go

### DIFF
--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -12,12 +12,6 @@ import (
 
 func Load_Traps() {
 
-	MethodSignatures["java/io/BufferedInputStream.<clinit>()V"] =
-		GMeth{
-			ParamSlots: 0,
-			GFunction:  trapClass,
-		}
-
 	MethodSignatures["java/io/BufferedOutputStream.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
@@ -25,12 +19,6 @@ func Load_Traps() {
 		}
 
 	MethodSignatures["java/io/BufferedWriter.<clinit>()V"] =
-		GMeth{
-			ParamSlots: 0,
-			GFunction:  trapClass,
-		}
-
-	MethodSignatures["java/io/ByteArrayInputStream.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  trapClass,

--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -118,6 +118,7 @@ func MTableLoadGFunctions(MTable *classloader.MT) {
 	Load_Lang_Long()
 	Load_Lang_Math()
 	Load_Lang_Object()
+	Load_Lang_Runtime()
 	Load_Lang_Short()
 	Load_Lang_StackTraceELement()
 	Load_Lang_String()

--- a/src/gfunction/javaLangRuntime.go
+++ b/src/gfunction/javaLangRuntime.go
@@ -1,0 +1,124 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2023 by  the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package gfunction
+
+import (
+	"jacobin/object"
+	"jacobin/statics"
+	"jacobin/types"
+	"runtime"
+)
+
+func Load_Lang_Runtime() {
+
+	MethodSignatures["java/lang/Runtime.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  runtimeClinit,
+		}
+
+	MethodSignatures["java/lang/Runtime.<init>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Runtime.addShutdownHook(Ljava/lang/Thread;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Runtime.availableProcessors()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  runtimeAvailableProcessors,
+		}
+
+	MethodSignatures["java/lang/Runtime.exit(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  exitI, // javaLangSystem.go
+		}
+
+	MethodSignatures["java/lang/Runtime.getRuntime()Ljava/lang/Runtime;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  runtimeGetRuntime,
+		}
+
+	MethodSignatures["java/lang/Runtime.halt(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  exitI, // javaLangSystem.go
+		}
+
+	MethodSignatures["java/lang/Runtime.load(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Runtime.load0(Ljava/lang/Class;Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Runtime.loadLibrary(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Runtime.loadLibrary0(Ljava/lang/Class;Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Runtime.removeShutdownHook(Ljava/lang/Thread;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Runtime.runFinalization()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Runtime.version()Ljava/lang/Runtime/Version;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+}
+
+const stringClassnameRuntime = "java/lang/Runtime"
+const stringFieldCurrentRuntime = "currentRuntime"
+
+func runtimeClinit([]interface{}) interface{} {
+	obj := object.MakePrimitiveObject(stringClassnameRuntime, types.ByteArray, nil)
+	_ = statics.AddStatic(stringClassnameRuntime+"."+stringFieldCurrentRuntime, statics.Static{
+		Type:  types.Ref + stringClassnameRuntime,
+		Value: obj,
+	})
+	return object.StringObjectFromGoString(stringClassnameRuntime)
+}
+
+// runtimeGetRuntime: Get the singleton Runtime object.
+func runtimeGetRuntime([]interface{}) interface{} {
+	return statics.GetStaticValue(stringClassnameRuntime, stringFieldCurrentRuntime)
+}
+
+// runtimeAvailableProcessors: Get the number of CPU cores.
+func runtimeAvailableProcessors([]interface{}) interface{} {
+	return int64(runtime.NumCPU())
+}

--- a/src/gfunction/otherMethods.go
+++ b/src/gfunction/otherMethods.go
@@ -122,4 +122,16 @@ func Load_Other_methods() {
 			GFunction:  clinitGeneric,
 		}
 
+	MethodSignatures["java/io/ByteArrayInputStream.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  clinitGeneric,
+		}
+
+	MethodSignatures["java/io/BufferedInputStream.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  clinitGeneric,
+		}
+
 }


### PR DESCRIPTION
* new file:   gfunction/javaLangRuntime.go - 
   --- `<clinit>`, getRuntime(), and availableProcessors(). 
   --- Trap all other methods.
* modified:   gfunction/gfunction.go - call Load_Lang_Runtime().
* modified:   gfunction/Traps.go - stop trapping `<clinit>` for java/io/ByteArrayInputStream.
* modified:   gfunction/otherMethods.go - small `<clinit>` for java/io/ByteArrayInputStream.
