### PR TITLE
JACOBIN-682 Fix to Windows pipe build up

### DIFF
--- a/src/jvm/runUtils_test.go
+++ b/src/jvm/runUtils_test.go
@@ -310,15 +310,15 @@ func TestCheckCastArray3(t *testing.T) {
 }
 
 func TestPushPeekPop(t *testing.T) {
-	// Let verbose trace messages go into a pipe that we will never see.
-	// We only care about evaluating the return from pop() in the loop.
-	// On Windows, this call must appear before anything else.
-	// testutil.UTnewConsole(t)
 
 	testutil.UTinit(t)
 	globals.TraceVerbose = false
 	var ret, thing interface{}
 	flagDeepTracing := false
+
+	// Let verbose trace messages go into a pipe that we will never see.
+	// We only care about evaluating the return from pop() in the loop.
+	testutil.UTnewConsole(t)
 
 	// Create frame (fr).
 	fr := frames.CreateFrame(13)
@@ -330,7 +330,7 @@ func TestPushPeekPop(t *testing.T) {
 	fr.Meth = []byte{byte(opcodes.NOP)}
 
 	// Try a nil stack.
-	t.Log("Trying a pop() with a nil stack. Ignore the following ThrowEx stack underflow warning.")
+	t.Log("Trying a pop() with a nil stack. Ignore any ThrowEx stack underflow warning.")
 	ret = pop(fr)
 	if ret != nil {
 		t.Errorf("TestPushPeekPop(nil): fr.TOS = -1. Expected nil returned from pop(), got %v", ret)
@@ -475,21 +475,21 @@ func TestPushPeekPop(t *testing.T) {
 	}
 
 	// Restore console for go test.
-	// testutil.UTrestoreConsole(t)
+	testutil.UTrestoreConsole(t)
 
 }
 
 func TestEmitTraceData(t *testing.T) {
-	// Let verbose trace messages go into a pipe that we will never see.
-	// We only care about evaluating the return from pop() in the loop.
-	// On Windows, this must be called before anything else.
-	// testutil.UTnewConsole(t)
 
 	testutil.UTinit(t)
 	globals.TraceVerbose = true
 	var ret interface{}
 	flagDeepTracing := false
-
+	
+	// Let verbose trace messages go into a pipe that we will never see.
+	// We only care about evaluating the return from pop() in the loop.
+	testutil.UTnewConsole(t)
+	
 	// Create frame (fr).
 	fr := frames.CreateFrame(13)
 	fr.Thread = 0 // Mainthread
@@ -620,5 +620,5 @@ func TestEmitTraceData(t *testing.T) {
 	}
 
 	// Restore console for go test.
-	// testutil.UTrestoreConsole(t)
+	testutil.UTrestoreConsole(t)
 }

--- a/src/testutil/testUtil.go
+++ b/src/testutil/testUtil.go
@@ -41,10 +41,12 @@ func UTinit(t *testing.T) {
 // Substitute 2 ones while executing Jacobin functions.
 func UTnewConsole(t *testing.T) {
 	var err error
+	var dummy *os.File
 
 	// Swap in a new stdout.
 	originalStdout = os.Stdout
-	_, testStdout, err = os.Pipe()
+	dummy, testStdout, err = os.Pipe()
+	_ = dummy.Close()
 	if err != nil {
 		os.Stdout = originalStdout // Restore original stdout.
 		t.Fatalf("stdTestBegin: os.Pipe()-->stdout failed, err: %s", err.Error())
@@ -53,7 +55,8 @@ func UTnewConsole(t *testing.T) {
 
 	// Swap in a new stderr.
 	originalStderr = os.Stderr
-	_, testStderr, err = os.Pipe()
+	dummy, testStderr, err = os.Pipe()
+	_ = dummy.Close()
 	if err != nil {
 		_ = testStdout.Close()
 		os.Stdout = originalStdout // Restore original stdout.


### PR DESCRIPTION
* testutil/testUtil.go UTnewConsole() - amended to close read-side pipe immediately after opening it.
* jvm/runUtils_test.go - TestPushPeekPop() and TestEmitTraceData() amended to use UTnewConsole() & UTrestoreConsole().
