### PR TITLE
JACOBIN-731 Re-instate SecurityManager; trap Class.getComponent()

### DIFF
--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -114,18 +114,6 @@ func Load_Traps() {
 			GFunction:  trapClass,
 		}
 
-	MethodSignatures["java/lang/SecurityManager.<clinit>()V"] =
-		GMeth{
-			ParamSlots: 0,
-			GFunction:  trapDeprecated,
-		}
-
-	MethodSignatures["java/lang/SecurityManager.<init>()V"] =
-		GMeth{
-			ParamSlots: 0,
-			GFunction:  trapDeprecated,
-		}
-
 	MethodSignatures["java/nio/ByteBuffer.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,

--- a/src/gfunction/javaLangClass.go
+++ b/src/gfunction/javaLangClass.go
@@ -38,6 +38,12 @@ func Load_Lang_Class() {
 			GFunction:  getAssertionsEnabledStatus,
 		}
 
+	MethodSignatures["java/lang/Class.getComponentType()Ljava/lang/Class;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
 	MethodSignatures["java/lang/Class.getModule()Ljava/lang/Module;"] =
 		GMeth{
 			ParamSlots: 0,

--- a/src/gfunction/javaLangSecurityManager.go
+++ b/src/gfunction/javaLangSecurityManager.go
@@ -1,183 +1,259 @@
 /*
  * Jacobin VM - A Java virtual machine
- * Copyright (c) 2023 by  the Jacobin authors. Consult jacobin.org.
+ * Copyright (c) 2025 by  the Jacobin authors. Consult jacobin.org.
  * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
  */
 
 package gfunction
 
-import (
-	"jacobin/excNames"
-	"jacobin/object"
-	"jacobin/trace"
-	"jacobin/types"
-)
+// TODO: The entire SecurityManager class is deprecated and will be removed in the future.
 
-// TODO: Delete this file and the reference to Load_Lang_SecurityManager() in gfunction.go
-// TODO: and javaLangSystem.go when the Java library stops using the SecurityManager class.
+var classNameSecurityManager = "java/lang/SecurityManager"
 
 func Load_Lang_SecurityManager() {
-
-	MethodSignatures["java/lang/SecurityManager.<clinit>()V"] =
+	MethodSignatures[classNameSecurityManager+".<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  clinitGeneric,
+			GFunction:  justReturn,
 		}
 
-	MethodSignatures["java/lang/SecurityManager.<init>()V"] =
+	MethodSignatures[classNameSecurityManager+".<init>()V"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  secmgrInit,
+			GFunction:  justReturn,
 		}
 
-	MethodSignatures["java/lang/SecurityManager.checkAccept(Ljava/lang/String;I)V"] =
+	MethodSignatures[classNameSecurityManager+".checkAccept(Ljava/lang/String;I)V"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  justReturn,
 		}
 
-	MethodSignatures["java/lang/SecurityManager.checkAccess(Ljava/lang/Thread)V"] =
+	MethodSignatures[classNameSecurityManager+".checkAccess(Ljava/lang/Thread;)V"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  justReturn,
 		}
 
-	MethodSignatures["java/lang/SecurityManager.checkAccess(Ljava/lang/ThreadGroup)V"] =
+	MethodSignatures[classNameSecurityManager+".checkAccess(Ljava/lang/ThreadGroup;)V"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  justReturn,
 		}
 
-	MethodSignatures["java/lang/SecurityManager.checkConnect(Ljava/lang/String;I)V"] =
+	MethodSignatures[classNameSecurityManager+".checkAwtEventQueueAccess()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures[classNameSecurityManager+".checkConnect(Ljava/lang/String;I)V"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  justReturn,
 		}
 
-	MethodSignatures["java/lang/SecurityManager.checkConnect(Ljava/lang/String;ILjava/lang/Object;)V"] =
+	MethodSignatures[classNameSecurityManager+".checkConnect(Ljava/lang/String;ILjava/lang/Object;)V"] =
 		GMeth{
 			ParamSlots: 3,
 			GFunction:  justReturn,
 		}
 
-	MethodSignatures["java/lang/SecurityManager.checkCreateClassLoader()V"] =
+	MethodSignatures[classNameSecurityManager+".checkCreateClassLoader()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  justReturn,
 		}
 
-	MethodSignatures["java/lang/SecurityManager.checkDelete(Ljava/lang/String;)V"] =
+	MethodSignatures[classNameSecurityManager+".checkDelete(Ljava/lang/String;)V"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  justReturn,
 		}
 
-	MethodSignatures["java/lang/SecurityManager.checkExec(Ljava/lang/String;)V"] =
+	MethodSignatures[classNameSecurityManager+".checkExec(Ljava/lang/String;)V"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  justReturn,
 		}
 
-	MethodSignatures["java/lang/SecurityManager.checkExit(I)V"] =
+	MethodSignatures[classNameSecurityManager+".checkExit(I)V"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  justReturn,
 		}
 
-	MethodSignatures["java/lang/SecurityManager.checkLink(Ljava/lang/String;)V"] =
+	MethodSignatures[classNameSecurityManager+".checkLink(Ljava/lang/String;)V"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  justReturn,
 		}
 
-	MethodSignatures["java/lang/SecurityManager.checkListen(I)V"] =
+	MethodSignatures[classNameSecurityManager+".checkListen(I)V"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  justReturn,
 		}
 
-	MethodSignatures["java/lang/SecurityManager.checkMulticast(Ljava/net/InetAddress;)V"] =
-		GMeth{
-			ParamSlots: 1,
-			GFunction:  justReturn,
-		}
-
-	MethodSignatures["java/lang/SecurityManager.checkPackageAccess(Ljava/lang/String;)V"] =
-		GMeth{
-			ParamSlots: 1,
-			GFunction:  justReturn,
-		}
-
-	MethodSignatures["java/lang/SecurityManager.checkPackageDefinition(Ljava/lang/String;)V"] =
-		GMeth{
-			ParamSlots: 1,
-			GFunction:  justReturn,
-		}
-
-	MethodSignatures["java/lang/SecurityManager.checkPermission(Ljava/security/Permission;)V"] =
-		GMeth{
-			ParamSlots: 1,
-			GFunction:  justReturn,
-		}
-
-	MethodSignatures["java/lang/SecurityManager.checkPrintJobAccess()V"] =
-		GMeth{
-			ParamSlots: 0,
-			GFunction:  justReturn,
-		}
-
-	MethodSignatures["java/lang/SecurityManager.checkPropertiesAccess()V"] =
-		GMeth{
-			ParamSlots: 0,
-			GFunction:  justReturn,
-		}
-
-	MethodSignatures["java/lang/SecurityManager.checkPropertyAccess(Ljava/lang/String;)V"] =
-		GMeth{
-			ParamSlots: 1,
-			GFunction:  justReturn,
-		}
-
-	MethodSignatures["java/lang/SecurityManager.checkRead(Ljava/io/FileDescriptor;)V"] =
-		GMeth{
-			ParamSlots: 1,
-			GFunction:  justReturn,
-		}
-
-	MethodSignatures["java/lang/SecurityManager.checkRead(Ljava/lang/String;)V"] =
-		GMeth{
-			ParamSlots: 1,
-			GFunction:  justReturn,
-		}
-
-	MethodSignatures["java/lang/SecurityManager.checkRead(Ljava/lang/String;Ljava/lang/Object;)V"] =
+	MethodSignatures[classNameSecurityManager+".checkMemberAccess(Ljava/lang/Class;I)V"] =
 		GMeth{
 			ParamSlots: 2,
 			GFunction:  justReturn,
 		}
 
-	MethodSignatures["java/lang/SecurityManager.checkWrite(Ljava/io/FileDescriptor;)V"] =
+	MethodSignatures[classNameSecurityManager+".checkMulticast(Ljava/net/InetAddress;)V"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  justReturn,
 		}
 
-	MethodSignatures["java/lang/SecurityManager.checkWrite(Ljava/lang/String;)V"] =
+	MethodSignatures[classNameSecurityManager+".checkMulticast(Ljava/net/InetAddress;B)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures[classNameSecurityManager+".checkPackageAccess(Ljava/lang/String;)V"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  justReturn,
 		}
 
-}
+	MethodSignatures[classNameSecurityManager+".checkPackageDefinition(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
 
-func secmgrInit(params []interface{}) interface{} {
-	obj, ok := params[0].(*object.Object)
-	if !ok {
-		errMsg := "secmgrInit: SecurityManager parameter is not an object"
-		trace.Error(errMsg)
-		return getGErrBlk(excNames.VirtualMachineError, errMsg)
-	}
-	fld := object.Field{Ftype: types.Int, Fvalue: 42}
-	obj.FieldTable["value"] = fld
-	return nil
+	MethodSignatures[classNameSecurityManager+".checkPermission(Ljava/security/Permission;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures[classNameSecurityManager+".checkPermission(Ljava/security/Permission;Ljava/lang/Object;)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures[classNameSecurityManager+".checkPrintJobAccess()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures[classNameSecurityManager+".checkPropertiesAccess()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures[classNameSecurityManager+".checkPropertyAccess(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures[classNameSecurityManager+".checkRead(Ljava/io/FileDescriptor;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures[classNameSecurityManager+".checkRead(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures[classNameSecurityManager+".checkRead(Ljava/lang/String;Ljava/lang/Object;)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures[classNameSecurityManager+".checkSecurityAccess(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures[classNameSecurityManager+".checkSetFactory()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures[classNameSecurityManager+".checkSystemClipboardAccess()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures[classNameSecurityManager+".checkTopLevelWindow(Ljava/lang/Object;)Z"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures[classNameSecurityManager+".checkWrite(Ljava/io/FileDescriptor;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures[classNameSecurityManager+".checkWrite(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures[classNameSecurityManager+".classDepth(Ljava/lang/String;)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures[classNameSecurityManager+".classLoaderDepth()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures[classNameSecurityManager+".currentClassLoader()Ljava/lang/ClassLoader;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures[classNameSecurityManager+".currentLoadedClass()Ljava/lang/Class;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures[classNameSecurityManager+".getClassContext()[Ljava/lang/Class;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures[classNameSecurityManager+".getInCheck()Z"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures[classNameSecurityManager+".getSecurityContext()Ljava/lang/Object;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures[classNameSecurityManager+".getThreadGroup()Ljava/lang/ThreadGroup;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
+		}
 }

--- a/src/gfunction/javaLangStringBuilder.go
+++ b/src/gfunction/javaLangStringBuilder.go
@@ -454,7 +454,7 @@ func stringBuilderInitString(params []any) any {
 // F                           float64
 // I                           int64
 // J                           int64
-// Ljava/lang/Object;          *object.Object [diagnosed with an error]
+// Ljava/lang/Object;          *object.Object
 // Ljava/lang/String;          *object.Object
 // Ljava/lang/StringBuffer;    *object.Object
 func stringBuilderAppend(params []any) any {
@@ -494,9 +494,8 @@ func stringBuilderAppend(params []any) any {
 				}
 			}
 		default:
-			errMsg := fmt.Sprintf("stringBuilderAppend: Object value field value type (%T) is not a byte array nor a char array",
-				params[1])
-			return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+			str := object.StringifyAnythingGo(fvalue)
+			parmArray = object.JavaByteArrayFromGoString(str)
 		}
 	case int64: // int, long, short
 		str := fmt.Sprintf("%d", params[1].(int64))
@@ -506,8 +505,8 @@ func stringBuilderAppend(params []any) any {
 		str := strconv.FormatFloat(ff, 'f', -1, 64)
 		parmArray = object.JavaByteArrayFromGoString(str)
 	default:
-		errMsg := fmt.Sprintf("stringBuilderAppend: Parameter type (%T) is illegal", params[1])
-		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+		str := object.StringifyAnythingGo(params[1])
+		parmArray = object.JavaByteArrayFromGoString(str)
 	}
 
 	// Append parmArray to the byteArray.

--- a/src/gfunction/javaLangSystem.go
+++ b/src/gfunction/javaLangSystem.go
@@ -134,7 +134,7 @@ func Load_Lang_System() {
 	MethodSignatures["java/lang/System.getSecurityManager()Ljava/lang/SecurityManager;"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  trapDeprecated,
+			GFunction:  systemGetSecurityManager,
 		}
 
 	MethodSignatures["java/lang/System.identityHashCode(Ljava/lang/Object;)I"] =
@@ -508,6 +508,11 @@ func systemGetProperties([]interface{}) interface{} {
 
 	return object.MakeOneFieldObject(classNameProperties, fieldNameProperties, types.Properties, propMap)
 
+}
+
+// systemGetSecurityManager
+func systemGetSecurityManager(params []interface{}) interface{} {
+	return object.MakeEmptyObjectWithClassName(&classNameSecurityManager)
 }
 
 // Get the system line separator.

--- a/src/gfunction/javaUtilArrays.go
+++ b/src/gfunction/javaUtilArrays.go
@@ -19,6 +19,12 @@ func Load_Util_Arrays() {
 			ParamSlots: 2,
 			GFunction:  copyOfObjectPointers,
 		}
+
+	MethodSignatures["java/util/Arrays.copyOf([Ljava/lang/Object;ILjava/lang/Class;)[Ljava/lang/Object;"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  trapFunction,
+		}
 }
 
 // Copy the specified array of pointers, truncating or padding with nulls so the copy has the specified length.

--- a/src/gfunction/otherMethods.go
+++ b/src/gfunction/otherMethods.go
@@ -44,16 +44,16 @@ func Load_Other_methods() {
 			GFunction:  clinitGeneric,
 		}
 
-	MethodSignatures["java/lang/SecurityManager.checkRead(Ljava/lang/String;)V"] =
-		GMeth{
-			ParamSlots: 1,
-			GFunction:  justReturn,
-		}
-
-	MethodSignatures["java/math/BigDecimal.<clinit>()V"] =
+	MethodSignatures["java/lang/ThreadLocal.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,
 			GFunction:  clinitGeneric,
+		}
+
+	MethodSignatures["java/lang/ThreadLocal.<init>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
 		}
 
 	MethodSignatures["java/math/MathContext.<clinit>()V"] =


### PR DESCRIPTION
- modified:   gfunction/Traps.go - move SecurityManager traps to gfunction/javaLangSecurityManager.go.
- modified:   gfunction/javaLangClass.go - trap getComponent().
- modified:   gfunction/javaLangSecurityManager.go - 
     - void functions (nearly all of them) --> justReturn.
     - non-void returns --> trapDeprecated.
- modified:   gfunction/javaLangStringBuilder.go - append() use object.StringifyAnythingGo.
- modified:   gfunction/javaLangSystem.go - get a dummy SecurityManager.
- modified:   gfunction/otherMethods.go - add java/lang/ThreadLocal.`<clinit>` and `<init>` --> justReturn.
- modified:   gfunction/javaUtilArrays.go - trap copyOf([Ljava/lang/Object;ILjava/lang/Class;)[Ljava/lang/Object;
