### PR TITLE
JACOBIN-680, 683, 684, 686, 687

### DIFF
--- a/src/gfunction/jj.go
+++ b/src/gfunction/jj.go
@@ -8,7 +8,6 @@ package gfunction
 
 import (
 	"fmt"
-	"jacobin/globals"
 	"jacobin/object"
 	"jacobin/statics"
 	"jacobin/types"
@@ -87,7 +86,7 @@ func jjStringifyScalar(ftype string, fvalue any) *object.Object {
 			str = "null"
 		} else {
 			obj := fvalue.(*object.Object)
-			if obj.KlassName == globals.StringIndexString {
+			if obj.KlassName == types.StringPoolStringIndex {
 				// It is a Java String object. Return it as-is.
 				return obj
 			}

--- a/src/gfunction/jj_test.go
+++ b/src/gfunction/jj_test.go
@@ -1,7 +1,6 @@
 package gfunction
 
 import (
-	"fmt"
 	"io"
 	"jacobin/globals"
 	"jacobin/object"
@@ -102,11 +101,13 @@ func TestJjStringifyScalar_RefNull(t *testing.T) {
 }
 
 func TestJjStringifyScalar_RefNonNull(t *testing.T) {
-	obj := &object.Object{KlassName: 1}
+	globals.InitGlobals("test")
+	expected := "ABC"
+	obj := object.StringObjectFromGoString(expected)
 	result := jjStringifyScalar(types.Ref, obj)
-	expected := object.StringObjectFromGoString(fmt.Sprintf("%v", obj))
-	if object.GoStringFromStringObject(result) != object.GoStringFromStringObject(expected) {
-		t.Errorf("Expected %v, got %v", expected, result)
+	observed := object.GoStringFromStringObject(result)
+	if observed != expected {
+		t.Errorf("Expected %s, got %s", expected, observed)
 	}
 }
 

--- a/src/globals/globals.go
+++ b/src/globals/globals.go
@@ -346,6 +346,7 @@ func InitStringPool() {
 	// Add "java/lang/String"
 	StringPoolTable[types.StringClassName] = types.StringPoolStringIndex
 	StringPoolList = append(StringPoolList, types.StringClassName)
+	StringIndexString = 1
 
 	// Add "java/lang/Object"
 	StringPoolTable[types.ObjectClassName] = types.ObjectPoolStringIndex

--- a/src/globals/globals.go
+++ b/src/globals/globals.go
@@ -346,7 +346,6 @@ func InitStringPool() {
 	// Add "java/lang/String"
 	StringPoolTable[types.StringClassName] = types.StringPoolStringIndex
 	StringPoolList = append(StringPoolList, types.StringClassName)
-	StringIndexString = 1
 
 	// Add "java/lang/Object"
 	StringPoolTable[types.ObjectClassName] = types.ObjectPoolStringIndex

--- a/src/jvm/runUtils.go
+++ b/src/jvm/runUtils.go
@@ -316,6 +316,9 @@ func getSuperclasses(classNameIndex uint32) []uint32 {
 
 	thisClassName := stringPool.GetStringPointer(classNameIndex)
 	thisClass := classloader.MethAreaFetch(*thisClassName)
+	if thisClass == nil {
+		return retval
+	}
 	thisClassSuper := thisClass.Data.SuperclassIndex
 
 	retval = append(retval, thisClassSuper)

--- a/src/object/format.go
+++ b/src/object/format.go
@@ -45,6 +45,26 @@ func fmtHelper(field Field, className string, fieldName string) string {
 		} else {
 			if fvalue != nil {
 				switch fvalue.(type) {
+				case []types.JavaByte:
+					str := GoStringFromJavaByteArray(fvalue.([]types.JavaByte))
+					last := len(str) - 1
+					if last < 0 {
+						return "\"\""
+					}
+					if str[last] == '\n' {
+						str = str[0:last]
+					}
+					return fmt.Sprintf("\"%s\"", str)
+				case []byte:
+					bytes := fvalue.([]byte)
+					last := len(bytes) - 1
+					if last < 0 {
+						return "\"\""
+					}
+					if bytes[last] == '\n' {
+						bytes = bytes[0:last]
+					}
+					return fmt.Sprintf("\"%s\"", string(bytes))
 				case *[]byte:
 					bytes := *fvalue.(*[]byte)
 					last := len(bytes) - 1
@@ -67,7 +87,8 @@ func fmtHelper(field Field, className string, fieldName string) string {
 	// Process the other types.
 	switch ftype {
 	case types.StringIndex:
-		return *stringPool.GetStringPointer(fvalue.(uint32))
+		stringItem := *stringPool.GetStringPointer(fvalue.(uint32))
+		return stringItem
 	case types.Bool:
 		// Special handling for boolean.
 		if flagStatic {
@@ -116,7 +137,7 @@ func fmtHelper(field Field, className string, fieldName string) string {
 			if len(bytes) < 1 {
 				return "<byte array of zero length>"
 			}
-			return fmt.Sprintf("% x", bytes)
+			return fmt.Sprintf("% 02x", bytes)
 		}
 	}
 

--- a/src/object/format_test.go
+++ b/src/object/format_test.go
@@ -209,7 +209,7 @@ func TestFmtHelper(t *testing.T) {
 
 	// String, unexpectedly using string.
 	// debug: stringPool.DumpStringPool("format_test.go-TestFmtHelper")
-	fld = Field{types.StringIndex, globals.StringIndexString}
+	fld = Field{types.StringIndex, types.StringPoolStringIndex}
 	str = fmtHelper(fld, className, fieldName)
 	if str != types.StringClassName {
 		t.Errorf("TestFmtHelper: expected fmtHelper to return \"%s\", got \"%v\"", types.StringClassName, str)

--- a/src/object/format_test.go
+++ b/src/object/format_test.go
@@ -11,6 +11,7 @@ import (
 	"jacobin/stringPool"
 	"jacobin/types"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -155,5 +156,123 @@ func TestFormatField(t *testing.T) {
 	t.Log("Will try FormatField again.")
 	str = obj.FormatField("Fred")
 	t.Log(str)
+
+}
+
+// used instead of throwing an exception, which creates a circularity problem
+func _formatCycleKiller(_ int, _ string) bool {
+	return true
+}
+
+func TestFmtHelper(t *testing.T) {
+	globals.InitGlobals("test")
+	globals.GetGlobalRef().FuncThrowException = _formatCycleKiller
+	className := filepath.FromSlash("java/lang/madeUpClass")
+	fieldName := "Fred"
+
+	// String.
+	javaBytes := []types.JavaByte{'A', 'B', 'C'}
+	fld := Field{types.StringClassRef, javaBytes}
+	str := fmtHelper(fld, className, fieldName)
+	if !strings.Contains(str, "ABC") {
+		t.Errorf("TestFmtHelper: expected fmtHelper to return \"ABC\", got \"%v\"", str)
+	}
+
+	// Static String.
+	fld = Field{types.Static + types.StringClassRef, javaBytes}
+	str = fmtHelper(fld, className, fieldName)
+	if !strings.Contains(str, "ABC") && !strings.Contains(str, "static") {
+		t.Errorf("TestFmtHelper: expected fmtHelper to return \"ABC\", got \"%v\"", str)
+	}
+
+	// String, unexpectedly using []byte.
+	bites := []byte{'A', 'B', 'C'}
+	fld = Field{types.StringClassRef, bites}
+	str = fmtHelper(fld, className, fieldName)
+	if !strings.Contains(str, "ABC") {
+		t.Errorf("TestFmtHelper: expected fmtHelper to return \"ABC\", got \"%v\"", str)
+	}
+
+	// String, unexpectedly using *[]byte.
+	fld = Field{types.StringClassRef, &bites}
+	str = fmtHelper(fld, className, fieldName)
+	if !strings.Contains(str, "ABC") {
+		t.Errorf("TestFmtHelper: expected fmtHelper to return \"ABC\", got \"%v\"", str)
+	}
+
+	// String, unexpectedly using string.
+	fld = Field{types.StringClassRef, "ABC"}
+	str = fmtHelper(fld, className, fieldName)
+	if !strings.Contains(str, "ABC") {
+		t.Errorf("TestFmtHelper: expected fmtHelper to return \"ABC\", got \"%v\"", str)
+	}
+
+	// String, unexpectedly using string.
+	// debug: stringPool.DumpStringPool("format_test.go-TestFmtHelper")
+	fld = Field{types.StringIndex, globals.StringIndexString}
+	str = fmtHelper(fld, className, fieldName)
+	if str != types.StringClassName {
+		t.Errorf("TestFmtHelper: expected fmtHelper to return \"%s\", got \"%v\"", types.StringClassName, str)
+	}
+
+	// Primitive integer.
+	fld = Field{types.Int, int64(42)}
+	str = fmtHelper(fld, className, fieldName)
+	if str != "42" {
+		t.Errorf("TestFmtHelper: expected fmtHelper to return \"42\", got \"%v\"", str)
+	}
+
+	// Primitive static long.
+	fld = Field{types.StaticLong, int64(42)}
+	str = fmtHelper(fld, className, fieldName)
+	if !strings.Contains(str, "42") && !strings.Contains(str, "static") {
+		t.Errorf("TestFmtHelper: expected fmtHelper to return STATIC \"42\", got \"%v\"", str)
+	}
+
+	// Primitive boolean.
+	fld = Field{types.Bool, types.JavaBoolTrue}
+	str = fmtHelper(fld, className, fieldName)
+	if str != "true" {
+		t.Errorf("TestFmtHelper: expected fmtHelper to return \"true\", got \"%v\"", str)
+	}
+
+	// Primitive boolean, unexpected Go bool.
+	fld = Field{types.Bool, true}
+	str = fmtHelper(fld, className, fieldName)
+	if str != "true" {
+		t.Errorf("TestFmtHelper: expected fmtHelper to return \"true\", got \"%v\"", str)
+	}
+
+	// Primitive byte array.
+	bites = []byte{'A', 'B', 'C'}
+	fld = Field{types.ByteArray, bites}
+	str = fmtHelper(fld, className, fieldName)
+	if str != "41 42 43" {
+		t.Errorf("TestFmtHelper: expected fmtHelper to return \"41 42 43\", got \"%v\"", str)
+	}
+
+	// Primitive byte array pointer.
+	bites = []byte{'A', 'B', 'C'}
+	fld = Field{types.ByteArray, &bites}
+	str = fmtHelper(fld, className, fieldName)
+	if str != "41 42 43" {
+		t.Errorf("TestFmtHelper: expected fmtHelper to return \"41 42 43\", got \"%v\"", str)
+	}
+
+	// Primitive byte array, wrong format.
+	jb := []types.JavaByte{1, 2, 3}
+	fld = Field{types.ByteArray, jb}
+	str = fmtHelper(fld, className, fieldName)
+	if !strings.Contains(str, "but value is of type") {
+		t.Errorf("TestFmtHelper: expected fmtHelper to return \"but value is of type\", got \"%v\"", str)
+	}
+
+	// Primitive byte array, length=0.
+	bites = []byte{}
+	fld = Field{types.ByteArray, bites}
+	str = fmtHelper(fld, className, fieldName)
+	if !strings.Contains(str, "array of zero") {
+		t.Errorf("TestFmtHelper: expected fmtHelper to return \"array of zero\", got \"%v\"", str)
+	}
 
 }

--- a/src/object/string.go
+++ b/src/object/string.go
@@ -141,6 +141,12 @@ func GoStringFromStringPoolIndex(index uint32) string {
 	}
 }
 
+// StringPoolIndexFromGoString: derive a string pool index based on the Go String of a class name.
+func StringPoolIndexFromGoString(arg string) uint32 {
+	obj := StringObjectFromGoString(arg)
+	return StringPoolIndexFromStringObject(obj)
+}
+
 // StringObjectFromStringPoolIndex: convenience method to create a string object using a string pool index
 func StringObjectFromPoolIndex(index uint32) *Object {
 	if index < stringPool.GetStringPoolSize() {

--- a/src/statics/statics.go
+++ b/src/statics/statics.go
@@ -133,6 +133,10 @@ func GetStaticValue(className string, fieldName string) any {
 	// was this static field previously loaded? Is so, get its location and move on.
 	prevLoaded, ok := Statics[staticName]
 	if !ok {
+		/*
+			An error is returned only in test mode.
+			In non-test mode, the exception is thrown and the JVM shuts down.
+		*/
 		glob := globals.GetGlobalRef()
 		glob.ErrorGoStack = string(debug.Stack())
 		errMsg := fmt.Sprintf("GetStaticValue: could not find static: %s", staticName)

--- a/src/statics/statics.go
+++ b/src/statics/statics.go
@@ -124,7 +124,7 @@ func LoadStaticsString() {
 // GetStaticValue: Given the class name and field name,
 // return the field contents.
 // If successful, return the field value and a nil error;
-// Else (error), return a nil field value and the non-nil error.
+// Else (error), return errors.New(errMsg).
 func GetStaticValue(className string, fieldName string) any {
 	var retValue any
 


### PR DESCRIPTION
gfunction
* jj_test.go - TestJjStringifyScalar_RefNonNull: InitGlobals("test").

jvm
* runUtils.go - JACOBIN-683 getSuperclasses() failed to diagnose nil return from MethAreaFetch.
* runUtils_test.go - JACOBIN-680 expanded coverage for runUtils.go to 80%.

object
* format.go - handle JavaByte arrays better.
* format_test.go 
   - JACOBIN-687 TestFmtHelper(). Expanded coverage to 75%.
   - JACOBIN-684 avoid GetStaticValue crash by setting up globals.FuncThrowException.
* string.go - new func: StringPoolIndexFromGoString.

statics
* statics.go - correct comments.