### PR TITLE
a few places missed showing the MethodType

### DIFF
--- a/src/gfunction/javaIoPrintStream.go
+++ b/src/gfunction/javaIoPrintStream.go
@@ -374,6 +374,13 @@ func Printf(params []interface{}) interface{} {
 	}
 	objPtr := retval.(*object.Object)
 	str := object.GoStringFromStringObject(objPtr)
+	switch params[0].(type) {
+	case *os.File:
+		break
+	default:
+		errMsg := fmt.Sprintf("Printf: Expected parameter type *os.File, observed: %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
 	fmt.Fprint(params[0].(*os.File), str)
 	return params[0] // Return the PrintStream object
 

--- a/src/gfunction/javaLangDouble.go
+++ b/src/gfunction/javaLangDouble.go
@@ -219,7 +219,7 @@ func doubleToLongBits(params []interface{}) interface{} {
 	if !math.IsNaN(value) {
 		return int64(math.Float64bits(value))
 	}
-	return 0x7ff8000000000000 // equivalent to Java's 0x7ff8000000000000L
+	return int64(0x7ff8000000000000) // equivalent to Java's 0x7ff8000000000000L
 }
 
 // Simulating longBitsToDouble in Go

--- a/src/gfunction/javaLangDouble.go
+++ b/src/gfunction/javaLangDouble.go
@@ -217,7 +217,7 @@ func doubleToRawLongBits(params []interface{}) interface{} {
 func doubleToLongBits(params []interface{}) interface{} {
 	value := params[0].(float64)
 	if !math.IsNaN(value) {
-		return *(*int64)(unsafe.Pointer(&value))
+		return int64(math.Float64bits(value))
 	}
 	return 0x7ff8000000000000 // equivalent to Java's 0x7ff8000000000000L
 }

--- a/src/gfunction/javaUtilHashSet.go
+++ b/src/gfunction/javaUtilHashSet.go
@@ -167,31 +167,36 @@ func hashsetAdd(params []interface{}) interface{} {
 		errMsg := "hashsetAdd: Argument parameter is nil or not an object"
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
+	fld, ok := that.FieldTable["value"]
+	if !ok || that == nil {
+		errMsg := "hashsetAdd: Argument parameter is missing the \"value\" field"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
 
 	// Hash the argument.
-	hashedUint64, err := util.HashAnything(*that)
+	hashedUint64, err := util.HashAnything(fld.Fvalue)
 	if err != nil {
 		errMsg := fmt.Sprintf("hashsetAdd: util.HashAnything failed, err: %v", err)
 		return getGErrBlk(excNames.VirtualMachineError, errMsg)
 	}
-	hashedString := strconv.FormatUint(hashedUint64, 10)
+	keyString := strconv.FormatUint(hashedUint64, 10)
 
 	// Remember whether the key already exists.
 	flagReturn := types.JavaBoolTrue // Assume not existing yet.
-	fld := this.FieldTable[fieldNameMap]
+	fld = this.FieldTable[fieldNameMap]
 	hm, ok := fld.Fvalue.(types.DefHashMap)
 	if !ok {
 		errMsg := "hashsetAdd: HashMap is not present"
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
-	_, exists := hm[hashedString]
+	_, exists := hm[keyString]
 	if exists {
 		flagReturn = types.JavaBoolFalse
 	}
 
 	// Add this argument.
 	var extparams = new([]interface{})
-	key := object.StringObjectFromGoString(hashedString)
+	key := object.StringObjectFromGoString(keyString)
 	*extparams = append(*extparams, this)
 	*extparams = append(*extparams, key)
 	*extparams = append(*extparams, that)
@@ -225,9 +230,14 @@ func hashsetRemove(params []interface{}) interface{} {
 		errMsg := "hashsetRemove: Argument parameter is nil or not an object"
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
+	fld, ok := that.FieldTable["value"]
+	if !ok || that == nil {
+		errMsg := "hashsetRemove: Argument parameter is missing the \"value\" field"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
 
 	// Hash the argument.
-	hashedUint64, err := util.HashAnything(*that)
+	hashedUint64, err := util.HashAnything(fld.Fvalue)
 	if err != nil {
 		errMsg := fmt.Sprintf("hashsetRemove: util.HashAnything failed, err: %v", err)
 		return getGErrBlk(excNames.VirtualMachineError, errMsg)
@@ -272,9 +282,14 @@ func hashsetContains(params []interface{}) interface{} {
 		errMsg := "hashsetContains: Argument parameter is nil or not an object"
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
+	fld, ok := that.FieldTable["value"]
+	if !ok || that == nil {
+		errMsg := "hashsetContains: Argument parameter is missing the \"value\" field"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
 
 	// Hash the argument.
-	hashedUint64, err := util.HashAnything(*that)
+	hashedUint64, err := util.HashAnything(fld.Fvalue)
 	if err != nil {
 		errMsg := fmt.Sprintf("hashsetContains: util.HashAnything failed, err: %v", err)
 		return getGErrBlk(excNames.VirtualMachineError, errMsg)

--- a/src/jvm/initializerBlock.go
+++ b/src/jvm/initializerBlock.go
@@ -114,8 +114,8 @@ func runJavaInitializer(m classloader.MData, k *classloader.Klass, fs *list.List
 	}
 
 	if globals.TraceVerbose {
-		infoMsg := fmt.Sprintf("Start init: class=%s, meth=%s, maxStack=%d, maxLocals=%d, code size=%d",
-			f.ClName, f.MethName, meth.MaxStack, meth.MaxLocals, len(meth.Code))
+		infoMsg := fmt.Sprintf("Start init: class=%s, meth=%s%s, maxStack=%d, maxLocals=%d, code size=%d",
+			f.ClName, f.MethName, f.MethType, meth.MaxStack, meth.MaxLocals, len(meth.Code))
 		trace.Trace(infoMsg)
 	}
 

--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -2821,19 +2821,24 @@ func doAthrow(fr *frames.Frame, _ int64) int {
 		if appMsg != nil {
 			switch appMsg.(type) {
 			case []types.JavaByte:
-				st := appMsg.([]types.JavaByte)
-				errMsg += fmt.Sprintf(": %s", object.GoStringFromJavaByteArray(st))
+				jbarray := appMsg.([]types.JavaByte)
+				errMsg += fmt.Sprintf(": %s", object.GoStringFromJavaByteArray(jbarray))
 			case *object.Object:
-				st := appMsg.(*object.Object)
-				value := st.FieldTable["value"].Fvalue
+				obj := appMsg.(*object.Object)
+				value := obj.FieldTable["value"].Fvalue
 				switch value.(type) {
 				case []byte:
-					errMsg += fmt.Sprintf(": %s", string(st.FieldTable["value"].Fvalue.([]byte)))
+					errMsg += fmt.Sprintf(": %s", string(obj.FieldTable["value"].Fvalue.([]byte)))
 				case uint32:
 					str := stringPool.GetStringPointer(value.(uint32))
 					errMsg += fmt.Sprintf(": %s", *str)
+				default:
+					str := fmt.Sprintf(": %v", value)
+					errMsg += fmt.Sprintf(": %s", str)
 				}
-
+			default:
+				str := fmt.Sprintf(": %v", appMsg)
+				errMsg += fmt.Sprintf(": %s", str)
 			}
 		}
 		trace.Error(errMsg)

--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -3221,15 +3221,15 @@ func ldc(fr *frames.Frame, width int) int {
 	}
 
 	CPe := classloader.FetchCPentry(fr.CP.(*classloader.CPool), idx)
-	if CPe.EntryType == 0 || // 0 = error
+	if CPe.EntryType == classloader.Dummy || // 0 = error
 		// Note: an invalid CP entry causes a java.lang.Verify error and
 		//       is caught before execution of the program begins.
 		// This bytecode does not load longs or doubles
 		CPe.EntryType == classloader.DoubleConst ||
 		CPe.EntryType == classloader.LongConst {
 		globals.GetGlobalRef().ErrorGoStack = string(debug.Stack())
-		errMsg := fmt.Sprintf("in %s.%s, LDC: Invalid type for bytecode operand",
-			util.ConvertInternalClassNameToUserFormat(fr.ClName), fr.MethName)
+		errMsg := fmt.Sprintf("in %s.%s, LDC: Invalid type for bytecode operand: %d",
+			util.ConvertInternalClassNameToUserFormat(fr.ClName), fr.MethName, CPe.EntryType)
 		status := exceptions.ThrowEx(excNames.ClassFormatError, errMsg, fr)
 		if status != exceptions.Caught {
 			return exceptions.ERROR_OCCURRED // applies only if in test

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -84,8 +84,8 @@ func StartExec(className string, mainThread *thread.ExecThread, globalStruct *gl
 	}
 
 	if globals.TraceInst {
-		traceInfo := fmt.Sprintf("StartExec: class=%s, meth=%s, maxStack=%d, maxLocals=%d, code size=%d",
-			f.ClName, f.MethName, m.MaxStack, m.MaxLocals, len(m.Code))
+		traceInfo := fmt.Sprintf("StartExec: class=%s, meth=%s%s, maxStack=%d, maxLocals=%d, code size=%d",
+			f.ClName, f.MethName, f.MethType, m.MaxStack, m.MaxLocals, len(m.Code))
 		trace.Trace(traceInfo)
 	}
 

--- a/src/jvm/runUtils.go
+++ b/src/jvm/runUtils.go
@@ -125,8 +125,8 @@ func pop(f *frames.Frame) interface{} {
 	var value interface{}
 
 	if f.TOS == -1 {
-		errMsg := fmt.Sprintf("stack underflow in pop() in %s.%s",
-			util.ConvertInternalClassNameToUserFormat(f.ClName), f.MethName)
+		errMsg := fmt.Sprintf("stack underflow in pop() in %s.%s%s",
+			util.ConvertInternalClassNameToUserFormat(f.ClName), f.MethName, f.MethType)
 		status := exceptions.ThrowEx(excNames.InternalException, errMsg, f)
 		if status != exceptions.Caught {
 			return nil // applies only if in test
@@ -183,14 +183,17 @@ func pop(f *frames.Frame) interface{} {
 	if globals.TraceVerbose {
 		LogTraceStack(f)
 	} // trace the resultant stack
+
+	// Return value to caller.
 	return value
+
 }
 
 // returns the value at the top of the stack without popping it off.
 func peek(f *frames.Frame) interface{} {
 	if f.TOS == -1 {
-		errMsg := fmt.Sprintf("stack underflow in peek() in %s.%s",
-			util.ConvertInternalClassNameToUserFormat(f.ClName), f.MethName)
+		errMsg := fmt.Sprintf("stack underflow in peek() in %s.%s%s",
+			util.ConvertInternalClassNameToUserFormat(f.ClName), f.MethName, f.MethType)
 		status := exceptions.ThrowEx(excNames.InternalException, errMsg, f)
 		if status != exceptions.Caught {
 			return nil // applies only if in test
@@ -218,8 +221,8 @@ func peek(f *frames.Frame) interface{} {
 // push onto the operand stack
 func push(f *frames.Frame, x interface{}) {
 	if f.TOS == len(f.OpStack)-1 {
-		errMsg := fmt.Sprintf("in %s.%s, exceeded op stack size of %d",
-			util.ConvertInternalClassNameToUserFormat(f.ClName), f.MethName, len(f.OpStack))
+		errMsg := fmt.Sprintf("in %s.%s%s, exceeded op stack size of %d",
+			util.ConvertInternalClassNameToUserFormat(f.ClName), f.MethName, f.MethType, len(f.OpStack))
 		status := exceptions.ThrowEx(excNames.StackOverflowError, errMsg, f)
 		if status != exceptions.Caught {
 			return // applies only if in test


### PR DESCRIPTION
A few places missed showing the MethodType while displaying the FQN:
* src/jvm/initializerBlock.go
* src/jvm/run.go
* src/jvm/runUtils.go

Also, modified src/jvm/interpret.go LDC such that when it is diagnosing the CPe.EntryType, show the invalid value.

JACOBIN-714 fixed gfunction/javaUtilHashSet.go to hash only the field value.

JACOBIN-713 fixed gfunction/javaLangDouble.doubleToLongBits to return an int64 instead of an int.