### PR TITLE
JACOBIN-719 implement Unsafe.getLong

### DIFF
--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -7,6 +7,7 @@
 package gfunction
 
 import (
+	"crypto/rand"
 	"fmt"
 	"jacobin/classloader"
 	"jacobin/excNames"
@@ -277,4 +278,23 @@ func InitBigIntegerField(obj *object.Object, argValue int64) {
 		fldSign = object.Field{Ftype: types.BigInteger, Fvalue: int64(+1)}
 	}
 	obj.FieldTable["signum"] = fldSign
+}
+
+// Return a random long.
+func returnRandomLong([]interface{}) interface{} {
+	// Generate random int64.
+	var result int64
+	byteArray := make([]byte, 8) // int64 is 8 bytes
+	_, err := rand.Read(byteArray)
+	if err != nil {
+		trace.Warning(fmt.Sprintf("secureRandomNextInt: Failed to generate random int64: %v", err))
+		return int64(42)
+	}
+
+	// Convert bytes to int64.
+	for i := 0; i < 8; i++ {
+		result = (result << 8) | int64(byteArray[i])
+	}
+
+	return result
 }

--- a/src/gfunction/javaLangClass.go
+++ b/src/gfunction/javaLangClass.go
@@ -23,12 +23,6 @@ import (
 
 func Load_Lang_Class() {
 
-	MethodSignatures["java/lang/Class.getPrimitiveClass(Ljava/lang/String;)Ljava/lang/Class;"] =
-		GMeth{
-			ParamSlots: 1,
-			GFunction:  getPrimitiveClass,
-		}
-
 	MethodSignatures["java/lang/Class.desiredAssertionStatus()Z"] =
 		GMeth{
 			ParamSlots: 0,
@@ -41,10 +35,16 @@ func Load_Lang_Class() {
 			GFunction:  getAssertionsEnabledStatus,
 		}
 
-	MethodSignatures["java/lang/Class.registerNatives()V"] =
+	MethodSignatures["java/lang/Class.getName()Ljava/lang/String;"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  clinitGeneric,
+			GFunction:  getName,
+		}
+
+	MethodSignatures["java/lang/Class.getPrimitiveClass(Ljava/lang/String;)Ljava/lang/Class;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  getPrimitiveClass,
 		}
 
 	MethodSignatures["java/lang/Class.isArray()Z"] =
@@ -53,10 +53,10 @@ func Load_Lang_Class() {
 			GFunction:  classIsArray,
 		}
 
-	MethodSignatures["java/lang/Class.getName()Ljava/lang/String;"] =
+	MethodSignatures["java/lang/Class.registerNatives()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  getName,
+			GFunction:  clinitGeneric,
 		}
 
 }

--- a/src/gfunction/javaLangObject.go
+++ b/src/gfunction/javaLangObject.go
@@ -36,7 +36,7 @@ func Load_Lang_Object() {
 	MethodSignatures["java/lang/Object.equals(Ljava/lang/Object;)Z"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  trapFunction,
+			GFunction:  objectEquals,
 		}
 
 	MethodSignatures["java/lang/Object.finalize()V"] =
@@ -177,4 +177,23 @@ func objectHashCode(params []interface{}) interface{} {
 
 	errMsg := fmt.Sprintf("objectHashCode: Unsupported parameter type: %T", params[0])
 	return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+}
+
+func objectEquals(params []interface{}) interface{} {
+	this, ok := params[0].(*object.Object)
+	if !ok {
+		return types.JavaBoolFalse
+	}
+	that, ok := params[1].(*object.Object)
+	if !ok {
+		return types.JavaBoolFalse
+	}
+
+	// If they are the same object, even if null, return true.
+	if this == that {
+		return types.JavaBoolTrue
+	}
+
+	// Not the same object.
+	return types.JavaBoolFalse
 }

--- a/src/gfunction/otherMethods.go
+++ b/src/gfunction/otherMethods.go
@@ -110,6 +110,24 @@ func Load_Other_methods() {
 			GFunction:  clinitGeneric,
 		}
 
+	MethodSignatures["jdk/internal/misc/VM.initialize()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["jdk/internal/misc/CDS.getRandomSeedForDumping()J"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  returnRandomLong,
+		}
+
+	MethodSignatures["jdk/internal/misc/CDS.isDumpingClassList0()Z"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  returnFalse,
+		}
+
 	MethodSignatures["jdk/internal/util/ArraysSupport.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,


### PR DESCRIPTION
modified:   gfunction/gfunction.go : added returnRandomLong()
modified:   gfunction/jdkInternalMiscUnsafe.go : added getLong()
modified:   gfunction/javaLangObject.go: added equals().
modified:   gfunction/javaLangClass.go: sorted MethodSignature entries by FQN (no functional changes).

modified:   gfunction/otherMethods.go : added
* jdk/internal/misc/VM.initialize()V - justReturn
* jdk/internal/misc/CDS.getRandomSeedForDumping()J - returnRandomLong
* jdk/internal/misc/CDS.isDumpingClassList0()Z - returnFalse
