### PR TITLE
Minor updates to improve error reporting

### DIFF
--- a/src/classloader/codeCheck.go
+++ b/src/classloader/codeCheck.go
@@ -449,7 +449,7 @@ var Code []byte
 func CheckCodeValidity(code []byte, cp *CPool) error {
 	// check that the code is valid
 	if code == nil {
-		errMsg := "CheckCodeValidity: code to be checked is nil"
+		errMsg := "CheckCodeValidity: Empty code segment"
 		return errors.New(errMsg)
 	}
 

--- a/src/jvm/instantiate.go
+++ b/src/jvm/instantiate.go
@@ -211,8 +211,9 @@ runInitializer:
 				code, &k.Data.CP)
 			if err != nil {
 				methName := k.Data.CP.Utf8Refs[m.Name]
-				errMsg := fmt.Sprintf("InstantiateClass: CheckCodeValidity failed in %s.%s:\n\t%s",
-					classname, methName, err.Error())
+				methDesc := k.Data.CP.Utf8Refs[m.Desc]
+				errMsg := fmt.Sprintf("InstantiateClass: CheckCodeValidity failed in %s.%s%s: %s",
+					classname, methName, methDesc, err.Error())
 				status := exceptions.ThrowEx(excNames.ClassFormatError, errMsg, nil)
 				if status != exceptions.Caught {
 					return nil, errors.New(errMsg) // applies only if in test

--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -284,7 +284,7 @@ func interpret(fs *list.List) {
 	}
 
 	fr := fs.Front().Value.(*frames.Frame)
-	if fr.FrameStack == nil { // make sure the can reference the frame stack
+	if fr.FrameStack == nil { // make sure we can reference the frame stack
 		fr.FrameStack = fs
 	}
 


### PR DESCRIPTION
src/classloader/codeCheck.go - use the interpreter.go phrase "Empty code segment" to assist Jacotest error categorization.
src/jvm/instantiate.go - show the method descriptor/type when reporting errors.


