### PR TITLE
JACOBIN-705 <clinit> and <init> functions must always return nil

### DIFF
--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -69,12 +69,12 @@ func getGErrBlk(exceptionType int, errMsg string) *GErrBlk {
 
 // do-nothing Go function shared by several source files
 func clinitGeneric([]interface{}) interface{} {
-	return object.StringObjectFromGoString("clinitGeneric")
+	return nil
 }
 
 // do-nothing Go function shared by several source files
 func justReturn([]interface{}) interface{} {
-	return object.StringObjectFromGoString("justReturn")
+	return nil
 }
 
 // return a Java null object.

--- a/src/gfunction/javaLangRuntime.go
+++ b/src/gfunction/javaLangRuntime.go
@@ -123,7 +123,7 @@ func runtimeClinit([]interface{}) interface{} {
 		Type:  types.Ref + stringClassnameRuntime,
 		Value: obj,
 	})
-	return object.StringObjectFromGoString(stringClassnameRuntime)
+	return nil
 }
 
 // runtimeGetRuntime: Get the singleton Runtime object.

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -784,7 +784,7 @@ func stringClinit([]interface{}) interface{} {
 		return getGErrBlk(excNames.ClassNotLoadedException, errMsg)
 	}
 	klass.Data.ClInit = types.ClInitRun // just mark that String.<clinit>() has been run
-	return object.StringObjectFromGoString("stringClinit")
+	return nil
 }
 
 // Instantiate a new empty string - "java/lang/String.<init>()V"

--- a/src/gfunction/javaLangString_test.go
+++ b/src/gfunction/javaLangString_test.go
@@ -26,24 +26,18 @@ func TestStringClinit(t *testing.T) {
 		switch retval.(type) {
 		case *GErrBlk:
 			gErr := retval.(*GErrBlk)
-			if !strings.Contains(gErr.ErrMsg, "TestStringClinit: Could not find java/lang/String") {
-				classloader.MethAreaDump()
-				t.Errorf("TestStringClinit: Unexpected error message. got %s", gErr.ErrMsg)
-			}
-			if gErr.ExceptionType != excNames.ClassNotLoadedException {
-				t.Errorf("TestStringClinit: Unexpected exception type. got %d", gErr.ExceptionType)
-			}
+			t.Errorf("TestStringClinit: Unexpected GErrBlk error message. got %s", gErr.ErrMsg)
+			return
 		case *object.Object:
-			str := object.GoStringFromStringObject(retval.(*object.Object))
-			if str != "stringClinit" {
-				t.Errorf("TestStringClinit: Expected \"stringClinit\", observed %v", str)
-			}
+			className := object.GoStringFromStringPoolIndex(retval.(*object.Object).KlassName)
+			t.Errorf("TestStringClinit: Unexpected object, class name %s", className)
 			return
 		default:
-			t.Errorf("TestStringClinit: Did not get expected error message, got %v", retval)
+			t.Errorf("TestStringClinit: Unexpected return, got %T, %v", retval, retval)
+			return
 		}
 	}
-	t.Error("TestStringClinit: stringClinit() returned nil")
+	t.Log("TestStringClinit: stringClinit() returned nil as expected")
 }
 
 func TestStringToUpperCase(t *testing.T) {

--- a/src/gfunction/javaLangSystem.go
+++ b/src/gfunction/javaLangSystem.go
@@ -143,7 +143,7 @@ func systemClinit([]interface{}) interface{} {
 		_ = statics.AddStatic("java/lang/System.out", statics.Static{Type: "GS", Value: os.Stdout})
 		klass.Data.ClInit = types.ClInitRun
 	}
-	return object.StringObjectFromGoString("systemClinit")
+	return nil
 }
 
 // arrayCopy copies an array or subarray from one array to another, both of which must exist.

