### PR TITLE
JACOBIN-707 fix printing of float64 to be more like hotspot

### DIFF
--- a/src/gfunction/javaIoPrintStream.go
+++ b/src/gfunction/javaIoPrintStream.go
@@ -11,8 +11,8 @@ import (
 	"jacobin/excNames"
 	"jacobin/object"
 	"jacobin/types"
-	"math"
 	"os"
+	"strconv"
 )
 
 /*
@@ -77,13 +77,13 @@ func Load_Io_PrintStream() {
 	MethodSignatures["java/io/PrintStream.println(D)V"] = // println double
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  PrintlnDoubleFloat,
+			GFunction:  PrintlnDouble,
 		}
 
 	MethodSignatures["java/io/PrintStream.println(F)V"] = // println float
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  PrintlnDoubleFloat,
+			GFunction:  PrintlnFloat,
 		}
 
 	MethodSignatures["java/io/PrintStream.println(Ljava/lang/Object;)V"] = // println object
@@ -293,12 +293,17 @@ func PrintlnLong(params []interface{}) interface{} {
 	return nil
 }
 
-// Doubles in Java are 64-bit FP. Like Hotspot, we print at least one decimal place of data.
-// "java/io/PrintStream.println(D)V"
-// "java/io/PrintStream.println(F)V"
-func PrintlnDoubleFloat(params []interface{}) interface{} {
-	doubleToPrint := params[1].(float64) // contains to a float64--the equivalent of a Java double
-	fmt.Fprintf(params[0].(*os.File), getDoubleFormat(doubleToPrint)+"\n", doubleToPrint)
+// PrintlnDouble = java/io/Prinstream.print(double)
+func PrintlnDouble(params []interface{}) interface{} {
+	xx := params[1].(float64) // contains to a float64--the equivalent of a Java double
+	fmt.Fprintln(params[0].(*os.File), strconv.FormatFloat(xx, 'g', -1, 64))
+	return nil
+}
+
+// PrintlnFloat = java/io/Prinstream.print(float)
+func PrintlnFloat(params []interface{}) interface{} {
+	xx := params[1].(float64) // contains to a float64--the equivalent of a Java double
+	fmt.Fprintln(params[0].(*os.File), strconv.FormatFloat(xx, 'g', -1, 32))
 	return nil
 }
 
@@ -341,21 +346,17 @@ func PrintLong(params []interface{}) interface{} {
 	return nil
 }
 
-// PrintFloat = java/io/Prinstream.print(float)
-// Doubles in Java are 64-bit FP
-// "java/io/PrintStream.print(F)V"
-func PrintFloat(params []interface{}) interface{} {
-	floatToPrint := params[1].(float64) // contains to a float64--the equivalent of a Java double
-	fmt.Fprintf(params[0].(*os.File), getDoubleFormat(floatToPrint), floatToPrint)
+// PrintDouble = java/io/Prinstream.print(double)
+func PrintDouble(params []interface{}) interface{} {
+	xx := params[1].(float64) // contains to a float64--the equivalent of a Java double
+	fmt.Fprint(params[0].(*os.File), strconv.FormatFloat(xx, 'g', -1, 64))
 	return nil
 }
 
-// PrintDouble = java/io/Prinstream.print(double)
-// Doubles in Java are 64-bit FP
-// "java/io/PrintStream.print(D)V"
-func PrintDouble(params []interface{}) interface{} {
-	doubleToPrint := params[1].(float64) // contains to a float64--the equivalent of a Java double
-	fmt.Fprintf(params[0].(*os.File), getDoubleFormat(doubleToPrint), doubleToPrint)
+// PrintFloat = java/io/Prinstream.print(float)
+func PrintFloat(params []interface{}) interface{} {
+	xx := params[1].(float64) // contains to a float64--the equivalent of a Java double
+	fmt.Fprint(params[0].(*os.File), strconv.FormatFloat(xx, 'g', -1, 32))
 	return nil
 }
 
@@ -376,20 +377,6 @@ func Printf(params []interface{}) interface{} {
 	fmt.Fprint(params[0].(*os.File), str)
 	return params[0] // Return the PrintStream object
 
-}
-
-// Trying to approximate the exact formatting used in HotSpot JVM
-// TODO: look at the JDK source code to map this formatting exactly.
-func getDoubleFormat(d float64) string {
-	if d < 0.0000001 || d > 10_000_000 {
-		return "%E"
-	} else {
-		if d == math.Floor(d) { // if the fractional part is 0, print a trailing .0
-			return "%.01f"
-		} else {
-			return "%f"
-		}
-	}
 }
 
 // Called by PrintObject and PrintlnObject

--- a/src/go.mod
+++ b/src/go.mod
@@ -8,9 +8,9 @@ module jacobin
 // go 1.24   // as of 2025-02-27 (v. 0.7.0) per JACOBIN-636
 go 1.24.0
 
-require golang.org/x/term v0.17.0
-
 require (
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	golang.org/x/sys v0.17.0 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0
+	golang.org/x/term v0.17.0
 )
+
+require golang.org/x/sys v0.17.0 // indirect


### PR DESCRIPTION
modified:   gfunction/javaIoPrintStream.go

Kalman filtering output

Hotspot
```
Exercise Kalman filtering
initializePLL: cosine: 0.9829930567854869, sine: 0.1836427246354304
initializePLL: modelVariance: 0.5, noiseAmplitude: 1000000.0, initialStateVariance: 10000.0
initializePLL: Initialised Kalman Filter matrices : {F=32[0.982993, 0.183643; -0.183643, 0.982993], Q=32[0.500000, 0.000000; 0.000000, 0.500000], H=16[1.000000, 0.000000], R=8[1000000000000.000000], P=32[10000.000000, 0.000000; 0.000000, 10000.000000], x=16[0.000000; 0.000000]}
testPhaseLockedLoop: mSteps: 20000
testPhaseLockedLoop: residual array (1st 3): -7.070098417349415 -1.8353661230849327 -3.607469944173245
Residual mean: 0.0033659341574785707, variance: 0.002495718144944807
abs(mean) < 0.5 : true
abs(variance) < 0.5 : true
```

Jacobin
```
Exercise Kalman filtering
initializePLL: cosine: 0.9829930567854869, sine: 0.1836427246354304
initializePLL: modelVariance: 0.5, noiseAmplitude: 1e+06, initialStateVariance: 10000
initializePLL: Initialised Kalman Filter matrices : {F=32[0.982993, 0.183643; -0.183643, 0.982993], Q=32[0.500000, 0.000000; 0.000000, 0.500000], H=16[1.000000, 0.000000], R=8[1000000000000.000000], P=32[10000.000000, 0.000000; 0.000000, 10000.000000], x=16[0.000000; 0.000000]}
testPhaseLockedLoop: mSteps: 20000
testPhaseLockedLoop: residual array (1st 3): -7.070098356153153 -1.835366123024158 -3.6074699439583844
Residual mean: 0.003366008758544922, variance: 0.0024957104537873987
abs(mean) < 0.5 : true
abs(variance) < 0.5 : true
```