### PR TITLE
JACOBIN-500 INVOKEINTERFACE move from native function requested to other things

### DIFF
--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -119,6 +119,7 @@ func MTableLoadGFunctions(MTable *classloader.MT) {
 	Load_Lang_Long()
 	Load_Lang_Math()
 	Load_Lang_Object()
+	Load_Lang_Process_Handle_Impl()
 	Load_Lang_Runtime()
 	Load_Lang_SecurityManager()
 	Load_Lang_Short()

--- a/src/gfunction/javaLangCharacter.go
+++ b/src/gfunction/javaLangCharacter.go
@@ -62,18 +62,18 @@ func Load_Lang_Character() {
 func charIsDigit(params []interface{}) interface{} {
 	ii := params[0].(int64)
 	if unicode.IsDigit(rune(ii)) {
-		return int64(1)
+		return types.JavaBoolTrue
 	}
-	return int64(0)
+	return types.JavaBoolFalse
 }
 
 // "java/lang/Character.isLetter(C)Z"
 func charIsLetter(params []interface{}) interface{} {
 	ii := params[0].(int64)
 	if unicode.IsLetter(rune(ii)) {
-		return int64(1)
+		return types.JavaBoolTrue
 	}
-	return int64(0)
+	return types.JavaBoolFalse
 }
 
 // "java/lang/Character.toLowerCase(C)C"

--- a/src/gfunction/javaLangDouble.go
+++ b/src/gfunction/javaLangDouble.go
@@ -14,7 +14,6 @@ import (
 	"jacobin/types"
 	"math"
 	"strconv"
-	"unsafe"
 )
 
 func Load_Lang_Double() {
@@ -209,7 +208,7 @@ func doubleToString(params []interface{}) interface{} {
 // "java/lang/Double.doubleToRawLongBits(D)J"
 func doubleToRawLongBits(params []interface{}) interface{} {
 	value := params[0].(float64)
-	return *(*int64)(unsafe.Pointer(&value))
+	return int64(math.Float64bits(value))
 }
 
 // Simulating doubleToLongBits in Go

--- a/src/gfunction/javaLangFloat.go
+++ b/src/gfunction/javaLangFloat.go
@@ -8,7 +8,6 @@ package gfunction
 
 import (
 	"math"
-	"unsafe"
 )
 
 func Load_Lang_Float() {
@@ -52,7 +51,7 @@ func intBitsToFloat(params []interface{}) interface{} {
 // "java/lang/Float.floatToRawIntBits(F)I"
 func floatToRawIntBits(params []interface{}) interface{} {
 	value := params[0].(float64)
-	return *(*int64)(unsafe.Pointer(&value))
+	return int64(math.Float64bits(value))
 }
 
 // Simulating floatToIntBits in Go
@@ -60,7 +59,7 @@ func floatToRawIntBits(params []interface{}) interface{} {
 func floatToIntBits(params []interface{}) interface{} {
 	value := params[0].(float64)
 	if !math.IsNaN(float64(value)) {
-		return *(*int64)(unsafe.Pointer(&value))
+		return int64(math.Float64bits(value))
 	}
 	return 0x7fc00000 // equivalent to Java's 0x7fc00000
 }

--- a/src/gfunction/javaLangProcessHandleImpl.go
+++ b/src/gfunction/javaLangProcessHandleImpl.go
@@ -1,0 +1,35 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2023 by  the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package gfunction
+
+import "os"
+
+func Load_Lang_Process_Handle_Impl() {
+
+	MethodSignatures["java/lang/ProcessHandleImpl.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  clinitGeneric,
+		}
+
+	MethodSignatures["java/lang/ProcessHandleImpl.initNative()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/ProcessHandleImpl.getCurrentPid0()J"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  phimplCurrentPid,
+		}
+
+}
+
+func phimplCurrentPid(params []interface{}) interface{} {
+	return int64(os.Getpid())
+}


### PR DESCRIPTION
JACOBIN-500 move from native function requested to `java.lang.NullPointerException: FQN: main.main([Ljava/lang/String;)V, INVOKEINTERFACE: object whose method, java/lang/ProcessHandleinfo()Ljava/lang/ProcessHandle$Info;, is invoked is null`
* gfunction/javaLangProcessHandleImpl.go
* modified:   gfunction/gfunction.go

Cleanup some return values:
*   gfunction/javaLangCharacter.go
*   gfunction/javaLangDouble.go
*   gfunction/javaLangFloat.go
