### PR TITLE
statics.go line 66: if flagTraceStatics && !util.IsFilePartOfJDK(&name)

### DIFF
--- a/src/statics/statics.go
+++ b/src/statics/statics.go
@@ -63,7 +63,7 @@ func AddStatic(name string, s Static) error {
 	staticsMutex.RLock()
 	Statics[name] = s
 	staticsMutex.RUnlock()
-	if flagTraceStatics && util.IsFilePartOfJDK(&name) {
+	if flagTraceStatics && !util.IsFilePartOfJDK(&name) {
 		if !testing.Testing() {
 			_, _ = fmt.Fprintf(os.Stderr, ">>>trace>>>AddStatic: Adding static entry with name=%s, value=%v\n", name, s.Value)
 		}


### PR DESCRIPTION
It used to be:
```if flagTraceStatics && util.IsFilePartOfJDK(&name)```
i.e. without a '!' infront of ```util.IsFilePartOfJDK(&name)```