### PR TITLE
JACOBIN-734 G-alternative mode

### DIFF
--- a/src/gfunction/galt.go
+++ b/src/gfunction/galt.go
@@ -1,0 +1,113 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2024 by the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package gfunction
+
+func Load_Experiment() {
+
+	MethodSignatures["java/io/FileInputStream.initIDs()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  returnTrue,
+		}
+
+	MethodSignatures["java/io/UnixFileSystem.initIDs()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  returnTrue,
+		}
+
+	MethodSignatures["java/lang/Class.desiredAssertionStatus()Z"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  returnTrue,
+		}
+
+	MethodSignatures["java/lang/Class.desiredAssertionStatus0()Z"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  returnTrue,
+		}
+
+	MethodSignatures["java/lang/Class.registerNatives()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/Runtime.availableProcessors()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  runtimeAvailableProcessors,
+		}
+
+	MethodSignatures["java/lang/System.registerNatives()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/lang/System.currentTimeMillis()J"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  systemCurrentTimeMillis,
+		}
+
+	MethodSignatures["java/lang/System.nanoTime()J"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  systemNanoTime,
+		}
+
+	MethodSignatures["java/lang/Thread.registerNatives()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["java/util/concurrent/atomic/AtomicLong.VMSupportsCS8()Z"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  returnTrue,
+		}
+
+	MethodSignatures["jdk/internal/misc/CDS.isDumpingArchive0()Z"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  returnFalse,
+		}
+
+	MethodSignatures["jdk/internal/misc/CDS.isDumpingClassList0()Z"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  returnFalse,
+		}
+
+	MethodSignatures["jdk/internal/misc/CDS.initializeFromArchive(Ljava/lang/Class;)V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["jdk/internal/misc/CDS.isSharingEnabled0()Z"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  returnFalse,
+		}
+
+	MethodSignatures["jdk/internal/misc/Unsafe.registerNatives()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["jdk/internal/misc/VM.initialize()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+}

--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -94,84 +94,90 @@ func returnCharsetName([]interface{}) interface{} {
 // they make available.
 func MTableLoadGFunctions(MTable *classloader.MT) {
 
-	// java/awt/*
-	Load_Awt_Graphics_Environment()
+	if globals.Galt {
+		Load_Experiment()
+	} else {
 
-	// java/io/*
-	Load_Io_BufferedReader()
-	Load_Io_Console()
-	Load_Io_File()
-	Load_Io_FileInputStream()
-	Load_Io_FileOutputStream()
-	Load_Io_FileReader()
-	Load_Io_FileWriter()
-	Load_Io_FilterInputStream()
-	Load_Io_InputStreamReader()
-	Load_Io_OutputStreamWriter()
-	Load_Io_PrintStream()
-	Load_Io_RandomAccessFile()
+		// java/awt/*
+		Load_Awt_Graphics_Environment()
 
-	// java/lang/*
-	Load_Lang_Boolean()
-	Load_Lang_Byte()
-	Load_Lang_Character()
-	Load_Lang_Class()
-	classClinitIsh()
-	Load_Lang_Double()
-	Load_Lang_Float()
-	Load_Lang_Integer()
-	Load_Lang_Long()
-	Load_Lang_Math()
-	Load_Lang_Object()
-	Load_Lang_Process_Handle_Impl() // includes ProcessHandleImpl, ProcessHandle, and ProcessHandle.Info
-	Load_Lang_Runtime()
-	Load_Lang_SecurityManager()
-	Load_Lang_Short()
-	Load_Lang_StackTraceELement()
-	Load_Lang_String()
-	Load_Lang_StringBuffer()
-	Load_Lang_StringBuilder()
-	Load_Lang_System()
-	Load_Lang_Thread()
-	Load_Lang_Throwable()
-	Load_Lang_UTF16()
+		// java/io/*
+		Load_Io_BufferedReader()
+		Load_Io_Console()
+		Load_Io_File()
+		Load_Io_FileInputStream()
+		Load_Io_FileOutputStream()
+		Load_Io_FileReader()
+		Load_Io_FileWriter()
+		Load_Io_FilterInputStream()
+		Load_Io_InputStreamReader()
+		Load_Io_OutputStreamWriter()
+		Load_Io_PrintStream()
+		Load_Io_RandomAccessFile()
 
-	// java/math/*
-	Load_Math_Big_Integer()
-	Load_Math_Big_Decimal()
+		// java/lang/*
+		Load_Lang_Boolean()
+		Load_Lang_Byte()
+		Load_Lang_Character()
+		Load_Lang_Class()
+		classClinitIsh()
+		Load_Lang_Double()
+		Load_Lang_Float()
+		Load_Lang_Integer()
+		Load_Lang_Long()
+		Load_Lang_Math()
+		Load_Lang_Object()
+		Load_Lang_Process_Handle_Impl()
+		Load_Lang_Runtime()
+		Load_Lang_SecurityManager()
+		Load_Lang_Short()
+		Load_Lang_StackTraceELement()
+		Load_Lang_String()
+		Load_Lang_StringBuffer()
+		Load_Lang_StringBuilder()
+		Load_Lang_System()
+		Load_Lang_Thread()
+		Load_Lang_Throwable()
+		Load_Lang_UTF16()
 
-	// java/security/*
-	Load_Security_SecureRandom()
+		// java/math/*
+		Load_Math_Big_Integer()
+		Load_Math_Big_Decimal()
 
-	// java/util/*
-	Load_Util_Arrays()
-	Load_Util_Base64()
-	Load_Util_Concurrent_Atomic_AtomicInteger()
-	Load_Util_Concurrent_Atomic_Atomic_Long()
-	Load_Util_Hash_Map()
-	Load_Util_Hash_Set()
-	Load_Util_HexFormat()
-	Load_Util_LinkedList()
-	Load_Util_Locale()
-	Load_Util_Properties()
-	Load_Util_Objects()
-	Load_Util_Optional()
-	Load_Util_Random()
-	Load_Util_Zip_Adler32()
-	Load_Util_Zip_Crc32_Crc32c()
+		// java/security/*
+		Load_Security_SecureRandom()
 
-	// jdk/internal/misc/*
-	Load_Jdk_Internal_Misc_Unsafe()
-	Load_Jdk_Internal_Misc_ScopedMemoryAccess()
+		// java/util/*
+		Load_Util_Arrays()
+		Load_Util_Base64()
+		Load_Util_Concurrent_Atomic_AtomicInteger()
+		Load_Util_Concurrent_Atomic_Atomic_Long()
+		Load_Util_Hash_Map()
+		Load_Util_Hash_Set()
+		Load_Util_HexFormat()
+		Load_Util_LinkedList()
+		Load_Util_Locale()
+		Load_Util_Properties()
+		Load_Util_Objects()
+		Load_Util_Optional()
+		Load_Util_Random()
+		Load_Util_Zip_Adler32()
+		Load_Util_Zip_Crc32_Crc32c()
 
-	// Load functions that invoke clinitGeneric() and do nothing else.
-	Load_Other_methods()
+		// jdk/internal/misc/*
+		Load_Jdk_Internal_Misc_Unsafe()
+		Load_Jdk_Internal_Misc_ScopedMemoryAccess()
 
-	// Load traps that lead to unconditional error returns.
-	Load_Traps()
+		// Load functions that invoke clinitGeneric() and do nothing else.
+		Load_Other_methods()
 
-	// jacobin JVM diagnostic routines
-	Load_jj()
+		// Load traps that lead to unconditional error returns.
+		Load_Traps()
+
+		// Load diagnostic helper functions.
+		Load_jj()
+
+	}
 
 	//	now, with the accumulated MethodSignatures maps, load MTable.
 	loadlib(MTable, MethodSignatures)

--- a/src/globals/globals.go
+++ b/src/globals/globals.go
@@ -108,6 +108,9 @@ type Globals struct {
 	FuncFillInStackTrace func([]any) any
 }
 
+// ---- JJ options
+var Galt bool
+
 // ---- trace categories
 var TraceInit bool
 var TraceCloadi bool
@@ -163,6 +166,10 @@ func InitGlobals(progName string) Globals {
 		FuncMinimalAbort:     fakeMinimalAbort,
 	}
 
+	// ----- G function alternative processing flag
+	Galt = false
+
+	// ----- Tracing flags
 	TraceInit = false
 	TraceCloadi = false
 	TraceInst = false

--- a/src/jvm/option_table_loader.go
+++ b/src/jvm/option_table_loader.go
@@ -21,7 +21,7 @@ import (
 //
 // The table is initially created in globals.go and its declaration contains a
 // key consisting of a string with the option as typed on the command line, and
-// a value concisting of an Option struct (also defined in global.go), having
+// a value consisting of an Option struct (also defined in global.go), having
 // this layout:
 //     type Option struct {
 //	        supported bool      // is this option supported in Jacobin?
@@ -29,7 +29,7 @@ import (
 //	        argStyle  int16     // what is the format for the argument values to this option?
 //                              // 0 = no argument      1 = value follows a :
 //                              // 2 = value follows =  4 = value follows a space
-//                              // 8 = option has multiple values separated by a single character (such as in -trace and -cp)
+//                              // 10 = option has multiple values separated by a single character (such as in -trace and -cp)
 //	        action  func(position int, name string, gl pointer to globasl) error
 //                              // which is the action to perform when this option found.
 //      }
@@ -86,9 +86,6 @@ func LoadOptionsTable(Global globals.Globals) {
 	Global.Options["-jar"] = jarFile
 	jarFile.Set = true
 
-	// newInterpreter := globals.Option{true, false, 0, newInterpeter}
-	// Global.Options["-new"] = newInterpreter
-
 	showversion := globals.Option{true, false, 0, showVersionStderr}
 	Global.Options["-showversion"] = showversion
 
@@ -100,6 +97,9 @@ func LoadOptionsTable(Global globals.Globals) {
 
 	traceInstruction := globals.Option{true, false, 10, enableTrace}
 	Global.Options["-trace"] = traceInstruction
+
+	JJ := globals.Option{true, false, 10, enableJJ}
+	Global.Options["-JJ"] = JJ
 
 	version := globals.Option{true, false, 1, versionStderrThenExit}
 	Global.Options["-version"] = version
@@ -216,6 +216,20 @@ func enableAssertions(pos int, name string, gl *globals.Globals) (int, error) {
 	setOptionToSeen("-ea", gl)
 	statics.AddStatic("main.$assertionsDisabled",
 		statics.Static{Type: types.Int, Value: types.JavaBoolFalse})
+	return pos, nil
+}
+
+func enableJJ(pos int, argValue string, gl *globals.Globals) (int, error) {
+	setOptionToSeen("-trace", gl)
+	array := strings.Split(argValue, TraceSep)
+	for i := 0; i < len(array); i++ {
+		switch array[i] {
+		case "galt":
+			globals.Galt = true
+		default:
+			return 0, fmt.Errorf("unknown -JJ option: %s", array[i])
+		}
+	}
 	return pos, nil
 }
 


### PR DESCRIPTION
new file:   gfunction/galt.go : See JACOBIN-734 for description.
modified:   gfunction/gfunction.go : if-else logic of loading MethodSignatures familes, based on globals.galt.
modified:   globals/globals.go : globals.galt : If true, load only the MethodSingatures entries from gfunction/galt.go.
modified:   jvm/interpreter.go : fix to ISHR processing when the parameter is a byte or types.JavaByte.
modified:   jvm/option_table_loader.go : implement the -JJ option.