--- a/src/gfunction/javaLangSystem_test.go
+++ b/src/gfunction/javaLangSystem_test.go
@@ -13,7 +13,6 @@ import (
 	"jacobin/object"
 	"jacobin/statics"
 	"jacobin/stringPool"
-	"jacobin/trace"
 	"jacobin/types"
 	"os"
 	"os/user"
@@ -24,44 +23,18 @@ import (
 	"time"
 )
 
-func TestSystemClassInitWithClinitRun(t *testing.T) {
+func TestSystemClinit(t *testing.T) {
 	globals.InitGlobals("test")
 	classloader.InitMethodArea()
 	classloader.MethAreaInsert("java/lang/System", &classloader.Klass{Data: &classloader.ClData{ClInit: types.ClInitRun}})
 	ret := systemClinit(nil)
-	successMsg := object.GoStringFromStringObject(ret.(*object.Object))
-	if successMsg != "systemClinit" {
-		t.Errorf("Expected message 'systemClinit', got %s", successMsg)
+	if ret != nil {
+		gErr := ret.(*GErrBlk)
+		t.Errorf("TestSystemClinit: Unexpected error message. got %s", gErr.ErrMsg)
 	}
+	t.Log("TestSystemClinit: stringClinit() returned nil as expected")
 }
 
-func TestSystemClassInitWithClinitNotRun(t *testing.T) {
-	globals.InitGlobals("test")
-	classloader.InitMethodArea()
-	classloader.MethAreaInsert("java/lang/System", &classloader.Klass{Data: &classloader.ClData{ClInit: types.ClInitNotRun}})
-	statics.PreloadStatics()
-
-	ret := systemClinit(nil)
-	successMsg := object.GoStringFromStringObject(ret.(*object.Object))
-	if successMsg != "systemClinit" {
-		t.Errorf("Expected message 'systemClinit', got %s", successMsg)
-	}
-
-	if statics.GetStaticValue("java/lang/System", "out") == nil {
-		t.Errorf("Expected to find static field 'out' in System class")
-	}
-}
-
-func TestSystemClassInitInvalid(t *testing.T) {
-	globals.InitGlobals("test")
-	classloader.InitMethodArea()
-	trace.Disable()
-	ret := systemClinit(nil)
-	successMsg := ret.(*GErrBlk).ErrMsg
-	if successMsg != "systemClinit: Expected java/lang/System to be in the MethodArea, but it was not" {
-		t.Errorf("Expected message that java/lang/System was not in the MethodArea', got %s", successMsg)
-	}
-}
 func TestArrayCopyNonOverlapping(t *testing.T) {
 	globals.InitGlobals("test")
 

--- a/src/gfunction/javaLangThrowable.go
+++ b/src/gfunction/javaLangThrowable.go
@@ -82,7 +82,7 @@ func throwableClinit([]interface{}) interface{} {
 		Type:  "[Ljava/lang/Throwable",
 		Value: emptyThrowableArray,
 	})
-	return object.StringObjectFromGoString("throwableClinit")
+	return nil
 }
 
 // This function is called by Throwable.<init>().

--- a/src/gfunction/javaMathBigInteger.go
+++ b/src/gfunction/javaMathBigInteger.go
@@ -433,7 +433,7 @@ func bigIntegerClinit([]interface{}) interface{} {
 		addStaticBigInteger("ZERO", int64(0))
 		klass.Data.ClInit = types.ClInitRun
 	}
-	return object.StringObjectFromGoString("bigIntegerClinit")
+	return nil
 }
 
 // Convert a byte slice into a signed big integer.

--- a/src/gfunction/javaSecuritySecureRandom.go
+++ b/src/gfunction/javaSecuritySecureRandom.go
@@ -246,13 +246,20 @@ func secureRandomInit(params []interface{}) interface{} {
 	seed := time.Now().UnixNano()
 	_reSeedObject(obj, seed)
 
-	return obj
+	return nil
 
 }
 
 // SecureRandomGetInstance - several variations of SecureRandom getInstance.
 func secureRandomGetInstance(params []interface{}) interface{} {
-	return secureRandomInit(params)
+
+	// Create SecureRandom object with default seed value.
+	obj := params[0].(*object.Object)
+	seed := time.Now().UnixNano()
+	_reSeedObject(obj, seed)
+
+	return obj
+
 }
 
 // secureRandomGetInstanceStrong.

--- a/src/gfunction/javaUtilConcurrentAtomicAtomicInteger.go
+++ b/src/gfunction/javaUtilConcurrentAtomicAtomicInteger.go
@@ -236,7 +236,7 @@ func atomicIntegerClinit(params []interface{}) interface{} {
 	obj := object.MakeEmptyObjectWithClassName(&className)
 	initialField := object.Field{Ftype: types.Int, Fvalue: int64(0)}
 	obj.FieldTable["value"] = initialField
-	return obj
+	return nil
 }
 
 // "java/util/concurrent/atomic/AtomicInteger.<init>()V"
@@ -244,7 +244,7 @@ func atomicIntegerInitVoid(params []interface{}) interface{} {
 	initialField := object.Field{Ftype: types.Int, Fvalue: int64(0)}
 	obj := params[0].(*object.Object)
 	obj.FieldTable["value"] = initialField
-	return obj
+	return nil
 }
 
 // "java/util/concurrent/atomic/AtomicInteger.<init>(I)V"
@@ -253,7 +253,7 @@ func atomicIntegerInitInt(params []interface{}) interface{} {
 	initialValue := params[1].(int64)
 	initialField := object.Field{Ftype: types.Int, Fvalue: initialValue}
 	obj.FieldTable["value"] = initialField
-	return obj
+	return nil
 }
 
 // "java/util/concurrent/atomic/AtomicInteger.Set(I)V"


### PR DESCRIPTION
	modified:   gfunction/gfunction.go
	modified:   gfunction/javaLangRuntime.go
	modified:   gfunction/javaLangString.go
	modified:   gfunction/javaLangString_test.go
	modified:   gfunction/javaLangSystem.go
	modified:   gfunction/javaLangSystem_test.go
	modified:   gfunction/javaLangThrowable.go
	modified:   gfunction/javaMathBigInteger.go
	modified:   gfunction/javaSecuritySecureRandom.go
	modified:   gfunction/javaUtilConcurrentAtomicAtomicInteger.go
