### PR TITLE
new workflow, on demand, jacotest/jacobin

### DIFF
--- a/.github/workflows/run_platypusguy_jacobin.yml
+++ b/.github/workflows/run_platypusguy_jacobin.yml
@@ -1,0 +1,69 @@
+# On demand, this workflow will run jacotest against https://github.com/platypusguy/jacobin.
+
+name: Jacotest with platypusguy Jacobin
+
+on:
+  workflow_dispatch:  # This ensures the workflow runs only on demand.
+
+jobs:
+
+  run_jacobin:
+    strategy:
+      matrix:
+        
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@main
+
+    - name: Setup Go
+      uses: actions/setup-go@main
+      with:
+          go-version: '1.24.x'
+          cache: true
+          cache-dependency-path: "**/go.sum"
+          
+    - name: Setup for Linux or MacOS
+      run: |
+        echo "$HOME/go/bin" >> $GITHUB_PATH
+      shell: bash
+      if: runner.os != 'Windows'
+
+    - name: Setup for Windows
+      run: |
+        echo "%HOMEPATH%\go\bin" | Out-File -Append -FilePath $env:GITHUB_PATH
+      shell: powershell
+      if: runner.os == 'Windows'
+        
+    - name: Setup Jacotest
+      run: |
+        cd src
+        go get
+        go install -v .
+        cd ..
+        jacotest -h
+
+    - name: Setup Jacobin
+      run: |
+        git clone https://github.com/platypusguy/jacobin
+        cd jacobin/src
+        go get
+        go install -v ./...
+        cd ../..
+        jacobin --version
+        
+    - name: Setup JDK
+      uses: actions/setup-java@main
+      with:
+        distribution: 'oracle'
+        java-version: '21'
+
+    - name: Run Test Cases
+      run: |
+        java --version
+        javac --version
+        jacotest -c -x || true
+
+    - name: Summary of Results
+      run: |
+        jacotest -r 3


### PR DESCRIPTION
On demand, `workflows/run_platypusguy_jacobin.yml` will run jacotest against https://github.com/platypusguy/jacobin.
Testing jobs:
* jacotest -x (does not abort)
* jacotest -r 3