### PR TITLE
JACOBIN-727 Improve object and LinkedList printing again

### DIFF
--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -39,6 +39,8 @@ var CreateFilePermissions os.FileMode = 0664 // When creating, read and write fo
 // Radix boundaries:
 var MinRadix int64 = 2
 var MaxRadix int64 = 36
+
+// int64 value boundaries:
 var MaxIntValue int64 = 2147483647
 var MinIntValue int64 = -2147483648
 
@@ -173,7 +175,7 @@ func MTableLoadGFunctions(MTable *classloader.MT) {
 
 	//	now, with the accumulated MethodSignatures maps, load MTable.
 	loadlib(MTable, MethodSignatures)
-
+	TestGfunctionsLoaded = true
 }
 
 // load the test gfunctions in testGfunctions.go

--- a/src/gfunction/javaIoPrintStream.go
+++ b/src/gfunction/javaIoPrintStream.go
@@ -449,26 +449,30 @@ func PrintlnString(params []interface{}) interface{} {
 
 // Called by PrintObject and PrintlnObject
 func _printObject(params []interface{}, newLine bool) interface{} {
-	var str string
+	var strBuffer string
 
 	// Watch out for a null object.
 	if params[1] == nil || object.IsNull(params[1]) {
-		str = types.NullString
+		strBuffer = types.NullString
 	} else {
 		switch params[1].(type) {
 		case *object.Object:
 			inObj := params[1].(*object.Object)
 			classNameSuffix := object.GetClassNameSuffix(inObj, true)
-			str := classNameSuffix + "{"
-			for name, field := range inObj.FieldTable {
-				str += fmt.Sprintf("%s=%s, ", name, object.StringifyAnythingGo(field))
+			if classNameSuffix == "String" {
+				strBuffer = object.GoStringFromStringObject(inObj)
+				break
 			}
-			str = str[:len(str)-2] + "}"
+			strBuffer = classNameSuffix + "{"
+			for name, field := range inObj.FieldTable {
+				strBuffer += fmt.Sprintf("%s=%s, ", name, object.StringifyAnythingGo(field))
+			}
+			strBuffer = strBuffer[:len(strBuffer)-2] + "}"
 			if newLine {
-				fmt.Fprintln(params[0].(*os.File), str)
+				fmt.Fprintln(params[0].(*os.File), strBuffer)
 				return nil
 			} else {
-				fmt.Fprint(params[0].(*os.File), str)
+				fmt.Fprint(params[0].(*os.File), strBuffer)
 				return nil
 			}
 		default:
@@ -478,9 +482,9 @@ func _printObject(params []interface{}, newLine bool) interface{} {
 	}
 
 	if newLine {
-		fmt.Fprintln(params[0].(*os.File), str)
+		fmt.Fprintln(params[0].(*os.File), strBuffer)
 	} else {
-		fmt.Fprint(params[0].(*os.File), str)
+		fmt.Fprint(params[0].(*os.File), strBuffer)
 	}
 
 	return nil

--- a/src/gfunction/javaIoPrintStream.go
+++ b/src/gfunction/javaIoPrintStream.go
@@ -458,6 +458,8 @@ func _printObject(params []interface{}, newLine bool) interface{} {
 		switch params[1].(type) {
 		case *object.Object:
 			inObj := params[1].(*object.Object)
+			classNameSuffix := object.GetClassNameSuffix(inObj, true)
+			str := classNameSuffix + "{"
 			for name, field := range inObj.FieldTable {
 				str += fmt.Sprintf("%s=%s, ", name, object.StringifyAnythingGo(field))
 			}

--- a/src/gfunction/javaLangObject.go
+++ b/src/gfunction/javaLangObject.go
@@ -156,6 +156,10 @@ func objectToString(params []interface{}) interface{} {
 	switch params[0].(type) {
 	case *object.Object:
 		inObj := params[0].(*object.Object)
+		classNameSuffix := object.GetClassNameSuffix(inObj, false)
+		if classNameSuffix == "LinkedList" {
+			return linkedlistToString(params)
+		}
 		return object.StringifyAnythingJava(inObj)
 	}
 

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -790,8 +790,9 @@ func stringClinit([]interface{}) interface{} {
 // Instantiate a new empty string - "java/lang/String.<init>()V"
 func newEmptyString(params []interface{}) interface{} {
 	// params[0] = target object for string (updated)
+	obj := params[0].(*object.Object)
 	bytes := make([]types.JavaByte, 0)
-	object.UpdateValueFieldFromJavaBytes(params[0].(*object.Object), bytes)
+	object.UpdateValueFieldFromJavaBytes(obj, bytes)
 	return nil
 }
 
@@ -800,14 +801,15 @@ func newEmptyString(params []interface{}) interface{} {
 func newStringFromBytes(params []interface{}) interface{} {
 	// params[0] = reference string (to be updated with byte array)
 	// params[1] = byte array object
+	obj := params[0].(*object.Object)
 	switch params[1].(*object.Object).FieldTable["value"].Fvalue.(type) {
 	case []byte:
 		bytes := object.JavaByteArrayFromGoByteArray(
 			params[1].(*object.Object).FieldTable["value"].Fvalue.([]byte))
-		object.UpdateValueFieldFromJavaBytes(params[0].(*object.Object), bytes)
+		object.UpdateValueFieldFromJavaBytes(obj, bytes)
 	case []types.JavaByte:
 		bytes := params[1].(*object.Object).FieldTable["value"].Fvalue.([]types.JavaByte)
-		object.UpdateValueFieldFromJavaBytes(params[0].(*object.Object), bytes)
+		object.UpdateValueFieldFromJavaBytes(obj, bytes)
 	}
 	return nil
 }
@@ -819,6 +821,7 @@ func newStringFromBytesSubset(params []interface{}) interface{} {
 	// params[1] = byte array object
 	// params[2] = start offset
 	// params[3] = end offset
+	obj := params[0].(*object.Object)
 	var bytes []types.JavaByte
 	switch params[1].(*object.Object).FieldTable["value"].Fvalue.(type) {
 	case []byte:
@@ -842,7 +845,7 @@ func newStringFromBytesSubset(params []interface{}) interface{} {
 
 	// Compute subarray and update params[0].
 	bytes = bytes[ssStart : ssStart+ssEnd]
-	object.UpdateValueFieldFromJavaBytes(params[0].(*object.Object), bytes)
+	object.UpdateValueFieldFromJavaBytes(obj, bytes)
 	return nil
 }
 
@@ -851,13 +854,14 @@ func newStringFromBytesSubset(params []interface{}) interface{} {
 func newStringFromChars(params []interface{}) interface{} {
 	// params[0] = reference string (to be updated with byte array)
 	// params[1] = byte array object
+	obj := params[0].(*object.Object)
 	ints := params[1].(*object.Object).FieldTable["value"].Fvalue.([]int64)
 
 	var bytes []types.JavaByte
 	for _, ii := range ints {
 		bytes = append(bytes, types.JavaByte(ii&0xFF))
 	}
-	object.UpdateValueFieldFromJavaBytes(params[0].(*object.Object), bytes)
+	object.UpdateValueFieldFromJavaBytes(obj, bytes)
 	return nil
 }
 
@@ -1166,7 +1170,7 @@ func StringFormatter(params []interface{}) interface{} {
 		fld := valuesIn[ii].FieldTable["value"]
 
 		// If type is string object, process it.
-		if fld.Ftype == types.ByteArray {
+		if fld.Ftype == types.StringClassRef {
 			var str string
 			switch fld.Fvalue.(type) {
 			case []byte:

--- a/src/gfunction/javaMathBigInteger.go
+++ b/src/gfunction/javaMathBigInteger.go
@@ -483,6 +483,7 @@ func bigIntegerInitByteArray(params []interface{}) interface{} {
 	// params[0]: base object
 	// params[1]: byte array object
 	obj := params[0].(*object.Object)
+	object.ClearFieldTable(obj)
 	fld := obj.FieldTable["value"]
 	jba := params[1].(*object.Object).FieldTable["value"].Fvalue.([]types.JavaByte)
 	bytes := object.GoByteArrayFromJavaByteArray(jba)
@@ -508,6 +509,7 @@ func bigIntegerInitProbablyPrime(params []interface{}) interface{} {
 	// params[3]: Random object (TODO: currently ignored).
 
 	obj := params[0].(*object.Object)
+	object.ClearFieldTable(obj)
 	fld := obj.FieldTable["value"]
 	bitLength := params[1].(int64)
 
@@ -534,6 +536,7 @@ func bigIntegerInitRandom(params []interface{}) interface{} {
 	//            will be set to a random value in the rang given by [0 : 2**(numbits) - 1].
 	// params[2]: Random object
 	obj := params[0].(*object.Object)
+	object.ClearFieldTable(obj)
 	fld := obj.FieldTable["value"]
 	numBits := params[1].(int64)
 	// TODO: Ignored for now: objRandom := params[2].(*object.Object)
@@ -565,6 +568,7 @@ func bigIntegerInitString(params []interface{}) interface{} {
 	// params[0]: base object
 	// params[1]: String object
 	obj := params[0].(*object.Object)
+	object.ClearFieldTable(obj)
 	fld := obj.FieldTable["value"]
 	str := object.GoStringFromStringObject(params[1].(*object.Object))
 	var zz = new(big.Int)
@@ -592,6 +596,7 @@ func bigIntegerInitStringRadix(params []interface{}) interface{} {
 	// params[1]: String object
 	// params[2]: radix int64
 	obj := params[0].(*object.Object)
+	object.ClearFieldTable(obj)
 	fld := obj.FieldTable["value"]
 	str := object.GoStringFromStringObject(params[1].(*object.Object))
 	rdx := params[2].(int64)

--- a/src/gfunction/javaUtilLinkedList.go
+++ b/src/gfunction/javaUtilLinkedList.go
@@ -315,6 +315,7 @@ func linkedlistInit(params []interface{}) interface{} {
 		return getGErrBlk(excNames.IllegalArgumentException, "linkedlistInit: Invalid self argument")
 	}
 
+	object.ClearFieldTable(self)
 	self.FieldTable["value"] = object.Field{
 		Ftype:  types.LinkedList,
 		Fvalue: list.New(),

--- a/src/gfunction/javaUtilLinkedListFuncRtoZ.go
+++ b/src/gfunction/javaUtilLinkedListFuncRtoZ.go
@@ -666,17 +666,35 @@ func linkedlistToArrayTyped(args []interface{}) interface{} {
 }
 
 func linkedlistToString(params []interface{}) interface{} {
+	// Get the linked list.
 	obj, ok := params[0].(*object.Object)
 	if !ok || obj == nil {
 		errMsg := "linkedlistToString: Not a valid list object"
 		return getGErrBlk(excNames.NullPointerException, errMsg)
 	}
-
 	field, ok := obj.FieldTable["value"]
 	if !ok || field.Ftype != types.LinkedList {
 		errMsg := "linkedlistToString: Field is not a valid linked list"
-		return getGErrBlk(excNames.NullPointerException, errMsg)
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	llst, ok := field.Fvalue.(*list.List)
+	if !ok || field.Ftype != types.LinkedList {
+		errMsg := "linkedlistToString: Linked list is corrupt"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
-	return object.StringifyAnythingJava(field)
+	// Walk the linked list, appending its elements to the string buffer.
+	classNameSuffix := object.GetClassNameSuffix(obj, false)
+	strBuffer := classNameSuffix + "{"
+	counter := 0
+	for element := llst.Front(); element != nil; element = element.Next() {
+		strBuffer += object.StringifyAnythingGo(element.Value) + ", "
+		counter += 1
+	}
+
+	// Return the complete string buffer.
+	if counter > 0 {
+		return object.StringObjectFromGoString(strBuffer[:len(strBuffer)-2] + "}")
+	}
+	return object.StringObjectFromGoString("{}")
 }

--- a/src/object/object.go
+++ b/src/object/object.go
@@ -89,9 +89,9 @@ func MakeOneFieldObject(classString string, fname string, ftype string, arg any)
 	return objPtr
 }
 
-// UpdateValueFieldFromJavaBytes: Set the value field of the given object to the given JavaByte array
+// UpdateValueFieldFromJavaBytes: Set the value field of the given String object to the given JavaByte array
 func UpdateValueFieldFromJavaBytes(objPtr *Object, argBytes []types.JavaByte) {
-	fld := Field{Ftype: types.ByteArray, Fvalue: argBytes}
+	fld := Field{Ftype: types.StringClassRef, Fvalue: argBytes}
 	objPtr.FieldTable["value"] = fld
 }
 

--- a/src/object/string.go
+++ b/src/object/string.go
@@ -40,7 +40,7 @@ func NewStringObject() *Object {
 	// enable compact strings.
 
 	value := make([]types.JavaByte, 0)
-	valueField := Field{Ftype: types.ByteArray, Fvalue: value} // empty string
+	valueField := Field{Ftype: types.StringClassRef, Fvalue: value} // empty string
 	s.FieldTable["value"] = valueField
 
 	// coder has two possible values:

--- a/src/object/stringifyAnything.go
+++ b/src/object/stringifyAnything.go
@@ -56,12 +56,18 @@ func StringifyAnythingGo(arg interface{}) string {
 				return "StringifyAnythingGo: corrupted Character object, missing \"value\" field"
 			}
 			return fmt.Sprintf("%d", fld.Fvalue.(int64)&0xff)
-		case "Double", "Float":
+		case "Double":
 			fld, ok := obj.FieldTable["value"]
 			if !ok {
-				return "StringifyAnythingGo: corrupted Double/Float object, missing \"value\" field"
+				return "StringifyAnythingGo: corrupted Double object, missing \"value\" field"
 			}
 			return strconv.FormatFloat(fld.Fvalue.(float64), 'g', -1, 64)
+		case "Float":
+			fld, ok := obj.FieldTable["value"]
+			if !ok {
+				return "StringifyAnythingGo: corrupted Float object, missing \"value\" field"
+			}
+			return strconv.FormatFloat(fld.Fvalue.(float64), 'g', -1, 32)
 		case "Integer", "Long", "Short":
 			fld, ok := obj.FieldTable["value"]
 			if !ok {
@@ -102,14 +108,24 @@ func StringifyAnythingGo(arg interface{}) string {
 			}
 			strBuffer = strBuffer[:len(strBuffer)-2] + "]"
 			return strBuffer
-		case types.DoubleArray, types.FloatArray:
+		case types.DoubleArray:
 			array, ok := obj.FieldTable["value"].Fvalue.([]float64)
 			if !ok {
-				return "StringifyAnythingGo: double/float array missing \"value\" field or array value corrupted"
+				return "StringifyAnythingGo: double array missing \"value\" field or array value corrupted"
 			}
 			strBuffer := "["
 			for ix := 0; ix < len(array); ix++ {
 				strBuffer += strconv.FormatFloat(array[ix], 'g', -1, 64) + ", "
+			}
+			return strBuffer[:len(strBuffer)-2] + "]"
+		case types.FloatArray:
+			array, ok := obj.FieldTable["value"].Fvalue.([]float64)
+			if !ok {
+				return "StringifyAnythingGo: float array missing \"value\" field or array value corrupted"
+			}
+			strBuffer := "["
+			for ix := 0; ix < len(array); ix++ {
+				strBuffer += strconv.FormatFloat(array[ix], 'g', -1, 32) + ", "
 			}
 			return strBuffer[:len(strBuffer)-2] + "]"
 		case types.IntArray, types.LongArray, types.ShortArray:
@@ -158,8 +174,10 @@ func StringifyAnythingGo(arg interface{}) string {
 			return "false"
 		case types.Int, types.Short, types.Long:
 			return strconv.FormatInt(fld.Fvalue.(int64), 10)
-		case types.Double, types.Float:
+		case types.Double:
 			return strconv.FormatFloat(fld.Fvalue.(float64), 'g', -1, 64)
+		case types.Float:
+			return strconv.FormatFloat(fld.Fvalue.(float64), 'g', -1, 32)
 		case types.BigInteger:
 			return fmt.Sprint(fld.Fvalue)
 		case types.LinkedList:

--- a/src/object/stringifyAnything.go
+++ b/src/object/stringifyAnything.go
@@ -162,10 +162,26 @@ func StringifyAnythingGo(arg interface{}) string {
 		case types.StringClassRef:
 			return GoStringFromJavaByteArray(fld.Fvalue.([]types.JavaByte))
 		case types.Byte:
-			ba1 := []byte{byte(fld.Fvalue.(int64))}
+			var ba1 []byte
+			switch fld.Fvalue.(type) {
+			case int64:
+				ba1 = []byte{byte(fld.Fvalue.(int64))}
+			case byte:
+				ba1 = []byte{byte(fld.Fvalue.(byte))}
+			default:
+				return "StringifyAnythingGo Field types.Byte: corrupted byte \"value\" field"
+			}
 			return "0x" + hex.EncodeToString(ba1)
 		case types.ByteArray:
-			bytes := GoByteArrayFromJavaByteArray(fld.Fvalue.([]types.JavaByte))
+			var bytes []byte
+			switch fld.Fvalue.(type) {
+			case []types.JavaByte:
+				bytes = GoByteArrayFromJavaByteArray(fld.Fvalue.([]types.JavaByte))
+			case []byte:
+				bytes = fld.Fvalue.([]byte)
+			default:
+				return "StringifyAnythingGo Field types.ByteArray: corrupted byte array \"value\" field"
+			}
 			return "0x" + hex.EncodeToString(bytes)
 		case types.Bool:
 			if fld.Fvalue == types.JavaBoolTrue {
@@ -173,7 +189,25 @@ func StringifyAnythingGo(arg interface{}) string {
 			}
 			return "false"
 		case types.Int, types.Short, types.Long:
-			return strconv.FormatInt(fld.Fvalue.(int64), 10)
+			var strValue string
+			switch fld.Fvalue.(type) {
+			case int64:
+				strValue = strconv.FormatInt(fld.Fvalue.(int64), 10)
+			case uint64:
+				strValue = strconv.FormatInt(int64(fld.Fvalue.(uint64)), 10)
+			case int32:
+				strValue = strconv.FormatInt(int64(fld.Fvalue.(int32)), 10)
+			case uint32:
+				strValue = strconv.FormatInt(int64(fld.Fvalue.(uint32)), 10)
+			case int16:
+				strValue = strconv.FormatInt(int64(fld.Fvalue.(int16)), 10)
+			case uint16:
+				strValue = strconv.FormatInt(int64(fld.Fvalue.(uint16)), 10)
+			default:
+				errMsg := fmt.Sprintf("StringifyAnythingGo  Field types.Int: unrecognized field value type, value: %T, %v", arg, arg)
+				return errMsg
+			}
+			return strValue
 		case types.Double:
 			return strconv.FormatFloat(fld.Fvalue.(float64), 'g', -1, 64)
 		case types.Float:
@@ -191,7 +225,7 @@ func StringifyAnythingGo(arg interface{}) string {
 			}
 			return strBuffer[:len(strBuffer)-2] + "]"
 		default:
-			errMsg := fmt.Sprintf("StringifyAnythingGo: unrecognized argument type, value: %T, %v", arg, arg)
+			errMsg := fmt.Sprintf("StringifyAnythingGo Field default: unrecognized argument type, value: %T, %v", arg, arg)
 			return errMsg
 		}
 		/*
@@ -203,7 +237,7 @@ func StringifyAnythingGo(arg interface{}) string {
 		End of Field
 	*/
 
-	errMsg := fmt.Sprintf("StringifyAnythingGo: unrecognized argument type, value: %T, %v", arg, arg)
+	errMsg := fmt.Sprintf("StringifyAnythingGo: neither *Object nor Field, value: %T, %v", arg, arg)
 	return errMsg
 
 }

--- a/src/types/javaTypes.go
+++ b/src/types/javaTypes.go
@@ -57,11 +57,11 @@ const Struct = "9" // used primarily in returning items from the CP
 const StringIndex = "T" // The index into the string pool
 const GolangString = "G"
 
-// References to types created and used in gfunctions
+// Field types created and used in gfunctions
 const BigInteger = "*BI" // The related Fvalue is a Golang *big.Int
 const FileHandle = "*FH" // The related Fvalue is a Golang *os.File
 const HashMap = "*HM"    // The related Fvalue is a Golang map[interface{}]interface{}
-const LinkedList = "*LL" // The related Fvalue is a Golang *List
+const LinkedList = "*LL" // The related Fvalue is a Golang *list.List
 const Properties = "*PT" // The related Fvalue is a Golang map[interface{}]interface{}
 
 func IsIntegral(t string) bool {


### PR DESCRIPTION
‎src/gfunction/javaMathBigInteger.go - `<init>`: remove hotspot library fields Jacobin does not use.
src/gfunction/javaIoPrintStream.go - print(object) corrections.
src/object/stringifyAnything.go - field type corrections, especially handling hotspot-generated field types.
‎src/gfunction/javaLangString.go - correct String field type.
‎src/object/string.go - correct String field type.
src/object/object.go - correct String field type.




