### PR TITLE
JACOBIN-734 use colon as option key/value separator

### DIFF
--- a/src/jvm/cli.go
+++ b/src/jvm/cli.go
@@ -96,16 +96,30 @@ func HandleCli(osArgs []string, Global *globals.Globals) (err error) {
 }
 
 // pass in the option potentially with embedded arguments and get back
-// the option name and the embedded argument(s), if any
+// the option name and the embedded argument(s) as a single string, if any
+//
+// Return, 3 patterns:
+// (1) Pattern is -key:value
+// * 	option name (key) - string (E.g. "-cp")
+// * 	option argument(s) - string (E.g. ".;C:\home\user\classes")
+// * 	error struct - nil (indicates success)
+// (2) Pattern is -key
+// * 	option name (key) - string (E.g. "--help")
+// * 	option argument(s) - ""
+// * 	error struct - nil (indicates success)
+// (3) Error
+// * 	option name (key) - ""
+// * 	option argument(s) - ""
+// * 	error struct - !nil (indicates failure)
 func getOptionRootAndArgs(option string) (string, string, error) {
 	if len(option) == 0 {
 		return "", "", errors.New("empty option error")
 	}
 
-	// if the option has an embedded arg value, it'll come after the first =
-	argMarker := strings.Index(option, "=")
+	// if the option has an embedded arg value, it'll come after the first colon (:).
+	argMarker := strings.Index(option, ":")
 
-	// if there's no embedded : or = then the option doesn't contain an arg value
+	// if there's no embedded colon (:), then the option doesn't contain an arg value
 	if argMarker == -1 {
 		return option, "", nil
 	}
@@ -114,7 +128,7 @@ func getOptionRootAndArgs(option string) (string, string, error) {
 
 }
 
-// you can can set JVM options using the three environment variables that are
+// you can set JVM options using the three environment variables that are
 // inspected in this function. Note: order is important because later options
 // can override earlier ones. These are checked before any of the command-line
 // options are processed.

--- a/src/jvm/cli_test.go
+++ b/src/jvm/cli_test.go
@@ -182,7 +182,7 @@ func TestInvalidTraceSelection(t *testing.T) {
 	_, werr, _ := os.Pipe()
 	os.Stderr = werr
 
-	options := "-trace=inst" + TraceSep + "class" + TraceSep + "mickey"
+	options := "-trace:inst" + TraceSep + "class" + TraceSep + "mickey"
 	args := []string{"jacobin", options}
 	err = HandleCli(args, &global)
 
@@ -211,7 +211,7 @@ func TestValidTraceSelection(t *testing.T) {
 	_, werr, _ := os.Pipe()
 	os.Stderr = werr
 
-	options := "-trace=inst" + TraceSep + "class" + TraceSep + "inst"
+	options := "-trace:inst" + TraceSep + "class" + TraceSep + "inst"
 	args := []string{"jacobin", options}
 	err = HandleCli(args, &global)
 

--- a/src/wholeClassTests/Hello1_test.go
+++ b/src/wholeClassTests/Hello1_test.go
@@ -150,7 +150,7 @@ func TestRunHelloTraceClass(t *testing.T) {
 
 	var cmd *exec.Cmd
 
-	_JVM_ARGS = "-trace=class"
+	_JVM_ARGS = "-trace:class"
 	// run the various combinations of args. This is necessary b/c the empty string is viewed as
 	// an actual specified option on the command line.
 	if len(_JVM_ARGS) > 0 {
@@ -207,7 +207,7 @@ func TestRunHelloTraceInit(t *testing.T) {
 
 	var cmd *exec.Cmd
 
-	_JVM_ARGS = "-trace=init"
+	_JVM_ARGS = "-trace:init"
 	// run the various combinations of args. This is necessary b/c the empty string is viewed as
 	// an actual specified option on the command line.
 	if len(_JVM_ARGS) > 0 {

--- a/src/wholeClassTests/LDIVexception_test.go
+++ b/src/wholeClassTests/LDIVexception_test.go
@@ -77,7 +77,7 @@ func TestRunLDIVexception(t *testing.T) {
 		t.Skip()
 	}
 
-	_JVM_ARGS = "-trace=inst"
+	_JVM_ARGS = "-trace:inst"
 	// run the various combinations of args. This is necessary b/c the empty string is viewed as
 	// an actual specified option on the command line.
 	if len(_JVM_ARGS) > 0 {


### PR DESCRIPTION
	modified:   jvm/cli.go
	modified:   jvm/cli_test.go
	modified:   wholeClassTests/Hello1_test.go
	modified:   wholeClassTests/LDIVexception_test.go
