### PR TITLE
JACOBIN-709 IDIV and IREM fixes -- do we need more?

### DIFF
--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -1153,6 +1153,10 @@ func doIdiv(fr *frames.Frame, _ int64) int {
 		status := exceptions.ThrowEx(excNames.ArithmeticException, errMsg, fr)
 		if status != exceptions.Caught {
 			return exceptions.ERROR_OCCURRED // applies only if in test
+		} else {
+			fs := fr.FrameStack
+			fr = fs.Front().Value.(*frames.Frame)
+			return 0
 		}
 	} else {
 		push(fr, val2/val1)
@@ -1193,6 +1197,10 @@ func doIrem(fr *frames.Frame, _ int64) int {
 		status := exceptions.ThrowEx(excNames.ArithmeticException, errMsg, fr)
 		if status != exceptions.Caught {
 			return exceptions.ERROR_OCCURRED // applies only if in test
+		} else {
+			fs := fr.FrameStack
+			fr = fs.Front().Value.(*frames.Frame)
+			return 0
 		}
 	} else {
 		res := val1 % val2


### PR DESCRIPTION
modified: jcm/interpreter.go  doIdiv and doIrem.

In throw.go, when catching an exception in a frame (catchFrame), we are correctly setting up that frame.
However, upon return Caught to IDIV, f = old value of the frame pointer. If the catch frame is the same frame, it does not matter. But, if the catch frame is an ancestor frame, it does.

Solution for IDIV and IREM: Update the current frame to the catch frame in fs[0] and return 0 (PC is already set up).

