### PR TITLE
JACOBIN-730 java/lang/System expansion

### DIFF
--- a/notes/javaBaseShare-natives-byParam.md
+++ b/notes/javaBaseShare-natives-byParam.md
@@ -124,7 +124,7 @@ java.base/share/classes/sun/nio/ch/Net.java:812:    native short pollnvalValue()
 java.base/share/classes/sun/nio/ch/Net.java:813:    native short pollconnValue();
 
 ### ()J
-java.base/share/classes/java/lang/System.java:528:    native long currentTimeMillis();
+java.base/share/classes/java/lang/System.java:528:    native long systemCurrentTimeMillis();
 java.base/share/classes/jdk/internal/foreign/abi/fallback/LibFallback.java:213: native long ffi_type_void();
 java.base/share/classes/jdk/internal/foreign/abi/fallback/LibFallback.java:214: native long ffi_type_uint8();
 java.base/share/classes/jdk/internal/foreign/abi/fallback/LibFallback.java:215: native long ffi_type_sint8();

--- a/src/gfunction/javaLangInteger.go
+++ b/src/gfunction/javaLangInteger.go
@@ -9,6 +9,7 @@ package gfunction
 import (
 	"fmt"
 	"jacobin/excNames"
+	"jacobin/globals"
 	"jacobin/object"
 	"jacobin/types"
 	"math/bits"
@@ -796,7 +797,7 @@ func integerGetInteger(params []interface{}) interface{} {
 	}
 
 	// Get the System.getProperty(name) value.
-	value := getProperty(name)
+	value := globals.GetSystemProperty(name)
 	if value == "" {
 		// If no system property by that name is available, return the default value if available.
 		if hasDefault {

--- a/src/gfunction/javaLangRuntime.go
+++ b/src/gfunction/javaLangRuntime.go
@@ -43,7 +43,7 @@ func Load_Lang_Runtime() {
 	MethodSignatures["java/lang/Runtime.exit(I)V"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  exitI, // javaLangSystem.go
+			GFunction:  systemExitI, // javaLangSystem.go
 		}
 
 	MethodSignatures["java/lang/Runtime.getRuntime()Ljava/lang/Runtime;"] =
@@ -55,7 +55,7 @@ func Load_Lang_Runtime() {
 	MethodSignatures["java/lang/Runtime.halt(I)V"] =
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  exitI, // javaLangSystem.go
+			GFunction:  systemExitI, // javaLangSystem.go
 		}
 
 	MethodSignatures["java/lang/Runtime.load(Ljava/lang/String;)V"] =

--- a/src/gfunction/javaLangSystem.go
+++ b/src/gfunction/javaLangSystem.go
@@ -127,7 +127,7 @@ func Load_Lang_System() {
 
 	MethodSignatures["java/lang/System.getProperty(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;"] =
 		GMeth{
-			ParamSlots: 1,
+			ParamSlots: 2,
 			GFunction:  systemGetPropertyDefault,
 		}
 

--- a/src/gfunction/javaLangSystem.go
+++ b/src/gfunction/javaLangSystem.go
@@ -18,13 +18,9 @@ import (
 	"jacobin/trace"
 	"jacobin/types"
 	"os"
-	"os/exec"
-	"os/user"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
-	"unicode"
 )
 
 /*
@@ -60,31 +56,43 @@ func Load_Lang_System() {
 	MethodSignatures["java/lang/System.arraycopy(Ljava/lang/Object;ILjava/lang/Object;II)V"] = // copy array (full or partial)
 		GMeth{
 			ParamSlots: 5,
-			GFunction:  arrayCopy,
+			GFunction:  systemArrayCopy,
+		}
+
+	MethodSignatures["java/lang/System.clearProperty(Ljava/lang/String;)Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  systemClearProperty,
 		}
 
 	MethodSignatures["java/lang/System.console()Ljava/io/Console;"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  getConsole,
+			GFunction:  systemConsole,
 		}
 
 	MethodSignatures["java/lang/System.currentTimeMillis()J"] = // get time in ms since Jan 1, 1970, returned as long
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  currentTimeMillis,
+			GFunction:  systemCurrentTimeMillis,
 		}
 
 	MethodSignatures["java/lang/System.exit(I)V"] = // shutdown the app
 		GMeth{
 			ParamSlots: 1,
-			GFunction:  exitI,
+			GFunction:  systemExitI,
 		}
 
 	MethodSignatures["java/lang/System.gc()V"] = // for a GC cycle
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  forceGC,
+			GFunction:  systemForceGC,
+		}
+
+	MethodSignatures["java/lang/System.getenv()Ljava/util/Map;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/lang/System.getenv(Ljava/lang/String;)Ljava/lang/String;"] =
@@ -93,22 +101,82 @@ func Load_Lang_System() {
 			GFunction:  systemGetenv,
 		}
 
+	MethodSignatures["java/lang/System.getLogger(Ljava/lang/String;)Ljava/lang/System/Logger;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/System.getLogger(Ljava/lang/String;Ljava/util/ResourceBundle;)Ljava/lang/System/Logger;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/System.getProperties()Ljava/util/Properties;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  systemGetProperties,
+		}
+
 	MethodSignatures["java/lang/System.getProperty(Ljava/lang/String;)Ljava/lang/String;"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  systemGetProperty,
 		}
 
+	MethodSignatures["java/lang/System.getProperty(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  systemGetPropertyDefault,
+		}
+
 	MethodSignatures["java/lang/System.getSecurityManager()Ljava/lang/SecurityManager;"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  systemGetSecurityManager,
+			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures["java/lang/System.identityHashCode(Ljava/lang/Object;)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/System.inheritedChannel()Ljava/nio/channels/Channel;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/System.lineSeparator()Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  systemLineSeparator,
+		}
+
+	MethodSignatures["java/lang/System.load(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/System.loadLibrary(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/System.mapLibraryName(Ljava/lang/String;)Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
 		}
 
 	MethodSignatures["java/lang/System.nanoTime()J"] = // get nanoseconds time, returned as long
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  nanoTime,
+			GFunction:  systemNanoTime,
 		}
 
 	MethodSignatures["java/lang/System.registerNatives()V"] =
@@ -117,21 +185,50 @@ func Load_Lang_System() {
 			GFunction:  justReturn,
 		}
 
+	MethodSignatures["java/lang/System.runFinalization()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures["java/lang/System.setErr(Ljava/io/PrintStream;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/System.setIn(Ljava/io/InputStream;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/System.setOut(Ljava/io/PrintStream;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/System.setProperties(Ljava/util/Properties;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  systemSetProperties,
+		}
+
+	MethodSignatures["java/lang/System.setProperty(Ljava/lang/String;Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  systemSetProperty,
+		}
+
+	MethodSignatures["java/lang/System.setSecurityManager(Ljava/lang/SecurityManager;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapDeprecated,
+		}
+
 }
 
-/*
-		 check whether this systemClinit() has been previously run. If not, have it duplicate the
-	   following bytecodes from JDK 17 java/lang/System:
-			static {};
-			0: invokestatic  #637                // Method registerNatives:()V
-			3: aconst_null
-			4: putstatic     #640                // Field in:Ljava/io/InputStream;
-			7: aconst_null
-			8: putstatic     #387                // Field out:Ljava/io/PrintStream;
-			11: aconst_null
-			12: putstatic     #384                // Field err:Ljava/io/PrintStream;
-			15: return
-*/
 func systemClinit([]interface{}) interface{} {
 	klass := classloader.MethAreaFetch("java/lang/System")
 	if klass == nil {
@@ -148,12 +245,12 @@ func systemClinit([]interface{}) interface{} {
 	return nil
 }
 
-// arrayCopy copies an array or subarray from one array to another, both of which must exist.
+// systemArrayCopy copies an array or subarray from one array to another, both of which must exist.
 // It is a complex native function in the JDK. Javadoc here:
 // docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/System.html#arraycopy(java.lang.Object,int,java.lang.Object,int,int)
-func arrayCopy(params []interface{}) interface{} {
+func systemArrayCopy(params []interface{}) interface{} {
 	if len(params) != 5 {
-		errMsg := fmt.Sprintf("arrayCopy: Expected 5 parameters, got %d", len(params))
+		errMsg := fmt.Sprintf("systemArrayCopy: Expected 5 parameters, got %d", len(params))
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
@@ -164,13 +261,13 @@ func arrayCopy(params []interface{}) interface{} {
 	length := params[4].(int64)
 
 	if object.IsNull(src) || object.IsNull(dest) {
-		errMsg := fmt.Sprintf("arrayCopy: null src or dest")
+		errMsg := fmt.Sprintf("systemArrayCopy: null src or dest")
 		return getGErrBlk(excNames.NullPointerException, errMsg)
 	}
 
 	if srcPos < 0 || destPos < 0 || length < 0 {
 		errMsg := fmt.Sprintf(
-			"arrayCopy: Negative position in: srcPose=%d, destPos=%d, or length=%d", srcPos, destPos, length)
+			"systemArrayCopy: Negative position in: srcPose=%d, destPos=%d, or length=%d", srcPos, destPos, length)
 		return getGErrBlk(excNames.ArrayIndexOutOfBoundsException, errMsg)
 	}
 
@@ -178,7 +275,7 @@ func arrayCopy(params []interface{}) interface{} {
 	destType := *(stringPool.GetStringPointer(dest.KlassName))
 
 	if !strings.HasPrefix(srcType, types.Array) || !strings.HasPrefix(destType, types.Array) || srcType != destType {
-		errMsg := fmt.Sprintf("arrayCopy: invalid src or dest array")
+		errMsg := fmt.Sprintf("systemArrayCopy: invalid src or dest array")
 		return getGErrBlk(excNames.ArrayStoreException, errMsg)
 	}
 
@@ -186,7 +283,7 @@ func arrayCopy(params []interface{}) interface{} {
 	destLen := object.ArrayLength(dest)
 
 	if srcPos+length > srcLen || destPos+length > destLen {
-		errMsg := fmt.Sprintf("arrayCopy: Array position + length exceeds array size")
+		errMsg := fmt.Sprintf("systemArrayCopy: Array position + length exceeds array size")
 		return getGErrBlk(excNames.ArrayIndexOutOfBoundsException, errMsg)
 	}
 
@@ -300,24 +397,24 @@ func arrayCopy(params []interface{}) interface{} {
 }
 
 // Return the system input console as a *os.File.
-func getConsole([]interface{}) interface{} {
+func systemConsole([]interface{}) interface{} {
 	return statics.GetStaticValue("java/lang/System", "in")
 }
 
 // Return time in milliseconds, measured since midnight of Jan 1, 1970
-func currentTimeMillis([]interface{}) interface{} {
+func systemCurrentTimeMillis([]interface{}) interface{} {
 	return time.Now().UnixMilli() // is int64
 }
 
 // Return time in nanoseconds. Note that in golang this function has a lower (that is, less good)
 // resolution than Java: two successive calls often return the same value.
-func nanoTime([]interface{}) interface{} {
+func systemNanoTime([]interface{}) interface{} {
 	return time.Now().UnixNano() // is int64
 }
 
 // Exits the program directly, returning the passed in value
 // exit is a static function, so no object ref and exit value is in params[0]
-func exitI(params []interface{}) interface{} {
+func systemExitI(params []interface{}) interface{} {
 	exitCode := params[0].(int64)
 	var exitStatus = int(exitCode)
 	shutdown.Exit(exitStatus)
@@ -325,7 +422,7 @@ func exitI(params []interface{}) interface{} {
 }
 
 // Force a garbage collection cycle.
-func forceGC([]interface{}) interface{} {
+func systemForceGC([]interface{}) interface{} {
 	runtime.GC()
 	return nil
 }
@@ -336,126 +433,108 @@ func systemGetenv(params []interface{}) interface{} {
 	return object.StringObjectFromGoString(os.Getenv(key))
 }
 
-// Get the fake SecurityManager.
-func systemGetSecurityManager(params []interface{}) interface{} {
-	return object.MakePrimitiveObject("java/lang/SecurityManager", types.Int, 42)
+// Get a system property - high level function.
+func systemClearProperty(params []interface{}) interface{} {
+	propObj := params[0].(*object.Object) // string
+	propStr := object.GoStringFromStringObject(propObj)
+
+	value := globals.GetSystemProperty(propStr)
+	if value == "" {
+		return object.Null
+	}
+
+	globals.RemoveSystemProperty(propStr)
+
+	return object.StringObjectFromGoString(value)
 }
 
 // Get a system property - high level function.
 func systemGetProperty(params []interface{}) interface{} {
-	propObj := params[0].(*object.Object) // string
+	propObj := params[0].(*object.Object)
 	propStr := object.GoStringFromStringObject(propObj)
 
-	value := getProperty(propStr)
-
+	value := globals.GetSystemProperty(propStr)
 	if value == "" {
 		return object.Null
 	}
-	obj := object.StringObjectFromGoString(value)
-	return obj
+	return object.StringObjectFromGoString(value)
 }
 
-func getProperty(arg string) string {
-	var value string
-	g := globals.GetGlobalRef()
-	operSys := runtime.GOOS
+// Get a system property - high level function.
+func systemGetPropertyDefault(params []interface{}) interface{} {
+	propObj := params[0].(*object.Object)
+	propStr := object.GoStringFromStringObject(propObj)
 
-	switch arg {
-	case "file.encoding":
-		value = g.FileEncoding
-	case "file.separator":
-		value = string(os.PathSeparator)
-	case "java.class.path":
-		value = "." // OpenJDK JVM default value
-	case "java.compiler": // the name of the JIT compiler (we don't have a JIT)
-		value = "no JIT"
-	case "java.home":
-		value = g.JavaHome
-	case "java.io.tmpdir":
-		value = os.TempDir()
-	case "java.library.path":
-		value = g.JavaHome
-	case "java.vendor":
-		value = "Jacobin"
-	case "java.vendor.url":
-		value = "https://jacobin.org"
-	case "java.vendor.version":
-		value = g.Version
-	case "java.version":
-		value = strconv.Itoa(g.MaxJavaVersion)
-	// case "java.version.date":
-	// 	need to get this
-	case "java.vm.name":
-		value = fmt.Sprintf(
-			"Jacobin VM v. %s (Java %d) 64-bit VM", g.Version, g.MaxJavaVersion)
-	case "java.vm.specification.name":
-		value = "Java Virtual Machine Specification"
-	case "java.vm.specification.vendor":
-		value = "Oracle and Jacobin"
-	case "java.vm.specification.version":
-		value = strconv.Itoa(g.MaxJavaVersion)
-	case "java.vm.vendor":
-		value = "Jacobin"
-	case "java.vm.version":
-		value = strconv.Itoa(g.MaxJavaVersion)
-	case "line.separator":
-		if operSys == "windows" {
-			value = "\\r\\n"
-		} else {
-			value = "\\n"
-		}
-	case "native.encoding":
-		value = globals.GetCharsetName()
-	case "os.arch":
-		value = runtime.GOARCH
-	case "os.name":
-		value = operSys
-	case "os.version":
-		value = getOSVersion()
-	case "path.separator":
-		value = string(os.PathSeparator)
-	case "user.dir": // present working directory
-		value, _ = os.Getwd()
-	case "user.home":
-		currentUser, _ := user.Current()
-		value = currentUser.HomeDir
-	case "user.name":
-		currentUser, _ := user.Current()
-		value = currentUser.Name
-	case "user.timezone":
-		now := time.Now()
-		value, _ = now.Zone()
-	default:
-		value = ""
+	value := globals.GetSystemProperty(propStr)
+	if value == "" {
+		return params[1].(*object.Object)
 	}
-
-	return value
+	return object.StringObjectFromGoString(value)
 }
 
-// getOSVersion: Get the O/S version string and return it to caller.
-func getOSVersion() string {
-	var cmd *exec.Cmd
+// systemGetProperties: Create a Properties object and set its map elements to system properties.
+func systemGetProperties([]interface{}) interface{} {
+	var propMap types.DefProperties
+	propMap = make(types.DefProperties)
 
-	operSys := runtime.GOOS
-	switch operSys {
-	case "windows":
-		cmd = exec.Command("cmd", "/C", "ver")
-	default:
-		cmd = exec.Command("uname", "-r")
-	}
+	propMap["file.encoding"] = globals.GetSystemProperty("file.encoding")
+	propMap["file.separator"] = globals.GetSystemProperty("file.separator")
+	propMap["java.compiler"] = globals.GetSystemProperty("java.compiler")
+	propMap["java.home"] = globals.GetSystemProperty("java.home")
+	propMap["java.io.tmpdir"] = globals.GetSystemProperty("java.io.tmpdir")
+	propMap["java.library.path"] = globals.GetSystemProperty("java.library.path")
+	propMap["java.vendor"] = globals.GetSystemProperty("java.vendor")
+	propMap["java.vendor.url"] = globals.GetSystemProperty("java.vendor.url")
+	propMap["java.vendor.version"] = globals.GetSystemProperty("java.vendor.version")
+	propMap["java.version"] = globals.GetSystemProperty("java.version")
+	propMap["java.vm.name"] = globals.GetSystemProperty("java.vm.name")
+	propMap["java.vm.specification.name"] = globals.GetSystemProperty("java.vm.specification.name")
+	propMap["java.vm.specification.vendor"] = globals.GetSystemProperty("java.vm.specification.vendor")
+	propMap["java.vm.specification.version"] = globals.GetSystemProperty("java.vm.specification.version")
+	propMap["java.vm.vendor"] = globals.GetSystemProperty("java.vm.vendor")
+	propMap["java.vm.version"] = globals.GetSystemProperty("java.vm.version")
+	propMap["line.separator"] = globals.GetSystemProperty("line.separator")
+	propMap["native.encoding"] = globals.GetSystemProperty("native.encoding")
+	propMap["os.arch"] = globals.GetSystemProperty("os.arch")
+	propMap["os.name"] = globals.GetSystemProperty("os.name")
+	propMap["os.version"] = globals.GetSystemProperty("os.version")
+	propMap["path.separator"] = globals.GetSystemProperty("path.separator")
+	propMap["stdout.encoding"] = globals.GetSystemProperty("stdout.encoding")
+	propMap["stderr.encoding"] = globals.GetSystemProperty("stderr.encoding")
+	propMap["user.dir"] = globals.GetSystemProperty("user.dir")
+	propMap["user.home"] = globals.GetSystemProperty("user.home")
+	propMap["user.name"] = globals.GetSystemProperty("user.name")
+	propMap["user.timezone"] = globals.GetSystemProperty("user.timezone")
 
-	cmdBytes, err := cmd.CombinedOutput()
-	if err != nil {
-		errMsg := fmt.Sprintf("getOSVersion: cmd.CombinedOutput() failed on %s: %v", operSys, err)
-		return errMsg
-	}
+	return object.MakeOneFieldObject(classNameProperties, fieldNameProperties, types.Properties, propMap)
 
-	var cleanBytes []byte
-	for ix := 0; ix < len(cmdBytes); ix++ {
-		if unicode.IsPrint(rune(cmdBytes[ix])) {
-			cleanBytes = append(cleanBytes, cmdBytes[ix])
-		}
-	}
+}
 
-	return string(cleanBytes)
+// Get the system line separator.
+func systemLineSeparator([]interface{}) interface{} {
+	str := globals.GetSystemProperty("line.separator")
+	return object.StringObjectFromGoString(str)
+}
+
+// Set a system property.
+func systemSetProperties(params []interface{}) interface{} {
+	propertiesObj := params[0].(*object.Object)
+	newMap := propertiesObj.FieldTable[fieldNameProperties].Fvalue.(types.DefProperties)
+
+	globals.ReplaceSystemProperties(newMap)
+
+	return nil
+}
+
+// Set a system property.
+func systemSetProperty(params []interface{}) interface{} {
+	keyObj := params[0].(*object.Object)
+	keyStr := object.GoStringFromStringObject(keyObj)
+	valueObj := params[1].(*object.Object)
+	valueStr := object.GoStringFromStringObject(valueObj)
+
+	value := globals.GetSystemProperty(keyStr)
+	globals.SetSystemProperty(keyStr, valueStr)
+
+	return object.StringObjectFromGoString(value)
 }

--- a/src/gfunction/javaLangSystem_test.go
+++ b/src/gfunction/javaLangSystem_test.go
@@ -53,11 +53,11 @@ func TestArrayCopyNonOverlapping(t *testing.T) {
 	params[3] = int64(0)
 	params[4] = int64(5)
 
-	err := arrayCopy(params)
+	err := systemArrayCopy(params)
 
 	if err != nil {
 		e := err.(error)
-		t.Errorf("Unexpected error in test of arrayCopy(): %s", error.Error(e))
+		t.Errorf("Unexpected error in test of systemArrayCopy(): %s", error.Error(e))
 	}
 
 	rawDestArray := dest.FieldTable["value"].Fvalue.([]int64)
@@ -96,11 +96,11 @@ func TestArrayCopyOverlappingSameArray(t *testing.T) {
 
 	// result should be 2,3,4,5,6,5,6,7,8,9 (which totals 55)
 
-	err := arrayCopy(params)
+	err := systemArrayCopy(params)
 
 	if err != nil {
 		e := err.(error)
-		t.Errorf("Unexpected error in test of arrayCopy(): %s", error.Error(e))
+		t.Errorf("Unexpected error in test of systemArrayCopy(): %s", error.Error(e))
 	}
 
 	j := types.JavaByte(0)
@@ -131,7 +131,7 @@ func TestArrayInvalidParmCount(t *testing.T) {
 	params[3] = int64(0)
 	// params[4] = int64(5)
 
-	err := arrayCopy(params)
+	err := systemArrayCopy(params)
 
 	if err == nil {
 		t.Errorf("Expecting error, but got none")
@@ -161,7 +161,7 @@ func TestArrayCopyInvalidPos(t *testing.T) {
 	params[3] = int64(0)
 	params[4] = int64(5)
 
-	err := arrayCopy(params)
+	err := systemArrayCopy(params)
 
 	if err == nil {
 		t.Errorf("Exoected an error message, but got none")
@@ -191,7 +191,7 @@ func TestArrayCopyNullArray(t *testing.T) {
 	params[3] = int64(0)
 	params[4] = int64(5)
 
-	err := arrayCopy(params)
+	err := systemArrayCopy(params)
 
 	if err == nil {
 		t.Errorf("Exoected an error message, but got none")
@@ -224,7 +224,7 @@ func TestArrayCopyInvalidObject(t *testing.T) {
 	params[3] = int64(0)
 	params[4] = int64(5)
 
-	err := arrayCopy(params)
+	err := systemArrayCopy(params)
 
 	if err == nil {
 		t.Errorf("Exoected an error message, but got none")
@@ -254,7 +254,7 @@ func TestArrayCopyInvalidLength(t *testing.T) {
 	params[3] = int64(0)
 	params[4] = int64(200) // the invalid length
 
-	err := arrayCopy(params)
+	err := systemArrayCopy(params)
 
 	if err == nil {
 		t.Errorf("Exoected an error message, but got none")
@@ -268,7 +268,7 @@ func TestArrayCopyInvalidLength(t *testing.T) {
 
 func TestGetMilliTime(t *testing.T) {
 	globals.InitGlobals("test")
-	ret := currentTimeMillis(nil).(int64)
+	ret := systemCurrentTimeMillis(nil).(int64)
 	if ret < 1739512706877 { // milli time on 13 Feb 2025 at roughtly 10PM PST
 		t.Errorf("Expected a greater value from nanoTime(), got %d", ret)
 	}
@@ -276,7 +276,7 @@ func TestGetMilliTime(t *testing.T) {
 
 func TestGetNanoTime(t *testing.T) {
 	globals.InitGlobals("test")
-	ret := nanoTime(nil).(int64)
+	ret := systemNanoTime(nil).(int64)
 	if ret < 1739512706877498200 { // nanotime on 13 Feb 2025 at roughtly 10PM PST
 		t.Errorf("Expected a greater value from nanoTime(), got %d", ret)
 	}
@@ -284,7 +284,7 @@ func TestGetNanoTime(t *testing.T) {
 
 func TestExitI(t *testing.T) {
 	globals.InitGlobals("test")
-	ret := exitI([]interface{}{int64(17)})
+	ret := systemExitI([]interface{}{int64(17)})
 	if ret.(int64) != 17 {
 		t.Errorf("Expected exit code of 17, got %d", ret.(int64))
 	}
@@ -299,7 +299,7 @@ func TestGetConsole(t *testing.T) {
 	statics.PreloadStatics()
 	_ = systemClinit(nil)
 
-	ret := getConsole(nil)
+	ret := systemConsole(nil)
 	if ret.(*os.File) != os.Stdin {
 		t.Errorf("Expected getConsole() to return stdin, got %v", ret)
 	}
@@ -319,6 +319,7 @@ func TestGetProperty_FileEncoding(t *testing.T) {
 }
 
 func TestGetProperty_FileSeparator(t *testing.T) {
+	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("file.separator")
 	params := []interface{}{propObj}
 	result := systemGetProperty(params)
@@ -329,6 +330,7 @@ func TestGetProperty_FileSeparator(t *testing.T) {
 }
 
 func TestGetProperty_JavaClassPath(t *testing.T) {
+	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("java.class.path")
 	params := []interface{}{propObj}
 	result := systemGetProperty(params)
@@ -339,6 +341,7 @@ func TestGetProperty_JavaClassPath(t *testing.T) {
 }
 
 func TestGetProperty_JavaCompiler(t *testing.T) {
+	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("java.compiler")
 	params := []interface{}{propObj}
 	result := systemGetProperty(params)
@@ -360,6 +363,7 @@ func TestGetProperty_JavaHome(t *testing.T) {
 }
 
 func TestGetProperty_JavaIoTmpdir(t *testing.T) {
+	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("java.io.tmpdir")
 	params := []interface{}{propObj}
 	result := systemGetProperty(params)
@@ -381,6 +385,7 @@ func TestGetProperty_JavaLibraryPath(t *testing.T) {
 }
 
 func TestGetProperty_JavaVendor(t *testing.T) {
+	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("java.vendor")
 	params := []interface{}{propObj}
 	result := systemGetProperty(params)
@@ -391,6 +396,7 @@ func TestGetProperty_JavaVendor(t *testing.T) {
 }
 
 func TestGetProperty_JavaVendorUrl(t *testing.T) {
+	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("java.vendor.url")
 	params := []interface{}{propObj}
 	result := systemGetProperty(params)
@@ -435,6 +441,7 @@ func TestGetProperty_JavaVmName(t *testing.T) {
 }
 
 func TestGetProperty_JavaVmSpecificationName(t *testing.T) {
+	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("java.vm.specification.name")
 	params := []interface{}{propObj}
 	result := systemGetProperty(params)
@@ -445,6 +452,7 @@ func TestGetProperty_JavaVmSpecificationName(t *testing.T) {
 }
 
 func TestGetProperty_JavaVmSpecificationVendor(t *testing.T) {
+	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("java.vm.specification.vendor")
 	params := []interface{}{propObj}
 	result := systemGetProperty(params)
@@ -466,6 +474,7 @@ func TestGetProperty_JavaVmSpecificationVersion(t *testing.T) {
 }
 
 func TestGetProperty_JavaVmVendor(t *testing.T) {
+	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("java.vm.vendor")
 	params := []interface{}{propObj}
 	result := systemGetProperty(params)
@@ -487,6 +496,7 @@ func TestGetProperty_JavaVmVersion(t *testing.T) {
 }
 
 func TestGetProperty_LineSeparator(t *testing.T) {
+	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("line.separator")
 	params := []interface{}{propObj}
 	result := systemGetProperty(params)
@@ -502,6 +512,7 @@ func TestGetProperty_LineSeparator(t *testing.T) {
 }
 
 func TestGetProperty_NativeEncoding(t *testing.T) {
+	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("native.encoding")
 	params := []interface{}{propObj}
 	result := systemGetProperty(params)
@@ -512,6 +523,7 @@ func TestGetProperty_NativeEncoding(t *testing.T) {
 }
 
 func TestGetProperty_OsArch(t *testing.T) {
+	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("os.arch")
 	params := []interface{}{propObj}
 	result := systemGetProperty(params)
@@ -522,6 +534,7 @@ func TestGetProperty_OsArch(t *testing.T) {
 }
 
 func TestGetProperty_OsName(t *testing.T) {
+	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("os.name")
 	params := []interface{}{propObj}
 	result := systemGetProperty(params)
@@ -532,6 +545,7 @@ func TestGetProperty_OsName(t *testing.T) {
 }
 
 func TestGetProperty_OsVersion(t *testing.T) {
+	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("os.version")
 	params := []interface{}{propObj}
 	result := systemGetProperty(params)
@@ -543,6 +557,7 @@ func TestGetProperty_OsVersion(t *testing.T) {
 }
 
 func TestGetProperty_PathSeparator(t *testing.T) {
+	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("path.separator")
 	params := []interface{}{propObj}
 	result := systemGetProperty(params)
@@ -553,6 +568,7 @@ func TestGetProperty_PathSeparator(t *testing.T) {
 }
 
 func TestGetProperty_UserDir(t *testing.T) {
+	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("user.dir")
 	params := []interface{}{propObj}
 	result := systemGetProperty(params)
@@ -563,6 +579,7 @@ func TestGetProperty_UserDir(t *testing.T) {
 }
 
 func TestGetProperty_UserHome(t *testing.T) {
+	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("user.home")
 	params := []interface{}{propObj}
 	result := systemGetProperty(params)
@@ -574,6 +591,7 @@ func TestGetProperty_UserHome(t *testing.T) {
 }
 
 func TestGetProperty_UserName(t *testing.T) {
+	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("user.name")
 	params := []interface{}{propObj}
 	result := systemGetProperty(params)
@@ -585,6 +603,7 @@ func TestGetProperty_UserName(t *testing.T) {
 }
 
 func TestGetProperty_UserTimezone(t *testing.T) {
+	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("user.timezone")
 	params := []interface{}{propObj}
 	result := systemGetProperty(params)
@@ -596,10 +615,120 @@ func TestGetProperty_UserTimezone(t *testing.T) {
 }
 
 func TestGetProperty_Default(t *testing.T) {
+	globals.InitGlobals("test")
 	propObj := object.StringObjectFromGoString("unknown.property")
 	params := []interface{}{propObj}
 	result := systemGetProperty(params)
 	if result != object.Null {
 		t.Errorf("Expected null, got %v", result)
 	}
+}
+
+func TestSetProperty_JavaIoTmpdir(t *testing.T) {
+	globals.InitGlobals("test")
+	propObj := object.StringObjectFromGoString("java.io.tmpdir")
+	params := []interface{}{propObj}
+	result := systemGetProperty(params)
+	observed := object.GoStringFromStringObject(result.(*object.Object))
+	expected := os.TempDir()
+	if observed != expected {
+		t.Errorf("1. Expected %s, observed %s", expected, observed)
+		return
+	}
+
+	newValueObj := object.StringObjectFromGoString("rubbish")
+	params = []interface{}{propObj, newValueObj}
+	result = systemSetProperty(params)
+	observed = object.GoStringFromStringObject(result.(*object.Object))
+	if observed != expected {
+		t.Errorf("2. Expected %s, observed %s", expected, observed)
+		return
+	}
+	params = []interface{}{propObj}
+	result = systemGetProperty(params)
+	observed = object.GoStringFromStringObject(result.(*object.Object))
+	expected = "rubbish"
+	if observed != expected {
+		t.Errorf("3. Expected %s, observed %s", expected, observed)
+		return
+	}
+
+}
+
+func TestClearProperty_JavaIoTmpdir(t *testing.T) {
+	globals.InitGlobals("test")
+	propObj := object.StringObjectFromGoString("java.io.tmpdir")
+	params := []interface{}{propObj}
+	result := systemClearProperty(params)
+	observed := object.GoStringFromStringObject(result.(*object.Object))
+	expected := os.TempDir()
+	if observed != expected {
+		t.Errorf("1. Expected %s, observed %s", expected, observed)
+		return
+	}
+
+	result = systemGetProperty(params)
+	observed = object.GoStringFromStringObject(result.(*object.Object))
+	if observed != "" {
+		t.Errorf("Expected \"\", observed %s", observed)
+		return
+	}
+
+}
+
+func TestSetProperties(t *testing.T) {
+	globals.InitGlobals("test")
+
+	// Create a Properties object.
+	propsObj := object.MakeEmptyObjectWithClassName(&classNameProperties)
+	params := []interface{}{propsObj}
+	propertiesInit(params)
+
+	// Add 2 elements to the Properties object.
+	key1Obj := object.StringObjectFromGoString("color")
+	value1Obj := object.StringObjectFromGoString("green")
+	params = []interface{}{propsObj, key1Obj, value1Obj}
+	_ = propertiesSetProperty(params)
+	key2Obj := object.StringObjectFromGoString("sound")
+	value2Obj := object.StringObjectFromGoString("soft")
+	params = []interface{}{propsObj, key2Obj, value2Obj}
+	_ = propertiesSetProperty(params)
+
+	// Replace the system properties.
+	propsMap := propsObj.FieldTable[fieldNameProperties].Fvalue.(types.DefProperties)
+	globals.ReplaceSystemProperties(propsMap)
+
+	// Try to get tmp dir.
+	propObj := object.StringObjectFromGoString("java.io.tmpdir")
+	params = []interface{}{propObj}
+	result := systemGetProperty(params)
+	observed := object.GoStringFromStringObject(result.(*object.Object))
+	expected := ""
+	if observed != expected {
+		t.Errorf("3. Expected \"\", observed %s", observed)
+		return
+	}
+
+	// Try to get "color".
+	propObj = object.StringObjectFromGoString("color")
+	params = []interface{}{propObj}
+	result = systemGetProperty(params)
+	observed = object.GoStringFromStringObject(result.(*object.Object))
+	expected = "green"
+	if observed != expected {
+		t.Errorf("3. Expected %s, observed %s", expected, observed)
+		return
+	}
+
+	// Try to get "sound".
+	propObj = object.StringObjectFromGoString("sound")
+	params = []interface{}{propObj}
+	result = systemGetProperty(params)
+	observed = object.GoStringFromStringObject(result.(*object.Object))
+	expected = "soft"
+	if observed != expected {
+		t.Errorf("3. Expected %s, observed %s", expected, observed)
+		return
+	}
+
 }

--- a/src/globals/globals.go
+++ b/src/globals/globals.go
@@ -14,12 +14,16 @@ import (
 	"jacobin/config"
 	"jacobin/types"
 	"os"
+	"os/exec"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 )
 
 var StringEnvVarHeadless = "java.awt.headless"
@@ -192,6 +196,9 @@ func InitGlobals(progName string) Globals {
 			global.Headless = true
 		}
 	}
+
+	// Capture system properties from the O/S and its environment.
+	buildGlobalProperties()
 
 	global.Threads = make(map[int]interface{})
 
@@ -368,4 +375,192 @@ func SortCaseInsensitive(ptrSlice *[]string) {
 	slices.SortFunc(*ptrSlice, func(a, b string) int {
 		return strings.Compare(strings.ToLower(a), strings.ToLower(b))
 	})
+}
+
+/*
+System Properties Map: JVM System Properties
+
+Jacobin uses information from the operating system, startup arguments, and the host environment to set up its initial system properties.
+
+Properties are stored in the globalPropertiesMap, fetched with System.getProperties() or System.getProperty(key), and include items like:
+* os.name, os.arch, os.version
+* user.name, user.home, user.dir
+* java.home, java.class.path
+* file.separator, line.separator
+
+These values are derived from:
+* Environment variables (HOME, PATH, etc.)
+* The current working directory
+* Command-line -D options passed when launching the JVM
+
+*/
+
+var systemPropertiesMap types.DefProperties
+var systemPropertiesMutex = sync.RWMutex{}
+
+func getOsProperty(arg string) string {
+	var value string
+	operSys := runtime.GOOS
+
+	switch arg {
+	case "file.encoding":
+		value = global.FileEncoding
+	case "file.separator":
+		value = string(os.PathSeparator)
+	case "java.class.path":
+		value = "." // OpenJDK JVM default value
+	case "java.compiler": // the name of the JIT compiler (we don't have a JIT)
+		value = "no JIT"
+	case "java.home":
+		value = global.JavaHome
+	case "java.io.tmpdir":
+		value = os.TempDir()
+	case "java.library.path":
+		value = global.JavaHome
+	case "java.vendor":
+		value = "Jacobin"
+	case "java.vendor.url":
+		value = "https://jacobin.org"
+	case "java.vendor.version":
+		value = global.Version
+	case "java.version":
+		value = strconv.Itoa(global.MaxJavaVersion)
+	// case "java.version.date":
+	// 	need to get this
+	case "java.vm.name":
+		value = fmt.Sprintf(
+			"Jacobin VM v. %s (Java %d) 64-bit VM", global.Version, global.MaxJavaVersion)
+	case "java.vm.specification.name":
+		value = "Java Virtual Machine Specification"
+	case "java.vm.specification.vendor":
+		value = "Oracle and Jacobin"
+	case "java.vm.specification.version":
+		value = strconv.Itoa(global.MaxJavaVersion)
+	case "java.vm.vendor":
+		value = "Jacobin"
+	case "java.vm.version":
+		value = strconv.Itoa(global.MaxJavaVersion)
+	case "line.separator":
+		if operSys == "windows" {
+			value = "\\r\\n"
+		} else {
+			value = "\\n"
+		}
+	case "native.encoding", "stdout.encoding", "stderr.encoding":
+		value = GetCharsetName()
+	case "os.arch":
+		value = runtime.GOARCH
+	case "os.name":
+		value = operSys
+	case "os.version":
+		value = getOSVersion()
+	case "path.separator":
+		value = string(os.PathSeparator)
+	case "user.dir": // present working directory
+		value, _ = os.Getwd()
+	case "user.home":
+		currentUser, _ := user.Current()
+		value = currentUser.HomeDir
+	case "user.name":
+		currentUser, _ := user.Current()
+		value = currentUser.Name
+	case "user.timezone":
+		now := time.Now()
+		value, _ = now.Zone()
+	default:
+		value = ""
+	}
+
+	return value
+}
+
+// Build the Global Properties Map.
+func buildGlobalProperties() {
+	systemPropertiesMap = make(types.DefProperties)
+	systemPropertiesMutex.Lock()
+	defer systemPropertiesMutex.Unlock()
+
+	systemPropertiesMap["file.encoding"] = getOsProperty("file.encoding")
+	systemPropertiesMap["file.separator"] = getOsProperty("file.separator")
+	systemPropertiesMap["java.class.path"] = "." // TODO - fix this during CLASSPATH development
+	systemPropertiesMap["java.compiler"] = getOsProperty("java.compiler")
+	systemPropertiesMap["java.home"] = getOsProperty("java.home")
+	systemPropertiesMap["java.io.tmpdir"] = getOsProperty("java.io.tmpdir")
+	systemPropertiesMap["java.library.path"] = getOsProperty("java.library.path")
+	systemPropertiesMap["java.vendor"] = getOsProperty("java.vendor")
+	systemPropertiesMap["java.vendor.url"] = getOsProperty("java.vendor.url")
+	systemPropertiesMap["java.vendor.version"] = getOsProperty("java.vendor.version")
+	systemPropertiesMap["java.version"] = getOsProperty("java.version")
+	systemPropertiesMap["java.vm.name"] = getOsProperty("java.vm.name")
+	systemPropertiesMap["java.vm.specification.name"] = getOsProperty("java.vm.specification.name")
+	systemPropertiesMap["java.vm.specification.vendor"] = getOsProperty("java.vm.specification.vendor")
+	systemPropertiesMap["java.vm.specification.version"] = getOsProperty("java.vm.specification.version")
+	systemPropertiesMap["java.vm.vendor"] = getOsProperty("java.vm.vendor")
+	systemPropertiesMap["java.vm.version"] = getOsProperty("java.vm.version")
+	systemPropertiesMap["line.separator"] = getOsProperty("line.separator")
+	systemPropertiesMap["native.encoding"] = getOsProperty("native.encoding")
+	systemPropertiesMap["os.arch"] = getOsProperty("os.arch")
+	systemPropertiesMap["os.name"] = getOsProperty("os.name")
+	systemPropertiesMap["os.version"] = getOsProperty("os.version")
+	systemPropertiesMap["path.separator"] = getOsProperty("path.separator")
+	systemPropertiesMap["stdout.encoding"] = getOsProperty("stdout.encoding")
+	systemPropertiesMap["stderr.encoding"] = getOsProperty("stderr.encoding")
+	systemPropertiesMap["user.dir"] = getOsProperty("user.dir")
+	systemPropertiesMap["user.home"] = getOsProperty("user.home")
+	systemPropertiesMap["user.name"] = getOsProperty("user.name")
+	systemPropertiesMap["user.timezone"] = getOsProperty("user.timezone")
+}
+
+// GetSystemProperty: get a system property.
+func GetSystemProperty(key string) string {
+	return systemPropertiesMap[key]
+}
+
+// SetSystemProperty: add or update a system property.
+func SetSystemProperty(key, value string) {
+	systemPropertiesMutex.Lock()
+	defer systemPropertiesMutex.Unlock()
+	systemPropertiesMap[key] = value
+}
+
+// RemoveSystemProperty: remove a system property.
+func RemoveSystemProperty(key string) {
+	systemPropertiesMutex.Lock()
+	defer systemPropertiesMutex.Unlock()
+	delete(systemPropertiesMap, key)
+}
+
+// ReplaceSystemProperties: replace the current map with a new one.
+func ReplaceSystemProperties(newMap types.DefProperties) {
+	systemPropertiesMutex.Lock()
+	defer systemPropertiesMutex.Unlock()
+	systemPropertiesMap = newMap
+}
+
+// getOSVersion: Get the O/S version string and return it to caller.
+func getOSVersion() string {
+	var cmd *exec.Cmd
+
+	operSys := runtime.GOOS
+	switch operSys {
+	case "windows":
+		cmd = exec.Command("cmd", "/C", "ver")
+	default:
+		cmd = exec.Command("uname", "-r")
+	}
+
+	cmdBytes, err := cmd.CombinedOutput()
+	if err != nil {
+		errMsg := fmt.Sprintf("getOSVersion: cmd.CombinedOutput() failed on %s: %v", operSys, err)
+		return errMsg
+	}
+
+	var cleanBytes []byte
+	for ix := 0; ix < len(cmdBytes); ix++ {
+		if unicode.IsPrint(rune(cmdBytes[ix])) {
+			cleanBytes = append(cleanBytes, cmdBytes[ix])
+		}
+	}
+
+	return string(cleanBytes)
 }


### PR DESCRIPTION
- src/gfunction/javaLangSystem.go - move system property functions to global; added more functions and traps.
- src/globals/globals.go - new functions to support system properties, independent of O/S.
- src/gfunction/javaLangSystem_test.go - added globals.InitGlobals("test") in all unit tests that did not previously call this function; updated tests to use global functions; added new unit tests for new functions.
- src/gfunction/javaLangInteger.go - globals.GetSystemProperty(name).
- src/gfunction/javaLangRuntime.go - reflects a function name change, exitI to systemExitI,
- notes/javaBaseShare-natives-byParam.md - reflects a function name change, currentTimeMillis to systemCurrentTimeMillis.

So, now, Java programs can set properties, remove properties, and replace all of them from a caller-supplied Properties object.

Note that the fake SecurityManager (an object.Object with no functions) was removed. Instead all functions requesting this deprecated facility are trapped. If this turns out to be a bad idea for whatever reason, we can always re-instate it.