### PR TITLE
JACOBIN-698 (Properties), JACOBIN-699 (NOP SystemManager)

### DIFF
--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -145,6 +145,7 @@ func MTableLoadGFunctions(MTable *classloader.MT) {
 	Load_Util_Hash_Map()
 	Load_Util_HexFormat()
 	Load_Util_Locale()
+	Load_Util_Properties()
 	Load_Util_Objects()
 	Load_Util_Random()
 	Load_Util_Zip_Adler32()

--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -144,6 +144,7 @@ func MTableLoadGFunctions(MTable *classloader.MT) {
 	Load_Util_Concurrent_Atomic_AtomicInteger()
 	Load_Util_Concurrent_Atomic_Atomic_Long()
 	Load_Util_Hash_Map()
+	Load_Util_Hash_Set()
 	Load_Util_HexFormat()
 	Load_Util_Locale()
 	Load_Util_Properties()

--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -120,6 +120,7 @@ func MTableLoadGFunctions(MTable *classloader.MT) {
 	Load_Lang_Math()
 	Load_Lang_Object()
 	Load_Lang_Runtime()
+	Load_Lang_SecurityManager()
 	Load_Lang_Short()
 	Load_Lang_StackTraceELement()
 	Load_Lang_String()

--- a/src/gfunction/javaLangBoolean.go
+++ b/src/gfunction/javaLangBoolean.go
@@ -103,8 +103,9 @@ func Load_Lang_Boolean() {
 func booleanBooleanValue(params []interface{}) interface{} {
 	// Try for a Boolean object.
 	obj, ok := params[0].(*object.Object)
-	if !ok {
-		errMsg := fmt.Sprintf("booleanBooleanValue: The parameter is neither String nor boolean: %T", params[0])
+	if !ok || obj == nil {
+		errMsg := fmt.Sprintf("booleanBooleanValue: Boolean parameter is neither nil or an invalid object: {%T, %v}",
+			params[0], params[0])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -142,7 +143,12 @@ func booleanBooleanValue(params []interface{}) interface{} {
 func booleanGetBoolean(params []interface{}) interface{} {
 
 	// Get the property name and validate it.
-	obj := params[0].(*object.Object)
+	obj, ok := params[0].(*object.Object)
+	if !ok || obj == nil {
+		errMsg := fmt.Sprintf("booleanGetBoolean: Boolean parameter is neither nil or an invalid object: {%T, %v}",
+			params[0], params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
 	fld, ok := obj.FieldTable["value"]
 	if !ok {
 		errMsg := "booleanGetBoolean: Missing the \"value\" field"

--- a/src/gfunction/javaLangSecurityManager.go
+++ b/src/gfunction/javaLangSecurityManager.go
@@ -1,0 +1,183 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2023 by  the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package gfunction
+
+import (
+	"jacobin/excNames"
+	"jacobin/object"
+	"jacobin/trace"
+	"jacobin/types"
+)
+
+// TODO: Delete this file and the reference to Load_Lang_SecurityManager() in gfunction.go
+// TODO: and javaLangSystem.go when the Java library stops using the SecurityManager class.
+
+func Load_Lang_SecurityManager() {
+
+	MethodSignatures["java/lang/SecurityManager.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  clinitGeneric,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.<init>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  secmgrInit,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkAccept(Ljava/lang/String;I)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkAccess(Ljava/lang/Thread)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkAccess(Ljava/lang/ThreadGroup)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkConnect(Ljava/lang/String;I)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkConnect(Ljava/lang/String;ILjava/lang/Object;)V"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkCreateClassLoader()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkDelete(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkExec(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkExit(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkLink(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkListen(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkMulticast(Ljava/net/InetAddress;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkPackageAccess(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkPackageDefinition(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkPermission(Ljava/security/Permission;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkPrintJobAccess()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkPropertiesAccess()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkPropertyAccess(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkRead(Ljava/io/FileDescriptor;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkRead(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkRead(Ljava/lang/String;Ljava/lang/Object;)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkWrite(Ljava/io/FileDescriptor;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/SecurityManager.checkWrite(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+}
+
+func secmgrInit(params []interface{}) interface{} {
+	obj, ok := params[0].(*object.Object)
+	if !ok {
+		errMsg := "secmgrInit: SecurityManager parameter is not an object"
+		trace.Error(errMsg)
+		return getGErrBlk(excNames.VirtualMachineError, errMsg)
+	}
+	fld := object.Field{Ftype: types.Int, Fvalue: 42}
+	obj.FieldTable["value"] = fld
+	return nil
+}

--- a/src/gfunction/javaLangSystem.go
+++ b/src/gfunction/javaLangSystem.go
@@ -100,7 +100,7 @@ func Load_Lang_System() {
 	MethodSignatures["java/lang/System.getSecurityManager()Ljava/lang/SecurityManager;"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  returnNullObject,
+			GFunction:  systemGetSecurityManager,
 		}
 
 	MethodSignatures["java/lang/System.allowSecurityManager()Z"] =
@@ -332,6 +332,11 @@ func forceGC([]interface{}) interface{} {
 func systemGetenv(params []interface{}) interface{} {
 	key := object.GoStringFromStringObject(params[0].(*object.Object))
 	return object.StringObjectFromGoString(os.Getenv(key))
+}
+
+// Get the fake SecurityManager.
+func systemGetSecurityManager(params []interface{}) interface{} {
+	return object.MakePrimitiveObject("java/lang/SecurityManager", types.Int, 42)
 }
 
 // Get a property

--- a/src/gfunction/javaUtilHashMap.go
+++ b/src/gfunction/javaUtilHashMap.go
@@ -173,11 +173,11 @@ func _getKey(param interface{}) (interface{}, bool) {
 	if object.IsStringObject(keyObj) {
 		return object.GoStringFromStringObject(keyObj), true
 	}
-	fvalue := keyObj.FieldTable[fieldNameMap].Fvalue
+	fvalue := keyObj.FieldTable[fieldNameValue].Fvalue
 	switch fvalue.(type) {
 	case int64, float64:
 	default:
-		ftype := keyObj.FieldTable[fieldNameMap].Ftype
+		ftype := keyObj.FieldTable[fieldNameValue].Ftype
 		errMsg := fmt.Sprintf("HashMap:_getKey: Unsupported key type: {Ftype: %s, Fvalue: %T}", ftype, fvalue)
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg), false
 	}

--- a/src/gfunction/javaUtilHashMap.go
+++ b/src/gfunction/javaUtilHashMap.go
@@ -155,6 +155,7 @@ func hashmapInit(params []interface{}) interface{} {
 	defer hashmapMutex.Unlock()
 	nilMap := make(types.DefHashMap)
 	obj := params[0].(*object.Object)
+	obj.KlassName = object.StringPoolIndexFromGoString(classNameHashMap)
 	fld := obj.FieldTable[fieldNameMap]
 	fld.Ftype = types.HashMap
 	fld.Fvalue = nilMap

--- a/src/gfunction/javaUtilHashMap.go
+++ b/src/gfunction/javaUtilHashMap.go
@@ -15,6 +15,10 @@ import (
 	"sync"
 )
 
+var classNameHashMap = "java/util/HashMap"
+var hashmapMutex = sync.RWMutex{}
+var fieldNameMap = "map"
+
 func Load_Util_Hash_Map() {
 
 	MethodSignatures["java/util/HashMap.<clinit>()V"] =
@@ -145,36 +149,34 @@ func Load_Util_Hash_Map() {
 
 }
 
-var classNameHashMap = "java/util/HashMap"
-var hashmapMutex = sync.RWMutex{}
-
-// Initialise a hash map empty.
+// Initialise a hash map object to an empty state.
 func hashmapInit(params []interface{}) interface{} {
 	hashmapMutex.Lock()
 	defer hashmapMutex.Unlock()
 	nilMap := make(types.DefHashMap)
 	obj := params[0].(*object.Object)
-	fld := obj.FieldTable["value"]
+	fld := obj.FieldTable[fieldNameMap]
 	fld.Ftype = types.HashMap
 	fld.Fvalue = nilMap
-	obj.FieldTable["value"] = fld
+	obj.FieldTable[fieldNameMap] = fld
 	return nil
 }
 
+// An internal function to extract the HashMap key field value.
 func _getKey(param interface{}) (interface{}, bool) {
 	keyObj, ok := param.(*object.Object)
-	if !ok {
+	if !ok || keyObj == nil {
 		errMsg := "HashMap:_getKey: Key parameter is not an object"
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg), false
 	}
 	if object.IsStringObject(keyObj) {
 		return object.GoStringFromStringObject(keyObj), true
 	}
-	fvalue := keyObj.FieldTable["value"].Fvalue
+	fvalue := keyObj.FieldTable[fieldNameMap].Fvalue
 	switch fvalue.(type) {
 	case int64, float64:
 	default:
-		ftype := keyObj.FieldTable["value"].Ftype
+		ftype := keyObj.FieldTable[fieldNameMap].Ftype
 		errMsg := fmt.Sprintf("HashMap:_getKey: Unsupported key type: {Ftype: %s, Fvalue: %T}", ftype, fvalue)
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg), false
 	}
@@ -192,7 +194,7 @@ func hashmapPut(params []interface{}) interface{} {
 	}
 
 	this, ok := params[0].(*object.Object)
-	if !ok {
+	if !ok || this == nil {
 		errMsg := "hashmapPut: HashMap parameter is not an object"
 		return getGErrBlk(excNames.ClassCastException, errMsg)
 	}
@@ -212,7 +214,7 @@ func hashmapPut(params []interface{}) interface{} {
 	value := params[2]
 
 	// Get the current hash map.
-	fld := this.FieldTable["value"]
+	fld := this.FieldTable[fieldNameMap]
 	hm, ok := fld.Fvalue.(types.DefHashMap)
 	if !ok {
 		errMsg := "hashmapPut: HashMap parameter is missing its \"value\" field"
@@ -228,7 +230,7 @@ func hashmapPut(params []interface{}) interface{} {
 	// Store the new key-value pair in the hash map.
 	hm[key] = value
 	fld.Fvalue = hm
-	this.FieldTable["value"] = fld
+	this.FieldTable[fieldNameMap] = fld
 
 	// Return the previous value for that key.
 	return prevValue
@@ -242,7 +244,7 @@ func hashmapGet(params []interface{}) interface{} {
 	}
 
 	this, ok := params[0].(*object.Object)
-	if !ok {
+	if !ok || this == nil {
 		errMsg := "hashmapGet: The first parameter is not an object"
 		return getGErrBlk(excNames.ClassCastException, errMsg)
 	}
@@ -259,7 +261,7 @@ func hashmapGet(params []interface{}) interface{} {
 	}
 
 	// Get the current hash map.
-	fld := this.FieldTable["value"]
+	fld := this.FieldTable[fieldNameMap]
 	hm, ok := fld.Fvalue.(types.DefHashMap)
 	if !ok {
 		errMsg := "hashmapGet: The HashMap is not present"
@@ -286,7 +288,7 @@ func hashmapRemove(params []interface{}) interface{} {
 	}
 
 	this, ok := params[0].(*object.Object)
-	if !ok {
+	if !ok || this == nil {
 		errMsg := "hashmapRemove: The first parameter is not an object"
 		return getGErrBlk(excNames.ClassCastException, errMsg)
 	}
@@ -303,7 +305,7 @@ func hashmapRemove(params []interface{}) interface{} {
 	}
 
 	// Get the current hash map.
-	fld := this.FieldTable["value"]
+	fld := this.FieldTable[fieldNameMap]
 	hm, ok := fld.Fvalue.(types.DefHashMap)
 	if !ok {
 		errMsg := "hashmapRemove: The HashMap is not present"
@@ -327,7 +329,7 @@ func hashmapRemove(params []interface{}) interface{} {
 func hashmapSize(params []interface{}) interface{} {
 
 	this, ok := params[0].(*object.Object)
-	if !ok {
+	if !ok || this == nil {
 		errMsg := "hashmapSize: The first parameter is not an object"
 		return getGErrBlk(excNames.ClassCastException, errMsg)
 	}
@@ -338,7 +340,7 @@ func hashmapSize(params []interface{}) interface{} {
 	}
 
 	// Get the current hash map.
-	fld := this.FieldTable["value"]
+	fld := this.FieldTable[fieldNameMap]
 	hm, ok := fld.Fvalue.(types.DefHashMap)
 	if !ok {
 		errMsg := "hashmapSize: The HashMap is not present"
@@ -359,7 +361,7 @@ func hashmapPutAll(params []interface{}) interface{} {
 	}
 
 	this, ok := params[0].(*object.Object)
-	if !ok {
+	if !ok || this == nil {
 		errMsg := "hashmapPutAll: The first parameter is not an object"
 		return getGErrBlk(excNames.ClassCastException, errMsg)
 	}
@@ -370,7 +372,7 @@ func hashmapPutAll(params []interface{}) interface{} {
 	}
 
 	// Get the hash map from this.
-	thisFld := this.FieldTable["value"]
+	thisFld := this.FieldTable[fieldNameMap]
 	thisHmap, ok := thisFld.Fvalue.(types.DefHashMap)
 	if !ok {
 		errMsg := "hashmapPutAll: The HashMap is not present in the 1st parameter"
@@ -389,7 +391,7 @@ func hashmapPutAll(params []interface{}) interface{} {
 	}
 
 	// Get the hash map from that.
-	thatFld := that.FieldTable["value"]
+	thatFld := that.FieldTable[fieldNameMap]
 	thatHmap, ok := thatFld.Fvalue.(types.DefHashMap)
 	if !ok {
 		errMsg := "hashmapPutAll: The HashMap is not present in the 2nd parameter"
@@ -411,7 +413,7 @@ func hashmapContainsKey(params []interface{}) interface{} {
 	}
 
 	this, ok := params[0].(*object.Object)
-	if !ok {
+	if !ok || this == nil {
 		errMsg := "hashmapContainsKey: The first parameter is not an object"
 		return getGErrBlk(excNames.ClassCastException, errMsg)
 	}
@@ -428,7 +430,7 @@ func hashmapContainsKey(params []interface{}) interface{} {
 	}
 
 	// Get the current hash map.
-	fld := this.FieldTable["value"]
+	fld := this.FieldTable[fieldNameMap]
 	hm, ok := fld.Fvalue.(types.DefHashMap)
 	if !ok {
 		errMsg := "hashmapContainsKey: The HashMap is not present"

--- a/src/gfunction/javaUtilHashMap.go
+++ b/src/gfunction/javaUtilHashMap.go
@@ -164,7 +164,7 @@ func hashmapInit(params []interface{}) interface{} {
 func _getKey(param interface{}) (interface{}, bool) {
 	keyObj, ok := param.(*object.Object)
 	if !ok {
-		errMsg := "HashMap:_getKey: The key is not an object"
+		errMsg := "HashMap:_getKey: Key parameter is not an object"
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg), false
 	}
 	if object.IsStringObject(keyObj) {
@@ -174,7 +174,8 @@ func _getKey(param interface{}) (interface{}, bool) {
 	switch fvalue.(type) {
 	case int64, float64:
 	default:
-		errMsg := fmt.Sprintf("HashMap:_getKey: Unsupported key type: %T", fvalue)
+		ftype := keyObj.FieldTable["value"].Ftype
+		errMsg := fmt.Sprintf("HashMap:_getKey: Unsupported key type: {Ftype: %s, Fvalue: %T}", ftype, fvalue)
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg), false
 	}
 	return fvalue, true
@@ -192,12 +193,12 @@ func hashmapPut(params []interface{}) interface{} {
 
 	this, ok := params[0].(*object.Object)
 	if !ok {
-		errMsg := "hashmapPut: The first parameter is not an object"
+		errMsg := "hashmapPut: HashMap parameter is not an object"
 		return getGErrBlk(excNames.ClassCastException, errMsg)
 	}
 
 	if *stringPool.GetStringPointer(this.KlassName) != classNameHashMap {
-		errMsg := "hashmapPut: The object is not a HashMap"
+		errMsg := "hashmapPut: HashMap parameter is not a HashMap"
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -214,7 +215,7 @@ func hashmapPut(params []interface{}) interface{} {
 	fld := this.FieldTable["value"]
 	hm, ok := fld.Fvalue.(types.DefHashMap)
 	if !ok {
-		errMsg := "hashmapPut: The HashMap is not present"
+		errMsg := "hashmapPut: HashMap parameter is missing its \"value\" field"
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 

--- a/src/gfunction/javaUtilHashSet.go
+++ b/src/gfunction/javaUtilHashSet.go
@@ -1,0 +1,337 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2023 by  the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package gfunction
+
+import (
+	"fmt"
+	"jacobin/excNames"
+	"jacobin/object"
+	"jacobin/stringPool"
+	"jacobin/types"
+	"jacobin/util"
+	"strconv"
+)
+
+var classNameObject = "java/lang/Object"
+
+func Load_Util_Hash_Set() {
+
+	MethodSignatures["java/util/HashSet.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  clinitGeneric,
+		}
+
+	MethodSignatures["java/util/HashSet.<init>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  hashmapInit,
+		}
+
+	MethodSignatures["java/util/HashSet.<init>(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  hashmapInit,
+		}
+
+	MethodSignatures["java/util/HashSet.<init>(IF)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  hashmapInit,
+		}
+
+	MethodSignatures["java/util/HashSet.add(Ljava/lang/Object;)Z"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  hashsetAdd,
+		}
+
+	MethodSignatures["java/util/HashSet.addAll(Ljava/util/Collection;)Z"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/HashSet.clear()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  hashmapInit,
+		}
+
+	MethodSignatures["java/util/HashSet.clone()Ljava/lang/Object;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  hashmapInit,
+		}
+
+	MethodSignatures["java/util/HashSet.contains(Ljava/lang/Object;)Z"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  hashsetContains,
+		}
+
+	MethodSignatures["java/util/HashSet.containsAll(Ljava/util/Collection;)Z"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/HashSet.isEmpty()Z"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  hashsetIsEmpty,
+		}
+
+	MethodSignatures["java/util/HashSet.iterator()Ljava/util/Iterator;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/HashSet.newHashSet(I)Ljava/util/HashSet;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  hashmapInit,
+		}
+
+	MethodSignatures["java/util/HashSet.remove(Ljava/lang/Object;)Z"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  hashsetRemove,
+		}
+
+	MethodSignatures["java/util/HashSet.removeAll(Ljava/util/Collection;)Z"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/HashSet.retainAll(Ljava/util/Collection;)Z"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/HashSet.size()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  hashmapSize,
+		}
+
+	MethodSignatures["java/util/HashSet.spliterator()Ljava/util/Spliterator;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/HashSet.toArray()[Ljava/lang/Object;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  hashsetToArray,
+		}
+
+	MethodSignatures["java/util/HashSet.toArray([Ljava/lang/Object;)[Ljava/lang/Object;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+}
+
+// Compute the hash of the object being added to the HashSet.
+// Is it already present? Remember for later.
+// Use HashMap.put to add key=hash, value=parameter.
+// Return true if this entry did not previously exist; else return false.
+func hashsetAdd(params []interface{}) interface{} {
+
+	// Validate HashSet object parameter.
+	this, ok := params[0].(*object.Object)
+	if !ok || this == nil {
+		errMsg := "hashsetAdd: HashSet parameter is nil or not an object"
+		return getGErrBlk(excNames.ClassCastException, errMsg)
+	}
+
+	// It must be a HashMap object.
+	if *stringPool.GetStringPointer(this.KlassName) != classNameHashMap {
+		errMsg := "hashsetAdd: HashSet parameter is not a HashMap object"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Get argument to add.
+	that, ok := params[1].(*object.Object)
+	if !ok || that == nil {
+		errMsg := "hashsetAdd: Argument parameter is nil or not an object"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Hash the argument.
+	hashedUint64, err := util.HashAnything(*that)
+	if err != nil {
+		errMsg := fmt.Sprintf("hashsetAdd: util.HashAnything failed, err: %v", err)
+		return getGErrBlk(excNames.VirtualMachineError, errMsg)
+	}
+	hashedString := strconv.FormatUint(hashedUint64, 10)
+
+	// Remember whether the key already exists.
+	flagReturn := types.JavaBoolTrue // Assume not existing yet.
+	fld := this.FieldTable[fieldNameMap]
+	hm, ok := fld.Fvalue.(types.DefHashMap)
+	if !ok {
+		errMsg := "hashsetAdd: HashMap is not present"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	_, exists := hm[hashedString]
+	if exists {
+		flagReturn = types.JavaBoolFalse
+	}
+
+	// Add this argument.
+	var extparams = new([]interface{})
+	key := object.StringObjectFromGoString(hashedString)
+	*extparams = append(*extparams, this)
+	*extparams = append(*extparams, key)
+	*extparams = append(*extparams, that)
+	result := hashmapPut(*extparams)
+	switch result.(type) {
+	case *GErrBlk:
+		return result
+	}
+
+	return flagReturn
+}
+
+// Remove a hash set entry. Return true if something was actually removed; else return false.
+func hashsetRemove(params []interface{}) interface{} {
+	// Validate HashSet object parameter.
+	this, ok := params[0].(*object.Object)
+	if !ok || this == nil {
+		errMsg := "hashsetRemove: HashSet parameter is nil or not an object"
+		return getGErrBlk(excNames.ClassCastException, errMsg)
+	}
+
+	// It must be a HashMap object.
+	if *stringPool.GetStringPointer(this.KlassName) != classNameHashMap {
+		errMsg := "hashsetRemove: HashSet parameter is not a HashMap object"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Get argument to remove.
+	that, ok := params[1].(*object.Object)
+	if !ok || that == nil {
+		errMsg := "hashsetRemove: Argument parameter is nil or not an object"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Hash the argument.
+	hashedUint64, err := util.HashAnything(*that)
+	if err != nil {
+		errMsg := fmt.Sprintf("hashsetRemove: util.HashAnything failed, err: %v", err)
+		return getGErrBlk(excNames.VirtualMachineError, errMsg)
+	}
+	hashedString := strconv.FormatUint(hashedUint64, 10)
+
+	// Remove this argument.
+	var extparams = new([]interface{})
+	key := object.StringObjectFromGoString(hashedString)
+	*extparams = append(*extparams, this)
+	*extparams = append(*extparams, key)
+	result := hashmapRemove(*extparams)
+	switch result.(type) {
+	case *GErrBlk:
+		return result
+	}
+
+	if result == object.Null {
+		return types.JavaBoolFalse
+	}
+	return types.JavaBoolTrue
+}
+
+// Does the hash map Have the given key?
+func hashsetContains(params []interface{}) interface{} {
+	// Validate HashSet object parameter.
+	this, ok := params[0].(*object.Object)
+	if !ok || this == nil {
+		errMsg := "hashsetContains: HashSet parameter is nil or not an object"
+		return getGErrBlk(excNames.ClassCastException, errMsg)
+	}
+
+	// It must be a HashMap object.
+	if *stringPool.GetStringPointer(this.KlassName) != classNameHashMap {
+		errMsg := "hashsetContains: HashSet parameter is not a HashMap object"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Get argument to look for.
+	that, ok := params[1].(*object.Object)
+	if !ok || that == nil {
+		errMsg := "hashsetContains: Argument parameter is nil or not an object"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Hash the argument.
+	hashedUint64, err := util.HashAnything(*that)
+	if err != nil {
+		errMsg := fmt.Sprintf("hashsetContains: util.HashAnything failed, err: %v", err)
+		return getGErrBlk(excNames.VirtualMachineError, errMsg)
+	}
+	hashedString := strconv.FormatUint(hashedUint64, 10)
+
+	// Do the search.
+	var extparams = new([]interface{})
+	key := object.StringObjectFromGoString(hashedString)
+	*extparams = append(*extparams, this)
+	*extparams = append(*extparams, key)
+	return hashmapContainsKey(*extparams)
+}
+
+func hashsetIsEmpty(params []interface{}) interface{} {
+
+	result := hashmapSize(params)
+	switch result.(type) {
+	case *GErrBlk:
+		return result
+	}
+
+	if result == 0 {
+		return types.JavaBoolTrue
+	}
+	return types.JavaBoolFalse
+}
+
+func hashsetToArray(params []interface{}) interface{} {
+
+	// Validate HashSet object parameter.
+	this, ok := params[0].(*object.Object)
+	if !ok || this == nil {
+		errMsg := "hashsetToArray: HashSet parameter is nil or not an object"
+		return getGErrBlk(excNames.ClassCastException, errMsg)
+	}
+
+	// It must be a HashMap object.
+	if *stringPool.GetStringPointer(this.KlassName) != classNameHashMap {
+		errMsg := "hashsetToArray: HashSet parameter is not a HashMap object"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Get the current hash map.
+	fld := this.FieldTable[fieldNameMap]
+	hm, ok := fld.Fvalue.(types.DefHashMap)
+	if !ok {
+		errMsg := "hashsetToArray: HashMap field is not present"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Create an array of objects.
+	objArray := make([]any, 0, len(hm))
+	for _, value := range hm {
+		objArray = append(objArray, value)
+	}
+
+	return object.MakePrimitiveObject(classNameObject, types.RefArray, objArray)
+
+}

--- a/src/gfunction/javaUtilHashSet.go
+++ b/src/gfunction/javaUtilHashSet.go
@@ -297,7 +297,7 @@ func hashsetIsEmpty(params []interface{}) interface{} {
 		return result
 	}
 
-	if result == 0 {
+	if result.(int64) == 0 {
 		return types.JavaBoolTrue
 	}
 	return types.JavaBoolFalse
@@ -327,9 +327,9 @@ func hashsetToArray(params []interface{}) interface{} {
 	}
 
 	// Create an array of objects.
-	objArray := make([]any, 0, len(hm))
+	objArray := make([]*object.Object, 0, len(hm))
 	for _, value := range hm {
-		objArray = append(objArray, value)
+		objArray = append(objArray, value.(*object.Object))
 	}
 
 	return object.MakePrimitiveObject(classNameObject, types.RefArray, objArray)

--- a/src/gfunction/javaUtilProperties.go
+++ b/src/gfunction/javaUtilProperties.go
@@ -192,8 +192,8 @@ func propertiesInit(params []interface{}) interface{} {
 func propertiesGetProperty(params []interface{}) interface{} {
 	// Get properties table.
 	this, ok := params[0].(*object.Object)
-	if !ok {
-		errMsg := fmt.Sprintf("propertiesGetProperty: Properties object is invalid: %T", params[0])
+	if !ok || this == nil {
+		errMsg := fmt.Sprintf("propertiesGetProperty: Properties object is invalid: {type %T, value %v}", params[0], params[0])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	properties, ok := this.FieldTable[fieldNameProperties].Fvalue.(types.DefProperties)
@@ -205,7 +205,7 @@ func propertiesGetProperty(params []interface{}) interface{} {
 	// Get key.
 	keyObj, ok := params[1].(*object.Object)
 	if !ok {
-		errMsg := fmt.Sprintf("propertiesGetProperty: Key object is invalid: %T", params[1])
+		errMsg := fmt.Sprintf("propertiesGetProperty: Key object is invalid: {type %T, value %v}", params[1], params[1])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	key := object.GoStringFromStringObject(keyObj)
@@ -253,7 +253,7 @@ func propertiesRemove(params []interface{}) interface{} {
 	// Get properties table.
 	this, ok := params[0].(*object.Object)
 	if !ok {
-		errMsg := fmt.Sprintf("propertiesRemove: Properties object is invalid: %T", params[0])
+		errMsg := fmt.Sprintf("propertiesRemove: Properties object is invalid: {type %T, value %v}", params[0], params[0])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	fld, ok := this.FieldTable[fieldNameProperties]
@@ -266,7 +266,7 @@ func propertiesRemove(params []interface{}) interface{} {
 	// Get key.
 	keyObj, ok := params[1].(*object.Object)
 	if !ok {
-		errMsg := fmt.Sprintf("propertiesRemove: Key object is invalid: %T", params[1])
+		errMsg := fmt.Sprintf("propertiesRemove: Key object is invalid: {type %T, value %v}", params[1], params[1])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	key := object.GoStringFromStringObject(keyObj)
@@ -303,7 +303,7 @@ func propertiesSetProperty(params []interface{}) interface{} {
 	// Get properties table.
 	this, ok := params[0].(*object.Object)
 	if !ok {
-		errMsg := fmt.Sprintf("propertiesSetProperty: Properties object is invalid: %T", params[0])
+		errMsg := fmt.Sprintf("propertiesSetProperty: Properties object is invalid: {type %T, value %v}", params[0], params[0])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	fld, ok := this.FieldTable[fieldNameProperties]
@@ -316,7 +316,7 @@ func propertiesSetProperty(params []interface{}) interface{} {
 	// Get key.
 	keyObj, ok := params[1].(*object.Object)
 	if !ok {
-		errMsg := fmt.Sprintf("propertiesSetProperty: Key object is invalid: %T", params[1])
+		errMsg := fmt.Sprintf("propertiesSetProperty: Key object is invalid: {type %T, value %v}", params[1], params[1])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	key := object.GoStringFromStringObject(keyObj)
@@ -357,7 +357,7 @@ func propertiesSize(params []interface{}) interface{} {
 	// Get properties table.
 	this, ok := params[0].(*object.Object)
 	if !ok {
-		errMsg := fmt.Sprintf("propertiesSize: Properties object is invalid: %T", params[0])
+		errMsg := fmt.Sprintf("propertiesSize: Properties object is invalid: {type %T, value %v}", params[0], params[0])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	properties, ok := this.FieldTable[fieldNameProperties].Fvalue.(types.DefProperties)
@@ -377,7 +377,7 @@ func propertiesToString(params []interface{}) interface{} {
 	// Get properties table.
 	this, ok := params[0].(*object.Object)
 	if !ok {
-		errMsg := fmt.Sprintf("propertiesToString: Properties object is invalid: %T", params[0])
+		errMsg := fmt.Sprintf("propertiesToString: Properties object is invalid: {type %T, value %v}", params[0], params[0])
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	properties, ok := this.FieldTable[fieldNameProperties].Fvalue.(types.DefProperties)

--- a/src/gfunction/javaUtilProperties.go
+++ b/src/gfunction/javaUtilProperties.go
@@ -1,0 +1,408 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2023 by  the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package gfunction
+
+import (
+	"fmt"
+	"jacobin/excNames"
+	"jacobin/globals"
+	"jacobin/object"
+	"jacobin/types"
+	"sync"
+)
+
+// Implementation of some of the functions in Java/util/Locale.
+// Strategy: Locale = jacobin Object wrapping a Go string.
+
+func Load_Util_Properties() {
+
+	MethodSignatures["java/util/Properties.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  clinitGeneric,
+		}
+
+	MethodSignatures["java/util/Properties.<init>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  propertiesInit,
+		}
+
+	MethodSignatures["java/util/Properties.<init>(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  propertiesInit,
+		}
+
+	MethodSignatures["java/util/Properties.<init>(Ljava/util/Properties;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/Properties.clear()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  propertiesInit,
+		}
+
+	MethodSignatures["java/util/Properties.getProperty(Ljava/lang/String;)Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  propertiesGetProperty,
+		}
+
+	MethodSignatures["java/util/Properties.getProperty(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  propertiesGetProperty,
+		}
+
+	MethodSignatures["java/util/Properties.list(Ljava/io/PrintStream;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/Properties.list(Ljava/io/PrintWriter;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/Properties.load(Ljava/io/InputStream;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/Properties.load(Ljava/io/Reader;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/Properties.loadFromXML(Ljava/io/InputStream;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/Properties.propertyNames()Ljava/util/Enumeration;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/Properties.remove(Ljava/lang/Object;)Ljava/lang/Object;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  propertiesRemove,
+		}
+
+	MethodSignatures["java/util/Properties.save(Ljava/io/OutputStream;Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/Properties.setProperty(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  propertiesSetProperty,
+		}
+
+	MethodSignatures["java/util/Properties.size()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  propertiesSize,
+		}
+
+	MethodSignatures["java/util/Properties.store(Ljava/io/OutputStream;Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/Properties.store(Ljava/io/Writer;Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/Properties.storeToXML(Ljava/io/OutputStream;Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/Properties.storeToXML(Ljava/io/OutputStream;Ljava/lang/String;Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/Properties.storeToXML(Ljava/io/OutputStream;Ljava/lang/String;Ljava/nio/charset/Charset;)V"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/Properties.stringPropertyNames()Ljava/util/Set;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/Properties.toString()Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  propertiesToString,
+		}
+
+}
+
+var classNameProperties = "java/util/Properties"
+var fieldNameProperties = "map"
+var propertiesMutex = sync.RWMutex{}
+
+func propertiesInit(params []interface{}) interface{} {
+	propertiesMutex.Lock()
+	defer propertiesMutex.Unlock()
+
+	nilMap := make(types.DefProperties)
+	obj, ok := params[0].(*object.Object)
+	if !ok {
+		errMsg := fmt.Sprintf("Properties.<init>: Properties object is invalid: %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	object.ClearFieldTable(obj)
+	fld := obj.FieldTable[fieldNameProperties]
+	fld.Ftype = types.Properties
+	fld.Fvalue = nilMap
+	obj.FieldTable[fieldNameProperties] = fld
+	return nil
+}
+
+// Given a properties table and a key, retrieve the associated value.
+func propertiesGetProperty(params []interface{}) interface{} {
+	// Get properties table.
+	this, ok := params[0].(*object.Object)
+	if !ok {
+		errMsg := fmt.Sprintf("propertiesGetProperty: Properties object is invalid: %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	properties, ok := this.FieldTable[fieldNameProperties].Fvalue.(types.DefProperties)
+	if !ok {
+		errMsg := "propertiesGetProperty: Properties table is missing or invalid"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Get key.
+	keyObj, ok := params[1].(*object.Object)
+	if !ok {
+		errMsg := fmt.Sprintf("propertiesGetProperty: Key object is invalid: %T", params[1])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	key := object.GoStringFromStringObject(keyObj)
+	if len(key) == 0 {
+		errMsg := "propertiesGetProperty: Key parameter is not String or is null"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Get default value.
+	flagDefault := false
+	var dfltValue string
+	if len(params) > 2 {
+		dfltObj, ok := params[2].(*object.Object)
+		if ok {
+			dfltValue = object.GoStringFromStringObject(dfltObj)
+			if len(key) == 0 {
+				errMsg := "propertiesGetProperty: Default value parameter is not String or is null"
+				return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+			}
+			flagDefault = true
+		}
+	}
+
+	// Get value associated with key.
+	// If present, return it as a JavaString.
+	value, ok := properties[key]
+	if ok {
+		return object.StringObjectFromGoString(value)
+	}
+
+	// Value is not present.
+	// If default value supplied, return it.
+	// Otherwise, return null.
+	if flagDefault {
+		return object.StringObjectFromGoString(dfltValue)
+	}
+	return object.Null
+}
+
+// Given a properties table and a key, remove this entry.
+func propertiesRemove(params []interface{}) interface{} {
+	propertiesMutex.Lock()
+	defer propertiesMutex.Unlock()
+
+	// Get properties table.
+	this, ok := params[0].(*object.Object)
+	if !ok {
+		errMsg := fmt.Sprintf("propertiesRemove: Properties object is invalid: %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	fld, ok := this.FieldTable[fieldNameProperties]
+	if !ok {
+		errMsg := "propertiesRemove: Properties table is missing or invalid"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	properties := fld.Fvalue.(types.DefProperties)
+
+	// Get key.
+	keyObj, ok := params[1].(*object.Object)
+	if !ok {
+		errMsg := fmt.Sprintf("propertiesRemove: Key object is invalid: %T", params[1])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	key := object.GoStringFromStringObject(keyObj)
+	if len(key) == 0 {
+		errMsg := "propertiesRemove: Key parameter is not String or is null"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Return value.
+	flagReturnValue := false
+	oldValue, ok := properties[key]
+	if ok {
+		flagReturnValue = true
+	}
+
+	// Remove entry associated with key.
+	delete(properties, key)
+	fld.Fvalue = properties
+	this.FieldTable[fieldNameProperties] = fld
+
+	// If there was an old value, return it as a Java String.
+	// Otherwise, return null.
+	if flagReturnValue {
+		object.StringObjectFromGoString(oldValue)
+	}
+	return object.Null
+}
+
+// Given a properties table and a key, set its entry ith the specified value.
+func propertiesSetProperty(params []interface{}) interface{} {
+	propertiesMutex.Lock()
+	defer propertiesMutex.Unlock()
+
+	// Get properties table.
+	this, ok := params[0].(*object.Object)
+	if !ok {
+		errMsg := fmt.Sprintf("propertiesSetProperty: Properties object is invalid: %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	fld, ok := this.FieldTable[fieldNameProperties]
+	if !ok {
+		errMsg := "propertiesSetProperty: properties table is missing or invalid"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	properties := fld.Fvalue.(types.DefProperties)
+
+	// Get key.
+	keyObj, ok := params[1].(*object.Object)
+	if !ok {
+		errMsg := fmt.Sprintf("propertiesSetProperty: Key object is invalid: %T", params[1])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	key := object.GoStringFromStringObject(keyObj)
+	if len(key) == 0 {
+		errMsg := "propertiesGetProperty: Key parameter is not String or is null"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Get new value.
+	valueObj, ok := params[2].(*object.Object)
+	if !ok {
+		errMsg := "propertiesSetProperty: Value parameter is not an object"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	value := object.GoStringFromStringObject(valueObj)
+	if len(value) == 0 {
+		errMsg := "propertiesSetProperty: Value parameter is not String or is null"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Get old value if present.
+	oldValue, oldPresent := properties[key]
+
+	// Set entry key, value.
+	properties[key] = value
+	fld.Fvalue = properties
+	this.FieldTable[fieldNameProperties] = fld
+
+	// If there was an old value, return it. Otherwise, return Null.
+	if oldPresent {
+		return object.StringObjectFromGoString(oldValue)
+	}
+	return object.Null
+}
+
+// Given a properties table, compute the number of entries.
+func propertiesSize(params []interface{}) interface{} {
+	// Get properties table.
+	this, ok := params[0].(*object.Object)
+	if !ok {
+		errMsg := fmt.Sprintf("propertiesSize: Properties object is invalid: %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	properties, ok := this.FieldTable[fieldNameProperties].Fvalue.(types.DefProperties)
+	if !ok {
+		errMsg := "propertiesGetProperty: properties table is missing or invalid"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Return the number of entries.
+	return int64(len(properties))
+}
+
+// Given a properties table, return a string representation of this Properties object
+// in the form of a set of entries, enclosed in braces and separated by the ASCII characters " , " (comma and space).
+// Each entry is rendered as the key, an equals sign =, and the associated element.
+func propertiesToString(params []interface{}) interface{} {
+	// Get properties table.
+	this, ok := params[0].(*object.Object)
+	if !ok {
+		errMsg := fmt.Sprintf("propertiesToString: Properties object is invalid: %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	properties, ok := this.FieldTable[fieldNameProperties].Fvalue.(types.DefProperties)
+	if !ok {
+		errMsg := "propertiesToString: properties table is missing or invalid"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
+	// Create a slice of keys.
+	keys := make([]string, 0, len(properties))
+	for key := range properties {
+		keys = append(keys, key)
+	}
+
+	// Sort the keys, case-insensitive.
+	globals.SortCaseInsensitive(&keys)
+
+	// Build longString, consisting of key-value pairs.
+	var longString = "{"
+	for _, key := range keys {
+		value := properties[key]
+		longString += key + "=" + value + ", "
+	}
+	longString = longString[:len(longString)-2] + "}"
+
+	// Return longString as a Java String.
+	return object.StringObjectFromGoString(longString)
+}

--- a/src/go.mod
+++ b/src/go.mod
@@ -10,4 +10,7 @@ go 1.24.0
 
 require golang.org/x/term v0.17.0
 
-require golang.org/x/sys v0.17.0 // indirect
+require (
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	golang.org/x/sys v0.17.0 // indirect
+)

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,3 +1,5 @@
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
 golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.17.0 h1:mkTF7LCd6WGJNL3K1Ad7kwxNfYAW6a8a8QqtMblp/4U=

--- a/src/types/javaTypes.go
+++ b/src/types/javaTypes.go
@@ -46,7 +46,9 @@ const GolangString = "G"
 const FileHandle = "FH" // The related Fvalue is a Golang *os.File
 const BigInteger = "BI" // The related Fvalue is a Golang *big.Int
 const HashMap = "HM"    // The related Fvalue is a Golang map[interface{}]interface{}
+const Properties = "PT" // The related Fvalue is a Golang map[interface{}]interface{}
 type DefHashMap map[any]any
+type DefProperties map[string]string
 
 const Static = "X"
 const StaticDouble = "XD"

--- a/src/util/hashing.go
+++ b/src/util/hashing.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"math"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+// For any argument, compute and return a Base64-encoded hash (string).
+func HashAnything(arg interface{}) (uint64, error) {
+	digest := xxhash.New()
+	switch v := arg.(type) {
+	case int64:
+		barr := make([]byte, 8)
+		binary.LittleEndian.PutUint64(barr, uint64(v))
+		digest.Write(barr)
+	case float64:
+		barr := make([]byte, 8)
+		binary.LittleEndian.PutUint64(barr, math.Float64bits(v))
+		digest.Write(barr)
+	case []byte:
+		digest.Write(v)
+	default:
+		// Handle structs or other unknown types
+		jsonBytes, err := json.Marshal(arg)
+		if err != nil {
+			return 0, err
+		}
+		digest.Write(jsonBytes)
+	}
+	return digest.Sum64(), nil
+}

--- a/src/util/hashing_test.go
+++ b/src/util/hashing_test.go
@@ -1,0 +1,39 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2021-5 by the Jacobin authors. All rights reserved.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)
+ */
+
+package util
+
+import (
+	"testing"
+)
+
+func essai(t *testing.T, arg interface{}) {
+	value, err := HashAnything(arg)
+	if err != nil {
+		t.Errorf("TestHashPrimitives/essai: %v, err: %v", arg, err)
+		return
+	}
+	t.Logf("TestHashPrimitives/essai ok: %v --> %v", arg, value)
+}
+
+type tMisc struct {
+	ii int64
+	ff float64
+	bb [8]byte
+}
+
+func TestHashAnything(t *testing.T) {
+	for ix := 0; ix < 10; ix++ {
+		essai(t, ix)
+	}
+
+	essai(t, "a")
+	essai(t, "ab")
+	essai(t, "abc")
+
+	var misc tMisc = tMisc{42, 3.14159265, [8]byte{1, 2, 3, 4, 5, 6, 7, 8}}
+	essai(t, misc)
+}


### PR DESCRIPTION
JACOBIN-698
- modified: gfunction/javaUtilProperties.go - Add some additional evidence when things go astray.
- modified: types/javaTypes.go - Properties constructs.

JACOBIN-699
- new: gfunction/javaLangSecurityManager.go - a NOP, TODO: remove it and references in javaLangSystem.go and gfunction.go in the future when Java stops using it (deprecated but still in use).
- modified: gfunction/javaLangSystem.go - do not return nil for getSecurityManager().

JACOBIN-702
- new: gfunction/javaUtilHashSet.go - used HashMap for storage; key is a hash of the argument to HashSet.add.
- new: util/hashing.go - HashAnything().
- new: util/hashing_test.go - unit tests for HashAnything().
- modified: go.mod, and go.sum - incorporating github.com/cespare/xxhash/v2 in support of HashAnything().

Modified: gfunction/gfunction.go - added all the Load_X_Xs.
