### PR TITLE
JACOBIN-717 Fixed doIshr and doIushr

### DIFF
--- a/src/gfunction/javaIoPrintStream.go
+++ b/src/gfunction/javaIoPrintStream.go
@@ -403,12 +403,18 @@ func _printObject(params []interface{}, newLine bool) interface{} {
 					fmt.Fprintf(params[0].(*os.File), "class: %s, fields: ", className)
 				}
 				str = ""
+				count := 0
 				for name, _ := range inObj.FieldTable {
+					count += 1
 					if newLine {
 						str += fmt.Sprintf("%s=%s\n", name, object.ObjectFieldToString(inObj, name))
 					} else {
 						str += fmt.Sprintf("%s=%s, ", name, object.ObjectFieldToString(inObj, name))
 					}
+				}
+				if count < 1 {
+					str = "<none>"
+					break
 				}
 				if newLine {
 					fmt.Fprint(params[0].(*os.File), str)

--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -1246,26 +1246,17 @@ func doIshl(fr *frames.Frame, _ int64) int {
 // 0x7A, 0x7B ISHR, LSHR shift int/long to the right
 func doIshr(fr *frames.Frame, _ int64) int {
 	shiftBy := pop(fr).(int64)
-	val1 := pop(fr).(int64)
-	var val2 int64
-	if val1 < 0 { // if neg, shift as pos, then make neg
-		val2 = (-val1) >> (shiftBy & 0x1F) // only the bottom five bits are used
-		push(fr, -val2)
-	} else {
-		push(fr, val1>>(shiftBy&0x1F)) // only the bottom five bits are used
-	}
+	value := pop(fr).(int64)
+	shiftedVal := value >> (shiftBy&0x1F)
+	push(fr, shiftedVal)
 	return 1
 }
 
 // 0x7C, 0x7D IUSHR, LUSHR unsigned shift right of int/long
 func doIushr(fr *frames.Frame, _ int64) int {
 	shiftBy := pop(fr).(int64)
-	ushiftBy := uint64(shiftBy) & 0x3f // must be unsigned in golang; 0-63 bits per JVM
-	val1 := pop(fr).(int64)
-	if val1 < 0 { // per spec, cancel the negative sign
-		val1 = -val1
-	}
-	shiftedVal := val1 >> ushiftBy
+	value := pop(fr).(int64)
+	shiftedVal := int64(uint32(value) >> (shiftBy & 0x1F))
 	push(fr, shiftedVal)
 	return 1
 }

--- a/src/jvm/interpreter_II-LD_test.go
+++ b/src/jvm/interpreter_II-LD_test.go
@@ -650,6 +650,7 @@ func TestNewIushr(t *testing.T) {
 	f := newFrame(opcodes.IUSHR)
 	push(&f, int64(-200))
 	push(&f, int64(3)) // shift right 3 bits
+	expected := int64(536870887)
 
 	fs := frames.CreateFrameStack()
 	fs.PushFront(&f) // push the new frame
@@ -657,8 +658,8 @@ func TestNewIushr(t *testing.T) {
 
 	value := pop(&f).(int64)
 
-	if value != 25 { // 200 >> 3 = 25
-		t.Errorf("IUSHR: expected a result of 25, but got: %d", value)
+	if value != expected {
+		t.Errorf("IUSHR: expected a result of %d, but got: %d", expected, value)
 	}
 
 	if f.TOS != -1 {


### PR DESCRIPTION
modified:   gfunction/javaIoPrintStream.go - fix when an printing an object that has no fields.
modified:   jvm/interpreter.go - doIshr and doIushr.
modified:   jvm/interpreter_II-LD_test.go - Fixed doIushr test but we need more Jacotest cases and unit tests for shifting, in general.
