### PR TITLE
JACOBIN-721 expand Integer functions

### DIFF
--- a/src/gfunction/javaLangBoolean.go
+++ b/src/gfunction/javaLangBoolean.go
@@ -165,10 +165,10 @@ func booleanGetBoolean(params []interface{}) interface{} {
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
-	// Call getProperty() to get the property value.
+	// Call systemGetProperty() to get the property value.
 	var sysParams []interface{}
 	sysParams = append(sysParams, object.StringObjectFromGoString(propName))
-	propObj := getProperty(sysParams).(*object.Object)
+	propObj := systemGetProperty(sysParams).(*object.Object)
 	propStr := object.GoStringFromStringObject(propObj)
 	switch propStr {
 	case "true":
@@ -178,7 +178,7 @@ func booleanGetBoolean(params []interface{}) interface{} {
 	}
 
 	// Neither true nor false ==> exception.
-	errMsg := fmt.Sprintf("booleanGetBoolean: getProperty returned neither \"true\" nor \"false\": %v", propStr)
+	errMsg := fmt.Sprintf("booleanGetBoolean: systemGetProperty returned neither \"true\" nor \"false\": %v", propStr)
 	return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 }
 

--- a/src/gfunction/javaLangInteger.go
+++ b/src/gfunction/javaLangInteger.go
@@ -24,10 +24,40 @@ func Load_Lang_Integer() {
 			GFunction:  clinitGeneric,
 		}
 
+	MethodSignatures["java/lang/Integer.bitCount(I)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  integerBitCount,
+		}
+
 	MethodSignatures["java/lang/Integer.byteValue()B"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  integerByteValue,
+		}
+
+	MethodSignatures["java/lang/Integer.compare(II)I"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  integerCompare,
+		}
+
+	MethodSignatures["java/lang/Integer.compareTo(Ljava/lang/Integer;)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  integerCompareTo,
+		}
+
+	MethodSignatures["java/lang/Integer.compareUnsigned(II)I"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  integerCompareUnsigned,
+		}
+
+	MethodSignatures["java/lang/Integer.compress(II)I"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  integerCompress,
 		}
 
 	MethodSignatures["java/lang/Integer.decode(Ljava/lang/String;)Ljava/lang/Integer;"] =
@@ -36,10 +66,34 @@ func Load_Lang_Integer() {
 			GFunction:  integerDecode,
 		}
 
+	MethodSignatures["java/lang/Integer.describeConstable()Ljava/util/Optional;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Integer.divideUnsigned(II)I"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  integerDivideUnsigned,
+		}
+
 	MethodSignatures["java/lang/Integer.doubleValue()D"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  integerFloatDoubleValue,
+		}
+
+	MethodSignatures["java/lang/Integer.equals(Ljava/lang/Object;)Z"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  integerEquals,
+		}
+
+	MethodSignatures["java/lang/Integer.expand(II)I"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  integerExpand,
 		}
 
 	MethodSignatures["java/lang/Integer.floatValue()F"] =
@@ -48,22 +102,70 @@ func Load_Lang_Integer() {
 			GFunction:  integerFloatDoubleValue,
 		}
 
+	MethodSignatures["java/lang/Integer.getInteger(Ljava/lang/String;)Ljava/lang/Integer;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  integerGetInteger,
+		}
+
+	MethodSignatures["java/lang/Integer.getInteger(Ljava/lang/String;I)Ljava/lang/Integer;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  integerGetInteger,
+		}
+
+	MethodSignatures["java/lang/Integer.getInteger(Ljava/lang/String;Ljava/lang/Integer;)Ljava/lang/Integer;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  integerGetInteger,
+		}
+
+	MethodSignatures["java/lang/Integer.hashCode()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Integer.hashCode(I)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Integer.highestOneBit(I)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  integerHighestOneBit,
+		}
+
 	MethodSignatures["java/lang/Integer.intValue()I"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  integerIntLongValue,
+			GFunction:  integerIntLongShortValue,
 		}
 
 	MethodSignatures["java/lang/Integer.longValue()J"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  integerIntLongValue,
+			GFunction:  integerIntLongShortValue,
 		}
 
-	MethodSignatures["java/lang/Integer.longValue()J"] =
+	MethodSignatures["java/lang/Integer.lowestOneBit(I)I"] =
 		GMeth{
-			ParamSlots: 0,
-			GFunction:  integerIntLongValue,
+			ParamSlots: 1,
+			GFunction:  integerLowestOneBit,
+		}
+
+	MethodSignatures["java/lang/Integer.max(II)I"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  integerMax,
+		}
+
+	MethodSignatures["java/lang/Integer.min(II)I"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  integerMin,
 		}
 
 	MethodSignatures["java/lang/Integer.numberOfLeadingZeros(I)I"] =
@@ -78,6 +180,12 @@ func Load_Lang_Integer() {
 			GFunction:  integerNumberOfTrailingZeros,
 		}
 
+	MethodSignatures["java/lang/Integer.parseInt(Ljava/lang/CharSequence;III)I"] =
+		GMeth{
+			ParamSlots: 4,
+			GFunction:  trapFunction,
+		}
+
 	MethodSignatures["java/lang/Integer.parseInt(Ljava/lang/String;)I"] =
 		GMeth{
 			ParamSlots: 1,
@@ -90,16 +198,76 @@ func Load_Lang_Integer() {
 			GFunction:  integerParseIntRadix,
 		}
 
+	MethodSignatures["java/lang/Integer.parseUnsignedInt(Ljava/lang/CharSequence;III)I"] =
+		GMeth{
+			ParamSlots: 4,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Integer.parseUnsignedInt(Ljava/lang/String;)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  integerParseUnsignedInt,
+		}
+
+	MethodSignatures["java/lang/Integer.parseUnsignedInt(Ljava/lang/String;I)I"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  integerParseUnsignedInt,
+		}
+
+	MethodSignatures["java/lang/Integer.remainderUnsigned(II)I"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  integerRemainderUnsigned,
+		}
+
+	MethodSignatures["java/lang/Integer.resolveConstantDesc(Ljava/lang/invoke/MethodHandles/Lookup;)Ljava/lang/Integer;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Integer.reverse(I)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  integerReverse,
+		}
+
+	MethodSignatures["java/lang/Integer.reverseBytes(I)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  integerReverseBytes,
+		}
+
+	MethodSignatures["java/lang/Integer.rotateLeft(II)I"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  integerRotateLeft,
+		}
+
+	MethodSignatures["java/lang/Integer.rotateRight(II)I"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  integerRotateRight,
+		}
+
+	MethodSignatures["java/lang/Integer.shortValue()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  integerIntLongShortValue,
+		}
+
 	MethodSignatures["java/lang/Integer.signum(I)I"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  integerSignum,
 		}
 
-	MethodSignatures["java/lang/Integer.valueOf(I)Ljava/lang/Integer;"] =
+	MethodSignatures["java/lang/Integer.sum(II)I"] =
 		GMeth{
-			ParamSlots: 1,
-			GFunction:  integerValueOf,
+			ParamSlots: 2,
+			GFunction:  integerSum,
 		}
 
 	MethodSignatures["java/lang/Integer.toBinaryString(I)Ljava/lang/String;"] =
@@ -129,7 +297,19 @@ func Load_Lang_Integer() {
 	MethodSignatures["java/lang/Integer.toString(I)Ljava/lang/String;"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  integerToStringI,
+			GFunction:  integerToStringIorII,
+		}
+
+	MethodSignatures["java/lang/Integer.toString(II)Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  integerToStringIorII,
+		}
+
+	MethodSignatures["java/lang/Integer.toUnsignedLong(I)J"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  integerToUnsignedLong,
 		}
 
 	MethodSignatures["java/lang/Integer.toUnsignedString(I)Ljava/lang/String;"] =
@@ -144,7 +324,27 @@ func Load_Lang_Integer() {
 			GFunction:  integerToUnsignedStringRadix,
 		}
 
+	MethodSignatures["java/lang/Integer.valueOf(I)Ljava/lang/Integer;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  integerValueOfInt,
+		}
+
+	MethodSignatures["java/lang/Integer.valueOf(Ljava/lang/String;)Ljava/lang/Integer;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  integerValueOfString,
+		}
+
+	MethodSignatures["java/lang/Integer.valueOf(Ljava/lang/String;I)Ljava/lang/Integer;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  integerValueOfString,
+		}
+
 }
+
+var classNameInteger = "java/lang/Integer"
 
 // "java/lang/Integer.byteValue()B"
 func integerByteValue(params []interface{}) interface{} {
@@ -190,8 +390,10 @@ func integerFloatDoubleValue(params []interface{}) interface{} {
 	return float64(ii)
 }
 
+// "java/lang/Integer.intValue()J"
 // "java/lang/Integer.longValue()J"
-func integerIntLongValue(params []interface{}) interface{} {
+// "java/lang/Integer.shortValue()J"
+func integerIntLongShortValue(params []interface{}) interface{} {
 	var ii int64
 	parmObj := params[0].(*object.Object)
 	ii = parmObj.FieldTable["value"].Fvalue.(int64)
@@ -282,12 +484,6 @@ func integerSignum(params []interface{}) interface{} {
 	}
 }
 
-// "java/lang/Integer.valueOf(I)Ljava/lang/Integer;"
-func integerValueOf(params []interface{}) interface{} {
-	int64Value := params[0].(int64)
-	return Populator("java/lang/Integer", types.Int, int64Value)
-}
-
 // "java/lang/Integer.toString()Ljava/lang/String;"
 func integerToString(params []interface{}) interface{} {
 	obj1 := params[0].(*object.Object)
@@ -297,12 +493,31 @@ func integerToString(params []interface{}) interface{} {
 	return obj2
 }
 
-// "java/lang/Integer.toString(I)Ljava/lang/String;"
-func integerToStringI(params []interface{}) interface{} {
-	argInt64 := params[0].(int64)
-	str := fmt.Sprintf("%d", argInt64)
-	obj := object.StringObjectFromGoString(str)
-	return obj
+// integerToStringIorII returns a string representation of the integer, optionally in the specified radix.
+func integerToStringIorII(params []interface{}) interface{} {
+	if len(params) < 1 || len(params) > 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerToStringIorII requires 1 or 2 arguments")
+	}
+
+	input, ok := params[0].(int64)
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerToStringIorII: First argument must be an int64")
+	}
+
+	radix := 10
+	if len(params) == 2 {
+		rr, ok := params[1].(int64)
+		if !ok {
+			return getGErrBlk(excNames.IllegalArgumentException, "integerToStringIorII: Second argument must be an int64 representing the radix")
+		}
+		radix = int(rr)
+		if radix < 2 || radix > 36 {
+			return getGErrBlk(excNames.NumberFormatException, fmt.Sprintf("integerToStringIorII: Radix out of range: %d", radix))
+		}
+	}
+
+	str := strconv.FormatInt(input, radix)
+	return object.StringObjectFromGoString(str)
 }
 
 // "java/lang/Integer.toUnsignedString(I)Ljava/lang/String;"
@@ -342,14 +557,6 @@ func integerToUnsignedStringRadix(params []interface{}) interface{} {
 	return obj
 }
 
-// "java/lang/Integer.toBinaryString(I)Ljava/lang/String;"
-func integerToBinaryString(params []interface{}) interface{} {
-	argInt64 := params[0].(int64)
-	str := strconv.FormatInt(argInt64, 2)
-	obj := object.StringObjectFromGoString(str)
-	return obj
-}
-
 // "java/lang/Integer.toOctalString(I)Ljava/lang/String;"
 func integerToOctalString(params []interface{}) interface{} {
 	argInt64 := params[0].(int64)
@@ -376,4 +583,487 @@ func integerNumberOfTrailingZeros(params []interface{}) interface{} {
 func integerNumberOfLeadingZeros(params []interface{}) interface{} {
 	arg := uint32(params[0].(int64))
 	return int64(bits.LeadingZeros32(arg))
+}
+
+// RotateLeft performs a left bitwise rotation on an integer.
+func integerRotateLeft(params []interface{}) interface{} {
+
+	input, ok1 := params[0].(int64)
+	distance, ok2 := params[1].(int64)
+	if !ok1 || !ok2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerRotateLeft: Invalid argument types")
+	}
+
+	return int64(int32(input)<<distance | int32(input)>>(32-distance))
+}
+
+// RotateRight performs a right bitwise rotation on an integer.
+func integerRotateRight(params []interface{}) interface{} {
+
+	input, ok1 := params[0].(int64)
+	distance, ok2 := params[1].(int64)
+	if !ok1 || !ok2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerRotateRight: Invalid argument types")
+	}
+
+	return int64(int32(input)>>distance | int32(input)<<(32-distance))
+}
+
+// BitCount returns the number of one-bits in the two’s complement binary representation of an integer.
+func integerBitCount(params []interface{}) interface{} {
+
+	input, ok := params[0].(int64)
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerBitCount: Invalid argument type")
+	}
+
+	return int64(bits.OnesCount32(uint32(input)))
+}
+
+// Compare two integer values numerically.
+// Return 0 if x == y; return less than 0 if x < y; and return a value greater than 0 if x > y
+func integerCompare(params []interface{}) interface{} {
+
+	if len(params) != 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerCompare requires exactly 2 arguments")
+	}
+	inputA, ok1 := params[0].(int64)
+	inputB, ok2 := params[1].(int64)
+	if !ok1 || !ok2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerCompare: Invalid argument types")
+	}
+
+	return inputA - inputB
+}
+
+// CompareUnsigned compares two integers as unsigned values.
+func integerCompareUnsigned(params []interface{}) interface{} {
+
+	if len(params) != 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerCompareUnsigned requires exactly 2 arguments")
+	}
+	x, ok1 := params[0].(int64)
+	y, ok2 := params[1].(int64)
+	if !ok1 || !ok2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerCompareUnsigned: Invalid argument types")
+	}
+
+	ux, uy := uint32(x), uint32(y)
+	if ux < uy {
+		return int64(-1)
+	} else if ux > uy {
+		return int64(1)
+	}
+	return int64(0)
+}
+
+// integerCompress extracts bits from i\the input using the provided mask.
+func integerCompress(params []interface{}) interface{} {
+	if len(params) != 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerCompress requires exactly 2 arguments")
+	}
+
+	input, ok1 := params[0].(int64)
+	mask, ok2 := params[1].(int64)
+	if !ok1 || !ok2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerCompress: Invalid argument types for Compress")
+	}
+
+	result := int64(0)
+	pos := int64(0)
+	for mask != 0 {
+		if mask&1 != 0 {
+			result |= (input & 1) << pos
+			pos++
+		}
+		mask >>= 1
+		input >>= 1
+	}
+
+	return result
+}
+
+// integerDivideUnsigned performs unsigned integer division.
+func integerDivideUnsigned(params []interface{}) interface{} {
+	if len(params) != 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerDivideUnsigned requires exactly 2 arguments")
+	}
+
+	dividend, ok1 := params[0].(int64)
+	divisor, ok2 := params[1].(int64)
+	if !ok1 || !ok2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerDivideUnsigned: Invalid argument types for DivideUnsigned")
+	}
+	if divisor == 0 {
+		return getGErrBlk(excNames.ArithmeticException, "integerDivideUnsigned: Division by zero")
+	}
+
+	return int64(uint32(dividend) / uint32(divisor))
+}
+
+// integerEquals checks if an Integer object is equal to another object.
+func integerEquals(params []interface{}) interface{} {
+	if len(params) != 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerEquals requires exactly 2 arguments")
+	}
+
+	integerObj, ok1 := params[0].(*object.Object)
+	otherObj, ok2 := params[1].(*object.Object)
+	if !ok1 || !ok2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerEquals: Invalid argument types for Equals")
+	}
+
+	integerValue, exists := integerObj.FieldTable["value"]
+	if !exists || integerValue.Ftype != types.Int {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerEquals: Invalid Integer object structure")
+	}
+
+	otherValue, exists := otherObj.FieldTable["value"]
+	if !exists || otherValue.Ftype != types.Int {
+		return types.JavaBoolFalse
+	}
+
+	if integerValue.Fvalue == otherValue.Fvalue {
+		return types.JavaBoolTrue
+	}
+	return types.JavaBoolFalse
+}
+
+// integerExpand expands bits from the input using the provided mask.
+func integerExpand(params []interface{}) interface{} {
+	if len(params) != 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerExpand requires exactly 2 arguments")
+	}
+
+	input, ok1 := params[0].(int64)
+	mask, ok2 := params[1].(int64)
+	if !ok1 || !ok2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerExpand: Invalid argument types for integerExpand")
+	}
+
+	result := int64(0)
+	pos := int64(0)
+	for mask != 0 {
+		if mask&1 != 0 {
+			if input&1 != 0 {
+				result |= 1 << pos
+			}
+			input >>= 1
+		}
+		mask >>= 1
+		pos++
+	}
+
+	return result
+}
+
+// integerGetInteger retrieves the Integer object based on different types of input.
+func integerGetInteger(params []interface{}) interface{} {
+	if len(params) == 0 || len(params) > 3 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerGetInteger requires 1 to 3 arguments")
+	}
+
+	var name string
+	var defaultValue int64
+	hasDefault := false
+
+	// Get the property name.
+	nameObj, ok := params[0].(*object.Object)
+	if !ok || !object.IsStringObject(nameObj) {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerGetInteger: First parameter must be a Java String object")
+	}
+	name = object.GoStringFromStringObject(nameObj)
+	if len(name) < 1 {
+		return object.Null
+	}
+
+	// More than one parameter?
+	if len(params) > 1 {
+		// Try for a primitive integer default value.
+		defaultValue, ok = params[1].(int64)
+		if !ok {
+			// Try for an integer object default value.
+			thatObj, ok := params[1].(*object.Object)
+			if !ok || object.GoStringFromStringPoolIndex(thatObj.KlassName) != classNameInteger {
+				return object.Null
+			}
+			defaultValue, ok = thatObj.FieldTable["value"].Fvalue.(int64)
+			if !ok {
+				return object.Null
+			}
+		}
+		hasDefault = true
+	}
+
+	// Get the System.getProperty(name) value.
+	value := getProperty(name)
+	if value == "" {
+		// If no system property by that name is available, return the default value if available.
+		if hasDefault {
+			return defaultValue
+		}
+		return object.Null
+	}
+
+	// Numeric?
+	numeric, err := strconv.Atoi(value)
+	if err != nil {
+		return object.Null
+	}
+
+	// It is a numeric.
+	return object.MakePrimitiveObject(classNameInteger, types.Int, numeric)
+}
+
+// integerHighestOneBit returns an int value with at most a single one-bit, in the position of the highest-order one-bit in the specified int value.
+func integerHighestOneBit(params []interface{}) interface{} {
+	if len(params) != 1 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerHighestOneBit requires exactly 1 argument")
+	}
+	input, ok := params[0].(int64)
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerHighestOneBit: Invalid argument type")
+	}
+
+	if input == 0 {
+		return int64(0)
+	}
+	return int64(1 << (31 - bits.LeadingZeros32(uint32(input))))
+}
+
+// integerLowestOneBit returns an int value with at most a single one-bit, in the position of the lowest-order one-bit in the specified int value.
+func integerLowestOneBit(params []interface{}) interface{} {
+	if len(params) != 1 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerLowestOneBit requires exactly 1 argument")
+	}
+	input, ok := params[0].(int64)
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerLowestOneBit: Invalid argument type")
+	}
+
+	return int64(int32(input) & -int32(input))
+}
+
+// integerMax If A > B return A else return B.
+func integerMax(params []interface{}) interface{} {
+	if len(params) != 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerMax requires exactly 2 arguments")
+	}
+	A, ok := params[0].(int64)
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerMax: Invalid left argument type")
+	}
+	B, ok := params[1].(int64)
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerMax: Invalid right argument type")
+	}
+
+	if A > B {
+		return A
+	}
+	return B
+}
+
+// integerMin If A < B return A else return B.
+func integerMin(params []interface{}) interface{} {
+	if len(params) != 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerMin requires exactly 2 arguments")
+	}
+	A, ok := params[0].(int64)
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerMin: Invalid left argument type")
+	}
+	B, ok := params[1].(int64)
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerMin: Invalid right argument type")
+	}
+
+	if A < B {
+		return A
+	}
+	return B
+}
+
+// integerParseUnsignedInt parses the string argument as an unsigned integer in base 10 or the specified radix.
+func integerParseUnsignedInt(params []interface{}) interface{} {
+	if len(params) < 1 || len(params) > 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerParseUnsignedInt requires 1 or 2 arguments")
+	}
+
+	strObj, ok := params[0].(*object.Object)
+	if !ok || !object.IsStringObject(strObj) {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerParseUnsignedInt: First parameter must be a Java String object")
+	}
+	str := object.GoStringFromStringObject(strObj)
+
+	radix := 10
+	if len(params) == 2 {
+		rr, ok := params[1].(int64)
+		if !ok {
+			return getGErrBlk(excNames.IllegalArgumentException, "integerParseUnsignedInt: Second parameter must be an int64 representing the radix")
+		}
+		radix = int(rr)
+	}
+
+	value, err := strconv.ParseUint(str, radix, 32)
+	if err != nil {
+		return getGErrBlk(excNames.NumberFormatException, fmt.Sprintf("integerParseUnsignedInt: Invalid unsigned integer: %v", err))
+	}
+
+	return int64(value)
+}
+
+// integerRemainderUnsigned returns the remainder of dividing two unsigned integers.
+func integerRemainderUnsigned(params []interface{}) interface{} {
+	if len(params) != 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerRemainderUnsigned requires exactly 2 arguments")
+	}
+
+	dividend, ok1 := params[0].(int64)
+	divisor, ok2 := params[1].(int64)
+	if !ok1 || !ok2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerRemainderUnsigned: Invalid argument types")
+	}
+	if divisor == 0 {
+		return getGErrBlk(excNames.ArithmeticException, "integerRemainderUnsigned: Division by zero")
+	}
+
+	return int64(uint32(dividend) % uint32(divisor))
+}
+
+// integerReverse returns the value obtained by reversing the order of the bits in the two’s complement binary representation of the specified int value.
+func integerReverse(params []interface{}) interface{} {
+	if len(params) != 1 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerReverse requires exactly 1 argument")
+	}
+	i, ok := params[0].(int64)
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerReverse: Invalid argument type")
+	}
+
+	return int64(bits.Reverse32(uint32(i)))
+}
+
+// integerReverseBytes returns the value obtained by reversing the order of the bytes in the two’s complement representation of the specified int value.
+func integerReverseBytes(params []interface{}) interface{} {
+	if len(params) != 1 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerReverseBytes requires exactly 1 argument")
+	}
+	i, ok := params[0].(int64)
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerReverseBytes: Invalid argument type")
+	}
+
+	return int64(bits.ReverseBytes32(uint32(i)))
+}
+
+// integerSum returns the sum of two integers.
+func integerSum(params []interface{}) interface{} {
+	if len(params) != 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerSum requires exactly 2 arguments")
+	}
+	a, ok1 := params[0].(int64)
+	b, ok2 := params[1].(int64)
+	if !ok1 || !ok2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerSum: Invalid argument types for integerSum")
+	}
+
+	return a + b
+}
+
+// integerToBinaryString returns a string representation of the unsigned integer value in binary (base 2).
+func integerToBinaryString(params []interface{}) interface{} {
+	if len(params) != 1 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerToBinaryString requires exactly 1 argument")
+	}
+	input, ok := params[0].(int64)
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "Invalid argument type for integerToBinaryString")
+	}
+
+	binaryStr := strconv.FormatUint(uint64(uint32(input)), 2)
+	return object.StringObjectFromGoString(binaryStr)
+}
+
+// integerToUnsignedLong converts the argument to a long by an unsigned conversion.
+func integerToUnsignedLong(params []interface{}) interface{} {
+	if len(params) != 1 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerToUnsignedLong requires exactly 1 argument")
+	}
+	input, ok := params[0].(int64)
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerToUnsignedLong: Invalid argument type")
+	}
+
+	return int64(uint64(uint32(input)))
+}
+
+// "java/lang/Integer.valueOf(I)Ljava/lang/Integer;"
+func integerValueOfInt(params []interface{}) interface{} {
+	int64Value := params[0].(int64)
+	return Populator("java/lang/Integer", types.Int, int64Value)
+}
+
+// integerValueOf returns an Integer object for the specified string,
+// parsing it as an integer using the specified radix if one is supplied.
+func integerValueOfString(params []interface{}) interface{} {
+	if len(params) < 1 || len(params) > 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerValueOfString requires 1 or 2 arguments")
+	}
+
+	strObj, ok := params[0].(*object.Object)
+	if !ok || !object.IsStringObject(strObj) {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerValueOfString: First parameter must be a Java String object")
+	}
+	str := object.GoStringFromStringObject(strObj)
+
+	// Default radix is 10
+	radix := 10
+	if len(params) == 2 {
+		rr, ok := params[1].(int64)
+		if !ok {
+			return getGErrBlk(excNames.IllegalArgumentException, "integerValueOfString: Second parameter must be an int64 representing the radix")
+		}
+		radix = int(rr)
+	}
+
+	// Parse the string as an integer with the specified radix
+	value, err := strconv.ParseInt(str, radix, 32)
+	if err != nil {
+		return getGErrBlk(excNames.NumberFormatException, fmt.Sprintf("integerValueOfString: Invalid radix(%d): %v", radix, err))
+	}
+
+	// Create and return an Integer object
+	return object.MakePrimitiveObject(classNameInteger, types.Int, value)
+}
+
+// integerCompareTo compares two Integer objects.
+func integerCompareTo(params []interface{}) interface{} {
+	if len(params) != 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerCompareTo requires exactly 2 arguments")
+	}
+
+	thisObj, ok1 := params[0].(*object.Object)
+	otherObj, ok2 := params[1].(*object.Object)
+	if !ok1 || !ok2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerCompareTo: Arguments must be Integer objects")
+	}
+
+	thisVal, exists1 := thisObj.FieldTable["value"]
+	otherVal, exists2 := otherObj.FieldTable["value"]
+	if !exists1 || thisVal.Ftype != types.Int || !exists2 || otherVal.Ftype != types.Int {
+		return getGErrBlk(excNames.IllegalArgumentException, "integerCompareTo: Invalid Integer object structure")
+	}
+
+	x := thisVal.Fvalue.(int64)
+	y := otherVal.Fvalue.(int64)
+
+	switch {
+	case x < y:
+		return int64(-1)
+	case x > y:
+		return int64(1)
+	default:
+		return int64(0)
+	}
 }

