### PR TITLE
JACOBIN-710 fix POP2

### DIFF
--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -133,7 +133,7 @@ var DispatchTable = [203]BytecodeFunc{
 	doIastore,         // CASTORE         0x55
 	doIastore,         // SASTORE         0x56
 	doPop,             // POP             0x57
-	doPop2,            // POP2            0x58
+	doPop,             // POP2             0x58
 	doDup,             // DUP             0x59
 	doDupx1,           // DUP_X1          0x5A
 	doDupx2,           // DUP_X2          0x5B
@@ -947,10 +947,11 @@ func doBastore(fr *frames.Frame, _ int64) int {
 	return 1
 }
 
-// 0x57 POP pop item off op stack
+// 0x57 POP pop 1 item off op stack
+// 0x58 POP2 pop ditto because in Jacobin, we only need to pop off a single item.
 func doPop(fr *frames.Frame, _ int64) int {
 	if fr.TOS < 0 {
-		errMsg := fmt.Sprintf("stack underflow in POP in %s.%s",
+		errMsg := fmt.Sprintf("stack underflow in POP/POP2 in %s.%s",
 			util.ConvertInternalClassNameToUserFormat(fr.ClName), fr.MethName)
 		status := exceptions.ThrowEx(excNames.InternalException, errMsg, fr)
 		if status != exceptions.Caught {
@@ -958,20 +959,6 @@ func doPop(fr *frames.Frame, _ int64) int {
 		}
 	}
 	fr.TOS -= 1
-	return 1
-}
-
-// 0x58 POP2 pop 2 items off op stack
-func doPop2(fr *frames.Frame, _ int64) int {
-	if fr.TOS < 1 {
-		errMsg := fmt.Sprintf("stack underflow in POP2 in %s.%s",
-			util.ConvertInternalClassNameToUserFormat(fr.ClName), fr.MethName)
-		status := exceptions.ThrowEx(excNames.InternalException, errMsg, fr)
-		if status != exceptions.Caught {
-			return exceptions.ERROR_OCCURRED // applies only if in test
-		}
-	}
-	fr.TOS -= 2
 	return 1
 }
 

--- a/src/jvm/interpreter_LL-end_test.go
+++ b/src/jvm/interpreter_LL-end_test.go
@@ -773,31 +773,33 @@ func TestPopBytecodrUnderflow(t *testing.T) {
 func TestPop2(t *testing.T) {
 
 	f := newFrame(opcodes.POP2)
-	push(&f, int64(34)) // push three different values; 34 at bottom
-	push(&f, int64(21))
-	push(&f, int64(10))
+	// push three different values; 34 at bottom
+	push(&f, int64(34)) // fload_0 : Load float from local variable
+	push(&f, int64(21)) // iload : Load int from local variable
+	push(&f, int64(10)) // lconst_1 : Push long constant
 
 	fs := frames.CreateFrameStack()
 	fs.PushFront(&f) // push the new frame
 	interpret(fs)
 
-	if f.TOS != 0 {
+	if f.TOS != 1 {
 		t.Errorf("POP2: Expected stack with 1 item, but got a tos of: %d", f.TOS)
 	}
 
 	top := pop(&f).(int64)
 
-	if top != 34 {
-		t.Errorf("POP2: expected top's value to be 34, but got: %d", top)
+	if top != 21 {
+		t.Errorf("POP2: expected top's value to be 21, but got: %d", top)
 	}
 }
 
 // POP2: pop two items off stack -- make sure tracing doesn't affect the output
 func TestPop2WithTrace(t *testing.T) {
 	f := newFrame(opcodes.POP2)
-	push(&f, int64(34)) // push three different values; 34 at bottom
-	push(&f, int64(21))
-	push(&f, int64(10))
+	// push three different values; 34 at bottom
+	push(&f, int64(34)) // fload_0 : Load float from local variable
+	push(&f, int64(21)) // iload : Load int from local variable
+	push(&f, int64(10)) // lconst_1 : Push long constant
 
 	MainThread = thread.CreateThread()
 	MainThread.Stack = frames.CreateFrameStack()
@@ -805,14 +807,14 @@ func TestPop2WithTrace(t *testing.T) {
 	MainThread.Trace = true        // turn on tracing
 	interpret(MainThread.Stack)
 
-	if f.TOS != 0 {
+	if f.TOS != 1 {
 		t.Errorf("POP2: Expected stack with 1 item, but got a tos of: %d", f.TOS)
 	}
 
 	top := pop(&f).(int64)
 
-	if top != 34 {
-		t.Errorf("POP2: expected top's value to be 34, but got: %d", top)
+	if top != 21 {
+		t.Errorf("POP2: expected top's value to be 21, but got: %d", top)
 	}
 
 	if MainThread.Trace != true {
@@ -840,7 +842,7 @@ func TestPop2Underflow(t *testing.T) {
 
 	errMsg := string(msg)
 
-	if !strings.Contains(errMsg, "stack underflow in POP2") {
+	if !strings.Contains(errMsg, "stack underflow in POP") {
 		t.Errorf("Did not get expected error from invalid POP, got: %s", errMsg)
 	}
 }


### PR DESCRIPTION
The POP2 code was popping off 2 items. Jacobin only should have 1 popped off because we never push more than one item.

This was not seen before because of the G function cover-up in returning something in cases when we should have been returning nil, namely `<clinit>` and `<init>`.