### PR TITLE
JACOBIN-674, JACOBIN-675, JACOBIN-676

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@main
       with:
-        go-version: '1.21.x'
+        go-version: '1.24.x'
         cache: true
         cache-dependency-path: "**/go.sum"
       
@@ -58,7 +58,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@main
       with:
-        go-version: '1.21.x'
+        go-version: '1.24.x'
         cache: true
         cache-dependency-path: "**/go.sum"
       

--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -15,6 +15,7 @@ import (
 	"jacobin/object"
 	"jacobin/trace"
 	"jacobin/types"
+	"math/big"
 	"os"
 	"strings"
 )
@@ -213,7 +214,7 @@ func loadlib(tbl *classloader.MT, libMeths map[string]GMeth) {
 }
 
 // Populate an object for a primitive type (Byte, Character, Double, Float, Integer, Long, Short, String).
-func populator(classname string, fldtype string, fldvalue interface{}) *object.Object {
+func Populator(classname string, fldtype string, fldvalue interface{}) *object.Object {
 	var objPtr *object.Object
 	if fldtype == types.StringIndex {
 		objPtr = object.StringObjectFromGoString(fldvalue.(string))
@@ -251,4 +252,22 @@ func returnFalse(params []interface{}) interface{} {
 // Return true.
 func returnTrue(params []interface{}) interface{} {
 	return types.JavaBoolTrue
+}
+
+// InitBigIntegerField: Initialise the object field.
+// Fvalue holds *big.Int (pointer).
+func InitBigIntegerField(obj *object.Object, argValue int64) {
+	ptrBigInt := big.NewInt(argValue)
+	fldValue := object.Field{Ftype: types.BigInteger, Fvalue: ptrBigInt}
+	obj.FieldTable["value"] = fldValue
+	var fldSign object.Field
+	switch {
+	case argValue == 0:
+		fldSign = object.Field{Ftype: types.BigInteger, Fvalue: int64(0)}
+	case argValue < 0:
+		fldSign = object.Field{Ftype: types.BigInteger, Fvalue: int64(-1)}
+	default:
+		fldSign = object.Field{Ftype: types.BigInteger, Fvalue: int64(+1)}
+	}
+	obj.FieldTable["signum"] = fldSign
 }

--- a/src/gfunction/javaIoConsole.go
+++ b/src/gfunction/javaIoConsole.go
@@ -193,7 +193,7 @@ func consoleReadPassword([]interface{}) interface{} {
 	for _, bb := range password {
 		iArray = append(iArray, int64(bb))
 	}
-	return populator("[C", types.IntArray, iArray)
+	return Populator("[C", types.IntArray, iArray)
 }
 
 // Provides a formatted prompt, then reads a password or passphrase from the console.

--- a/src/gfunction/javaLangByte.go
+++ b/src/gfunction/javaLangByte.go
@@ -79,7 +79,7 @@ func byteDecode(params []interface{}) interface{} {
 	}
 
 	// Create Byte object.
-	return populator("java/lang/Byte", types.Byte, int64Value)
+	return Populator("java/lang/Byte", types.Byte, int64Value)
 }
 
 // "java/lang/Byte.doubleValue()D"
@@ -103,5 +103,5 @@ func byteToString(params []interface{}) interface{} {
 // "java/lang/Byte.valueOf(B)Ljava/lang/Byte;"
 func byteValueOf(params []interface{}) interface{} {
 	int64Value := params[0].(int64)
-	return populator("java/lang/Byte", types.Byte, int64Value)
+	return Populator("java/lang/Byte", types.Byte, int64Value)
 }

--- a/src/gfunction/javaLangCharacter.go
+++ b/src/gfunction/javaLangCharacter.go
@@ -93,7 +93,7 @@ func charToUpperCase(params []interface{}) interface{} {
 // "java/lang/Character.valueOf(C)Ljava/lang/Character;"
 func characterValueOf(params []interface{}) interface{} {
 	int64Value := params[0].(int64)
-	return populator("java/lang/Character", types.Char, int64Value)
+	return Populator("java/lang/Character", types.Char, int64Value)
 }
 
 // "java/lang/Character.charValue()C"

--- a/src/gfunction/javaLangInteger.go
+++ b/src/gfunction/javaLangInteger.go
@@ -178,7 +178,7 @@ func integerDecode(params []interface{}) interface{} {
 	}
 
 	// Create Integer object.
-	return populator("java/lang/Integer", types.Int, int64Value)
+	return Populator("java/lang/Integer", types.Int, int64Value)
 }
 
 // "java/lang/Integer.doubleValue()D"
@@ -285,7 +285,7 @@ func integerSignum(params []interface{}) interface{} {
 // "java/lang/Integer.valueOf(I)Ljava/lang/Integer;"
 func integerValueOf(params []interface{}) interface{} {
 	int64Value := params[0].(int64)
-	return populator("java/lang/Integer", types.Int, int64Value)
+	return Populator("java/lang/Integer", types.Int, int64Value)
 }
 
 // "java/lang/Integer.toString()Ljava/lang/String;"

--- a/src/gfunction/javaLangLong.go
+++ b/src/gfunction/javaLangLong.go
@@ -106,7 +106,7 @@ func longRotateRight(params []interface{}) interface{} {
 // "java/lang/Long.valueOf(J)Ljava/lang/Long;"
 func longValueOf(params []interface{}) interface{} {
 	int64Value := params[0].(int64)
-	return populator("java/lang/Long", types.Long, int64Value)
+	return Populator("java/lang/Long", types.Long, int64Value)
 }
 
 // "java/lang/Long.toHexString(J)Ljava/lang/String;"

--- a/src/gfunction/javaLangShort.go
+++ b/src/gfunction/javaLangShort.go
@@ -44,5 +44,5 @@ func shortDoubleValue(params []interface{}) interface{} {
 // "java/lang/Short.valueOf(S)Ljava/lang/Short;"
 func shortValueOf(params []interface{}) interface{} {
 	int64Value := params[0].(int64)
-	return populator("java/lang/Short", types.Short, int64Value)
+	return Populator("java/lang/Short", types.Short, int64Value)
 }

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -1228,7 +1228,7 @@ func StringFormatter(params []interface{}) interface{} {
 func getBytesFromString(params []interface{}) interface{} {
 	// params[0] = reference string with byte array to be returned
 	bytes := object.JavaByteArrayFromStringObject(params[0].(*object.Object))
-	return populator("[B", types.ByteArray, bytes)
+	return Populator("[B", types.ByteArray, bytes)
 }
 
 // java/lang/String.getBytes([BIIBI)V
@@ -1476,7 +1476,7 @@ func toCharArray(params []interface{}) interface{} {
 	for _, bb := range bytes {
 		iArray = append(iArray, int64(bb))
 	}
-	return populator("[C", types.IntArray, iArray)
+	return Populator("[C", types.CharArray, iArray)
 }
 
 // "java/lang/String.toLowerCase()Ljava/lang/String;"
@@ -2025,7 +2025,7 @@ func stringSplit(params []interface{}) interface{} {
 	for ix := 0; ix < len(result); ix++ {
 		outObjArray = append(outObjArray, object.StringObjectFromGoString(result[ix]))
 	}
-	return populator("[Ljava/lang/String;", types.RefArray, outObjArray)
+	return Populator("[Ljava/lang/String;", types.RefArray, outObjArray)
 
 }
 
@@ -2056,7 +2056,7 @@ func stringSplitLimit(params []interface{}) interface{} {
 	for ix := 0; ix < len(result); ix++ {
 		outObjArray = append(outObjArray, object.StringObjectFromGoString(result[ix]))
 	}
-	return populator("[Ljava/lang/String;", types.RefArray, outObjArray)
+	return Populator("[Ljava/lang/String;", types.RefArray, outObjArray)
 }
 
 func stringStrip(params []interface{}) interface{} {

--- a/src/gfunction/javaMathBigInteger.go
+++ b/src/gfunction/javaMathBigInteger.go
@@ -410,29 +410,11 @@ func getPrime(bitLength int) (*big.Int, string) {
 	}
 }
 
-// initBigIntegerField: Initialise the object field.
-// Fvalue holds *big.Int (pointer).
-func initBigIntegerField(obj *object.Object, argValue int64) {
-	ptrBigInt := big.NewInt(argValue)
-	fldValue := object.Field{Ftype: types.BigInteger, Fvalue: ptrBigInt}
-	obj.FieldTable["value"] = fldValue
-	var fldSign object.Field
-	switch {
-	case argValue == 0:
-		fldSign = object.Field{Ftype: types.BigInteger, Fvalue: int64(0)}
-	case argValue < 0:
-		fldSign = object.Field{Ftype: types.BigInteger, Fvalue: int64(-1)}
-	default:
-		fldSign = object.Field{Ftype: types.BigInteger, Fvalue: int64(+1)}
-	}
-	obj.FieldTable["signum"] = fldSign
-}
-
 // addStaticBigInteger: Form a BigInteger object based on the parameter value.
 func addStaticBigInteger(argName string, argValue int64) {
 	name := fmt.Sprintf("%s.%s", bigIntegerClassName, argName)
 	obj := object.MakeEmptyObjectWithClassName(&bigIntegerClassName)
-	initBigIntegerField(obj, argValue)
+	InitBigIntegerField(obj, argValue)
 	_ = statics.AddStatic(name, statics.Static{Type: "Ljava/math/BigInteger;", Value: obj})
 }
 
@@ -1410,7 +1392,7 @@ func bigIntegerValueOf(params []interface{}) interface{} {
 
 	argValue := params[0].(int64)
 	obj := object.MakeEmptyObjectWithClassName(&bigIntegerClassName)
-	initBigIntegerField(obj, argValue)
+	InitBigIntegerField(obj, argValue)
 
 	return obj
 }

--- a/src/object/arrays.go
+++ b/src/object/arrays.go
@@ -237,7 +237,7 @@ func ArrayLength(arrayRef *Object) int64 {
 	case types.FloatArray:
 		array := o.Fvalue.([]float64)
 		size = int64(len(array))
-	case types.IntArray:
+	case types.IntArray, types.CharArray:
 		array := o.Fvalue.([]int64)
 		size = int64(len(array))
 	default:

--- a/src/object/string.go
+++ b/src/object/string.go
@@ -216,7 +216,9 @@ func ObjectFieldToString(obj *Object, fieldName string) string {
 		case []types.JavaByte:
 			return GoStringFromJavaByteArray(fld.Fvalue.([]types.JavaByte))
 		}
-	case types.CharArray, types.IntArray, types.LongArray, types.ShortArray:
+	case types.CharArray:
+		return GoStringFromJavaCharArray(fld.Fvalue.([]int64))
+	case types.IntArray, types.LongArray, types.ShortArray:
 		var str string
 		for _, elem := range fld.Fvalue.([]int64) {
 			str += fmt.Sprint(elem)
@@ -245,4 +247,13 @@ func ObjectFieldToString(obj *Object, fieldName string) string {
 	result := fmt.Sprintf("UNRECOGNIZED: %s.%s(Ftype: %s)", GoStringFromStringPoolIndex(obj.KlassName), fieldName, fld.Ftype)
 	return result
 
+}
+
+// Go string from a Java character array.
+func GoStringFromJavaCharArray(inArray []int64) string {
+	var sb strings.Builder
+	for _, ch := range inArray {
+		sb.WriteRune(rune(ch))
+	}
+	return sb.String()
 }

--- a/src/testutil/testUtil.go
+++ b/src/testutil/testUtil.go
@@ -93,19 +93,6 @@ func UTgfunc(t *testing.T, className, methodName, methodType string, obj *object
 	fr.MethName = methodName
 	fr.MethType = methodType
 
-	// Add CP to the frame.
-	CP := classloader.CPool{}
-	CP.CpIndex = make([]classloader.CpEntry, 10)
-	CP.CpIndex[0] = classloader.CpEntry{Type: 0, Slot: 0}
-	CP.CpIndex[1] = classloader.CpEntry{Type: classloader.ClassRef, Slot: 0}
-	CP.FieldRefs = make([]classloader.ResolvedFieldEntry, 1)
-	CP.FieldRefs[0] = classloader.ResolvedFieldEntry{
-		ClName:  "testClass",
-		FldName: "testField",
-		FldType: "I",
-	}
-	fr.CP = &CP
-
 	// Push fr to front of fs.
 	_ = frames.PushFrame(fs, fr)
 

--- a/src/testutil/testUtil.go
+++ b/src/testutil/testUtil.go
@@ -1,0 +1,141 @@
+package testutil
+
+import (
+	"fmt"
+	"jacobin/classloader"
+	"jacobin/frames"
+	"jacobin/gfunction"
+	"jacobin/globals"
+	"jacobin/object"
+	"jacobin/statics"
+	"os"
+	"testing"
+)
+
+var flagInit = false
+
+// Standard unit test initialisation without processing stderr and stdout.
+func UTinit(t *testing.T) {
+	if flagInit {
+		return
+	}
+	globals.InitGlobals("test")
+	statics.Statics = make(map[string]statics.Static)
+	statics.PreloadStatics()
+	err := classloader.Init()
+	if err != nil {
+		t.Fatalf("stdInit: classloader.Init() failed, err: %s", err.Error())
+	}
+	classloader.LoadBaseClasses()
+	classloader.MTable = make(map[string]classloader.MTentry)
+	gfunction.MTableLoadGFunctions(&classloader.MTable)
+	flagInit = true
+}
+
+// NOT THREAD-SAFE.
+var originalStderr *os.File
+var originalStdout *os.File
+var testStderr *os.File
+var testStdout *os.File
+
+// Save current stdout and stderr.
+// Substitute 2
+func UTnewConsole(t *testing.T) {
+	var err error
+
+	// Swap in a new stdout.
+	originalStdout = os.Stdout
+	_, testStdout, err = os.Pipe()
+	if err != nil {
+		os.Stdout = originalStdout // Restore original stdout.
+		t.Fatalf("stdTestBegin: os.Pipe()-->stdout failed, err: %s", err.Error())
+	}
+	os.Stdout = testStdout
+
+	// Swap in a new stderr.
+	originalStderr = os.Stderr
+	_, testStderr, err = os.Pipe()
+	if err != nil {
+		_ = testStdout.Close()
+		os.Stdout = originalStdout // Restore original stdout.
+		os.Stderr = originalStderr // Restore original stderr.
+		t.Fatalf("stdTestBegin: os.Pipe()-->stderr failed, err: %s", err.Error())
+	}
+	os.Stderr = testStderr
+}
+
+// Close testing stderr & stdout; restore the original stderr & stdout.
+func UTrestoreConsole(t *testing.T) {
+	_ = testStderr.Close()
+	_ = testStdout.Close()
+	os.Stdout = originalStdout
+	os.Stderr = originalStderr
+}
+
+// Execute a G function.
+// Return result to caller.
+func UTgfunc(t *testing.T, className, methodName, methodType string, obj *object.Object, args []interface{}) interface{} {
+
+	// String form of FQN.
+	fqn := fmt.Sprintf("%s.%s%s", className, methodName, methodType)
+
+	// Initialize Jacobin infrastructure and set up new stdout and stderr.
+	UTinit(t)
+	UTnewConsole(t)
+
+	// Create empty frame stack (fs).
+	fs := frames.CreateFrameStack()
+
+	// Create frame (fr).
+	fr := frames.CreateFrame(3)
+	fr.Thread = 0 // Mainthread
+	fr.FrameStack = fs
+	fr.ClName = className
+	fr.MethName = methodName
+	fr.MethType = methodType
+
+	// Add CP to the frame.
+	CP := classloader.CPool{}
+	CP.CpIndex = make([]classloader.CpEntry, 10)
+	CP.CpIndex[0] = classloader.CpEntry{Type: 0, Slot: 0}
+	CP.CpIndex[1] = classloader.CpEntry{Type: classloader.ClassRef, Slot: 0}
+	CP.FieldRefs = make([]classloader.ResolvedFieldEntry, 1)
+	CP.FieldRefs[0] = classloader.ResolvedFieldEntry{
+		ClName:  "testClass",
+		FldName: "testField",
+		FldType: "I",
+	}
+	fr.CP = &CP
+
+	// Push fr to front of fs.
+	_ = frames.PushFrame(fs, fr)
+
+	// Create mtEntry.
+	mtEntry := classloader.MTable[fqn]
+	if mtEntry.Meth == nil {
+		t.Fatalf("UTgfunc: classloader.MTable[%s] not found", fqn)
+	}
+
+	paramCount := len(args)
+
+	// params = args in reverse order (expected by RunGfunction).
+	params := make([]interface{}, paramCount)
+	for ix := 0; ix < paramCount; ix++ {
+		params[ix] = args[paramCount-1-ix]
+	}
+
+	// Add the object reference (Java class or file I/O).
+	if obj != nil {
+		params = append(params, obj)
+	}
+
+	// Run the G function.
+	result := gfunction.RunGfunction(mtEntry, fs, className, methodName, methodType, &params, true, false)
+
+	// Restore previous stderr and stdout.
+	UTrestoreConsole(t)
+
+	// Return the result to caller.
+	return result
+
+}

--- a/src/testutil/testUtil.go
+++ b/src/testutil/testUtil.go
@@ -12,6 +12,11 @@ import (
 	"testing"
 )
 
+// ***** NOT THREAD-SAFE *****
+var originalStderr *os.File
+var originalStdout *os.File
+var testStderr *os.File
+var testStdout *os.File
 var flagInit = false
 
 // Standard unit test initialisation without processing stderr and stdout.
@@ -32,14 +37,8 @@ func UTinit(t *testing.T) {
 	flagInit = true
 }
 
-// NOT THREAD-SAFE.
-var originalStderr *os.File
-var originalStdout *os.File
-var testStderr *os.File
-var testStdout *os.File
-
 // Save current stdout and stderr.
-// Substitute 2
+// Substitute 2 ones while executing Jacobin functions.
 func UTnewConsole(t *testing.T) {
 	var err error
 

--- a/src/testutil/testUtil_test.go
+++ b/src/testutil/testUtil_test.go
@@ -1,0 +1,185 @@
+package testutil
+
+import (
+	"jacobin/gfunction"
+	"jacobin/object"
+	"math"
+	"testing"
+)
+
+// Unit test the unit test utilities.
+
+const loopCount = 20
+const absTolerance = 1e-9
+const relTolerance = 1e-6
+
+func float64CloseEnough(tweedleDee, tweedleDum float64) bool {
+	diff := math.Abs(tweedleDee - tweedleDum)
+
+	// Absolute difference check for very small values.
+	if diff <= absTolerance {
+		return true
+	}
+
+	// Compute the maximum of the magnitudes.
+	maxMagnitude := math.Max(math.Abs(tweedleDee), math.Abs(tweedleDum))
+
+	// Relative difference check for larger values.
+	return diff <= maxMagnitude*relTolerance
+}
+
+func TestUTinit(t *testing.T) {
+	for ix := 0; ix < loopCount; ix++ {
+		UTinit(t)
+	}
+}
+
+func TestUTconsoles(t *testing.T) {
+	for ix := 0; ix < loopCount; ix++ {
+		UTnewConsole(t)
+		UTrestoreConsole(t)
+	}
+}
+
+func TestUTensemble(t *testing.T) {
+	for ix := 0; ix < loopCount; ix++ {
+		UTinit(t)
+		UTnewConsole(t)
+		UTrestoreConsole(t)
+	}
+}
+
+func TestMathSqrt_D_D(t *testing.T) {
+	var params []interface{}
+	params = append(params, 4.0)
+	result := UTgfunc(t, "java/lang/Math", "sqrt", "(D)D", nil, params)
+	switch result.(type) {
+	case float64:
+		if !float64CloseEnough(result.(float64), 2.0) {
+			t.Errorf("TestMathSqrt_D_D: Expected sqrt(4)=2, observed: %f", result.(float64))
+		}
+	case gfunction.GErrBlk:
+		t.Errorf("TestMathSqrt_D_D: gfunction.GErrBlk.ErrMsg: %s", result.(gfunction.GErrBlk).ErrMsg)
+	default:
+		t.Errorf("TestMathSqrt_D_D: Expected result of type float64, observed: %T", result)
+	}
+}
+
+func TestStrictMathCbrt_D_D(t *testing.T) {
+	var params []interface{}
+	params = append(params, 27.0)
+	result := UTgfunc(t, "java/lang/StrictMath", "cbrt", "(D)D", nil, params)
+	switch result.(type) {
+	case float64:
+		if !float64CloseEnough(result.(float64), 3.0) {
+			t.Errorf("TestStrictMathCbrt_D_D: Expected cbrt(27)=3, observed: %f", result.(float64))
+		}
+	case gfunction.GErrBlk:
+		t.Errorf("TestStrictMathCbrt_D_D: gfunction.GErrBlk.ErrMsg: %s", result.(gfunction.GErrBlk).ErrMsg)
+	default:
+		t.Errorf("TestStrictMathCbrt_D_D: Expected result of type float64, observed: %T", result)
+	}
+}
+
+func TestStringLength(t *testing.T) {
+	var params []interface{}
+	obj := object.StringObjectFromGoString("ABCDEF")
+	result := UTgfunc(t, "java/lang/String", "length", "()I", obj, params)
+	switch result.(type) {
+	case int64:
+		if result.(int64) != 6 {
+			t.Errorf("TestStringLength: Expected length(\"ABCDEF\")=6, observed: %d", result.(int64))
+		}
+	case gfunction.GErrBlk:
+		t.Errorf("TestStringLength: gfunction.GErrBlk.ErrMsg: %s", result.(gfunction.GErrBlk).ErrMsg)
+	default:
+		t.Errorf("TestStringLength: Expected result of type int64, observed: %T", result)
+	}
+}
+
+func TestStringRepeater(t *testing.T) {
+	var params []interface{}
+	objIn := object.StringObjectFromGoString("Beetlejuice")
+	params = append(params, int64(3))
+	expected := "BeetlejuiceBeetlejuiceBeetlejuice"
+	result := UTgfunc(t, "java/lang/String", "repeat", "(I)Ljava/lang/String;", objIn, params)
+	switch result.(type) {
+	case *object.Object:
+		observed := object.GoStringFromStringObject(result.(*object.Object))
+		if observed != expected {
+			t.Errorf("TestStringRepeater: Expected: \"%s\", observed: \"%s\"", expected, observed)
+		}
+	case gfunction.GErrBlk:
+		t.Errorf("TestStringRepeater: gfunction.GErrBlk.ErrMsg: %s", result.(gfunction.GErrBlk).ErrMsg)
+	default:
+		t.Errorf("TestStringRepeater: Expected result of type String object, observed: %T", result)
+	}
+}
+
+func TestStringToCharArray(t *testing.T) {
+	var params []interface{}
+
+	// Here's the base string and its bytes equivalent.
+	expected := "ABCDEF"
+	bytes := []byte(expected)
+
+	// Make a Java object of the string.
+	objIn := object.StringObjectFromGoString(expected)
+
+	// Make an int64 array of the bytes.
+	var iArray []int64
+	for ix := 0; ix < len(expected); ix++ {
+		iArray = append(iArray, int64(bytes[ix]))
+	}
+
+	// Try it.
+	result := UTgfunc(t, "java/lang/String", "toCharArray", "()[C", objIn, params)
+	switch result.(type) {
+	case *object.Object:
+		observed := object.ObjectFieldToString(result.(*object.Object), "value")
+		if observed != expected {
+			t.Errorf("TestStringToCharArray: Expected: \"%s\", observed: \"%s\"", expected, observed)
+		}
+	case gfunction.GErrBlk:
+		t.Errorf("TestStringToCharArray: gfunction.GErrBlk.ErrMsg: %s", result.(gfunction.GErrBlk).ErrMsg)
+	default:
+		t.Errorf("TestStringToCharArray: Expected result of type [C object, observed: %T", result)
+	}
+}
+
+func TestBigInteger(t *testing.T) {
+
+	var params []interface{}
+	biClassName := "java/math/BigInteger"
+	expected := int64(42)
+
+	// Need to do an early initialisation before object.MakeEmptyObjectWithClassName).
+	UTinit(t)
+
+	// Initialise the base object.
+	obj := object.MakeEmptyObjectWithClassName(&biClassName)
+	gfunction.InitBigIntegerField(obj, int64(0))
+
+	// Add the String value to params.
+	params = append(params, object.StringObjectFromGoString("42"))
+
+	// Try java/math/BigInteger.<init>.(Ljava/lang/String;)V
+	result := UTgfunc(t, "java/math/BigInteger", "<init>", "(Ljava/lang/String;)V", obj, params)
+	if result != nil {
+		t.Fatalf("TestBigInteger: <init>: Expected nil return")
+	}
+
+	// Try intValue()
+	params = nil
+	result = UTgfunc(t, "java/math/BigInteger", "intValue", "()I", obj, params)
+	switch result.(type) {
+	case int64:
+		if result.(int64) != expected {
+			t.Errorf("TestStringToCharArray: Expected: \"%d\", observed: \"%d\"", expected, result.(int64))
+		}
+	case gfunction.GErrBlk:
+		t.Errorf("TestStringToCharArray: gfunction.GErrBlk.ErrMsg: %s", result.(gfunction.GErrBlk).ErrMsg)
+	default:
+		t.Errorf("TestStringToCharArray: Expected result of type [C object, observed: %T", result)
+	}
+}

--- a/src/testutil/testUtil_test.go
+++ b/src/testutil/testUtil_test.go
@@ -13,6 +13,9 @@ const loopCount = 20
 const absTolerance = 1e-9
 const relTolerance = 1e-6
 
+// Close enough?
+// If very small, use an absolute tolerance.
+// Otherwise, use a relative tolerance.
 func float64CloseEnough(tweedleDee, tweedleDum float64) bool {
 	diff := math.Abs(tweedleDee - tweedleDum)
 


### PR DESCRIPTION
JACOBIN-674:
* testutil/testUtil.go, testutil/testUtil_test.go: new unit test utilities and self-tests.

JACOBIN-675:
* object/string.go: new function: GoStringFromJavaCharArray().
* gfunction/javaLangString.go: fix toCharArray(), field type should be types.CharArray, not types.IntArray.
* gfunction/gfunction.go: new home to Populator() and InitBigIntegerField(). 
* The other source files were impacted only by capitalisations.

JACOBIN-676:
* object/arrays.go ArrayLength(): treat types.CharArray the same as types.IntArray.