--- a/src/gfunction/javaLangSystem_test.go
+++ b/src/gfunction/javaLangSystem_test.go
@@ -311,7 +311,7 @@ func TestGetProperty_FileEncoding(t *testing.T) {
 	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("file.encoding")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString(globals.GetGlobalRef().FileEncoding)
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -321,7 +321,7 @@ func TestGetProperty_FileEncoding(t *testing.T) {
 func TestGetProperty_FileSeparator(t *testing.T) {
 	propObj := object.StringObjectFromGoString("file.separator")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString(string(os.PathSeparator))
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -331,7 +331,7 @@ func TestGetProperty_FileSeparator(t *testing.T) {
 func TestGetProperty_JavaClassPath(t *testing.T) {
 	propObj := object.StringObjectFromGoString("java.class.path")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString(".")
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -341,7 +341,7 @@ func TestGetProperty_JavaClassPath(t *testing.T) {
 func TestGetProperty_JavaCompiler(t *testing.T) {
 	propObj := object.StringObjectFromGoString("java.compiler")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString("no JIT")
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -352,7 +352,7 @@ func TestGetProperty_JavaHome(t *testing.T) {
 	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("java.home")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString(globals.GetGlobalRef().JavaHome)
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -362,7 +362,7 @@ func TestGetProperty_JavaHome(t *testing.T) {
 func TestGetProperty_JavaIoTmpdir(t *testing.T) {
 	propObj := object.StringObjectFromGoString("java.io.tmpdir")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString(os.TempDir())
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -373,7 +373,7 @@ func TestGetProperty_JavaLibraryPath(t *testing.T) {
 	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("java.library.path")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString(globals.GetGlobalRef().JavaHome)
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -383,7 +383,7 @@ func TestGetProperty_JavaLibraryPath(t *testing.T) {
 func TestGetProperty_JavaVendor(t *testing.T) {
 	propObj := object.StringObjectFromGoString("java.vendor")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString("Jacobin")
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -393,7 +393,7 @@ func TestGetProperty_JavaVendor(t *testing.T) {
 func TestGetProperty_JavaVendorUrl(t *testing.T) {
 	propObj := object.StringObjectFromGoString("java.vendor.url")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString("https://jacobin.org")
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -404,7 +404,7 @@ func TestGetProperty_JavaVendorVersion(t *testing.T) {
 	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("java.vendor.version")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString(globals.GetGlobalRef().Version)
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -415,7 +415,7 @@ func TestGetProperty_JavaVersion(t *testing.T) {
 	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("java.version")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString(strconv.Itoa(globals.GetGlobalRef().MaxJavaVersion))
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -426,7 +426,7 @@ func TestGetProperty_JavaVmName(t *testing.T) {
 	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("java.vm.name")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString(
 		fmt.Sprintf("Jacobin VM v. %s (Java %d) 64-bit VM", globals.GetGlobalRef().Version, globals.GetGlobalRef().MaxJavaVersion))
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
@@ -437,7 +437,7 @@ func TestGetProperty_JavaVmName(t *testing.T) {
 func TestGetProperty_JavaVmSpecificationName(t *testing.T) {
 	propObj := object.StringObjectFromGoString("java.vm.specification.name")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString("Java Virtual Machine Specification")
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -447,7 +447,7 @@ func TestGetProperty_JavaVmSpecificationName(t *testing.T) {
 func TestGetProperty_JavaVmSpecificationVendor(t *testing.T) {
 	propObj := object.StringObjectFromGoString("java.vm.specification.vendor")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString("Oracle and Jacobin")
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -458,7 +458,7 @@ func TestGetProperty_JavaVmSpecificationVersion(t *testing.T) {
 	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("java.vm.specification.version")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString(strconv.Itoa(globals.GetGlobalRef().MaxJavaVersion))
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -468,7 +468,7 @@ func TestGetProperty_JavaVmSpecificationVersion(t *testing.T) {
 func TestGetProperty_JavaVmVendor(t *testing.T) {
 	propObj := object.StringObjectFromGoString("java.vm.vendor")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString("Jacobin")
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -479,7 +479,7 @@ func TestGetProperty_JavaVmVersion(t *testing.T) {
 	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("java.vm.version")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString(strconv.Itoa(globals.GetGlobalRef().MaxJavaVersion))
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -489,7 +489,7 @@ func TestGetProperty_JavaVmVersion(t *testing.T) {
 func TestGetProperty_LineSeparator(t *testing.T) {
 	propObj := object.StringObjectFromGoString("line.separator")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	var expected string
 	if runtime.GOOS == "windows" {
 		expected = "\\r\\n"
@@ -504,7 +504,7 @@ func TestGetProperty_LineSeparator(t *testing.T) {
 func TestGetProperty_NativeEncoding(t *testing.T) {
 	propObj := object.StringObjectFromGoString("native.encoding")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString(globals.GetCharsetName())
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -514,7 +514,7 @@ func TestGetProperty_NativeEncoding(t *testing.T) {
 func TestGetProperty_OsArch(t *testing.T) {
 	propObj := object.StringObjectFromGoString("os.arch")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString(runtime.GOARCH)
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -524,7 +524,7 @@ func TestGetProperty_OsArch(t *testing.T) {
 func TestGetProperty_OsName(t *testing.T) {
 	propObj := object.StringObjectFromGoString("os.name")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString(runtime.GOOS)
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -534,7 +534,7 @@ func TestGetProperty_OsName(t *testing.T) {
 func TestGetProperty_OsVersion(t *testing.T) {
 	propObj := object.StringObjectFromGoString("os.version")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString("not yet available")
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -544,7 +544,7 @@ func TestGetProperty_OsVersion(t *testing.T) {
 func TestGetProperty_PathSeparator(t *testing.T) {
 	propObj := object.StringObjectFromGoString("path.separator")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected := object.StringObjectFromGoString(string(os.PathSeparator))
 	if object.GoStringFromStringObject(result.(*object.Object)) != object.GoStringFromStringObject(expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -554,7 +554,7 @@ func TestGetProperty_PathSeparator(t *testing.T) {
 func TestGetProperty_UserDir(t *testing.T) {
 	propObj := object.StringObjectFromGoString("user.dir")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	expected, _ := os.Getwd()
 	if object.GoStringFromStringObject(result.(*object.Object)) != expected {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -564,7 +564,7 @@ func TestGetProperty_UserDir(t *testing.T) {
 func TestGetProperty_UserHome(t *testing.T) {
 	propObj := object.StringObjectFromGoString("user.home")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	currentUser, _ := user.Current()
 	expected := currentUser.HomeDir
 	if object.GoStringFromStringObject(result.(*object.Object)) != expected {
@@ -575,7 +575,7 @@ func TestGetProperty_UserHome(t *testing.T) {
 func TestGetProperty_UserName(t *testing.T) {
 	propObj := object.StringObjectFromGoString("user.name")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	currentUser, _ := user.Current()
 	expected := currentUser.Name
 	if object.GoStringFromStringObject(result.(*object.Object)) != expected {
@@ -586,7 +586,7 @@ func TestGetProperty_UserName(t *testing.T) {
 func TestGetProperty_UserTimezone(t *testing.T) {
 	propObj := object.StringObjectFromGoString("user.timezone")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	now := time.Now()
 	expected, _ := now.Zone()
 	if object.GoStringFromStringObject(result.(*object.Object)) != expected {
@@ -597,7 +597,7 @@ func TestGetProperty_UserTimezone(t *testing.T) {
 func TestGetProperty_Default(t *testing.T) {
 	propObj := object.StringObjectFromGoString("unknown.property")
 	params := []interface{}{propObj}
-	result := getProperty(params)
+	result := systemGetProperty(params)
 	if result != object.Null {
 		t.Errorf("Expected null, got %v", result)
 	}

--- a/src/gfunction/otherMethods.go
+++ b/src/gfunction/otherMethods.go
@@ -122,7 +122,25 @@ func Load_Other_methods() {
 			GFunction:  returnRandomLong,
 		}
 
+	MethodSignatures["jdk/internal/misc/CDS.initializeFromArchive(Ljava/lang/Class;)V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["jdk/internal/misc/CDS.isDumpingArchive0()Z"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  returnFalse,
+		}
+
 	MethodSignatures["jdk/internal/misc/CDS.isDumpingClassList0()Z"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  returnFalse,
+		}
+
+	MethodSignatures["jdk/internal/misc/CDS.isSharingEnabled0()Z"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  returnFalse,


### PR DESCRIPTION
modified:   src/gfunction/javaLangSystem.go - split getProperty into 2 functions: a MethodSignature-driven function (systemGetProperty) and a callable function (getProperty) that is used by an Integer function, getInteger.
modified:   src/gfunction/javaLangBoolean.go - call systemGetProperty.
modified:   src/gfunction/javaLangInteger.go - new functions.
modified:   src/gfunction/javaLangSystem_test.go - call systemGetProperty.
modified:   src/gfunction/otherMethods.go - added jdk/internal/misc/CDS functions that return false or return nil.
