### PR TITLE
JACOBIN-744 Interpreter doAthrow crash on detailMessage = null object

### DIFF
--- a/src/go.sum
+++ b/src/go.sum
@@ -1,11 +1,11 @@
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 golang.org/x/mod v0.25.0 h1:n7a+ZbQKQA/Ysbyb0/6IbB1H/X41mKgbhfv7AfG/44w=
 golang.org/x/mod v0.25.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
 golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
 golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
-golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
-golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/telemetry v0.0.0-20240521205824-bda55230c457 h1:zf5N6UOrA487eEFacMePxjXAJctxKmyjKUsjA11Uzuk=

--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -2949,8 +2949,7 @@ func doAthrow(fr *frames.Frame, _ int64) int {
 					errMsg += fmt.Sprintf(": %s", str)
 				}
 			default:
-				str := fmt.Sprintf(": %v", appMsg)
-				errMsg += fmt.Sprintf(": %s", str)
+				errMsg += ": objectRef.FieldTable[\"detailMessage\"] is object.Null"
 			}
 		}
 		trace.Error(errMsg)

--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -2924,14 +2924,20 @@ func doAthrow(fr *frames.Frame, _ int64) int {
 		}
 
 		appMsg := objectRef.FieldTable["detailMessage"].Fvalue
-		if appMsg != nil {
+		if appMsg != object.Null {
 			switch appMsg.(type) {
 			case []types.JavaByte:
 				jbarray := appMsg.([]types.JavaByte)
 				errMsg += fmt.Sprintf(": %s", object.GoStringFromJavaByteArray(jbarray))
 			case *object.Object:
+				var value any
 				obj := appMsg.(*object.Object)
-				value := obj.FieldTable["value"].Fvalue
+				fld, ok := obj.FieldTable["value"]
+				if !ok {
+					value = "<missing>"
+				} else {
+					value = fld.Fvalue
+				}
 				switch value.(type) {
 				case []byte:
 					errMsg += fmt.Sprintf(": %s", string(obj.FieldTable["value"].Fvalue.([]byte)))


### PR DESCRIPTION
modified interpreter.go: fixes to doAthrow.