### PR TITLE
JACOBIN-746 Process (traps), Runtime (traps), and System (errMsg enhancement in systemArrayCopy)

### DIFF
--- a/src/classloader/classloader.go
+++ b/src/classloader/classloader.go
@@ -340,13 +340,13 @@ loadAclass:
 // LoadClassFromFile first canonicalizes the filename, and reads the file from the classpath,
 // and class the classloader to load it.
 func LoadClassFromFile(cl Classloader, fname string) (uint32, uint32, error) {
-	var filename string
+	var classFilename string
 	if !strings.HasSuffix(fname, ".class") {
-		filename = fname + ".class"
+		classFilename = fname + ".class"
 	} else {
-		filename = fname
+		classFilename = fname
 	}
-	if filename == ".class" || strings.HasSuffix(filename, ";.class") {
+	if classFilename == ".class" || strings.HasSuffix(classFilename, ";.class") {
 		errMsg := "LoadClassFromFile: class name" + fname + " is invalid"
 		trace.Error(errMsg)
 		debug.PrintStack()
@@ -356,7 +356,9 @@ func LoadClassFromFile(cl Classloader, fname string) (uint32, uint32, error) {
 	// read the file, starting with the first entry in the classpath
 	var rawBytes []byte
 	var err error
+	var filename string
 	for i, path := range globals.GetGlobalRef().Classpath {
+		filename = classFilename
 		// if the filepath is not absolute and does not start with the classpath entry, prepend the classpath entry
 		if !filepath.IsAbs(filename) && !strings.HasPrefix(filename, path) {
 			filename = filepath.Join(globals.GetGlobalRef().Classpath[i], filename)

--- a/src/classloader/classloader.go
+++ b/src/classloader/classloader.go
@@ -357,7 +357,6 @@ func LoadClassFromFile(cl Classloader, fname string) (uint32, uint32, error) {
 	var rawBytes []byte
 	var err error
 	for i, path := range globals.GetGlobalRef().Classpath {
-		filename = fname
 		// if the filepath is not absolute and does not start with the classpath entry, prepend the classpath entry
 		if !filepath.IsAbs(filename) && !strings.HasPrefix(filename, path) {
 			filename = filepath.Join(globals.GetGlobalRef().Classpath[i], filename)

--- a/src/gfunction/javaLangProcess.go
+++ b/src/gfunction/javaLangProcess.go
@@ -1,0 +1,76 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2023 by  the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package gfunction
+
+func Load_Lang_Process() {
+
+	MethodSignatures["javaLangProcess.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["javaLangProcess.<init>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn,
+		}
+
+	MethodSignatures["javaLangProcess.destroy()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["javaLangProcess.destroyForcibly()Ljava/lang/Process;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["javaLangProcess.exitValue()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["javaLangProcess.getErrorStream()Ljava/io/InputStream;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["javaLangProcess.getInputStream()Ljava/io/InputStream;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["javaLangProcess.getOutputStream()Ljava/io/OutputStream;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["javaLangProcess.isAlive()Z"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["javaLangProcess.waitFor()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["javaLangProcess.waitFor(JLjava/util/concurrent/TimeUnit;)Z"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+}

--- a/src/gfunction/javaLangRuntime.go
+++ b/src/gfunction/javaLangRuntime.go
@@ -40,10 +40,58 @@ func Load_Lang_Runtime() {
 			GFunction:  runtimeAvailableProcessors,
 		}
 
+	MethodSignatures["java/lang/Runtime.exec(Ljava/lang/String;)Ljava/lang/Process;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures["java/lang/Runtime.exec([Ljava/lang/String;)Ljava/lang/Process;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Runtime.exec([Ljava/lang/String;[Ljava/lang/String;)Ljava/lang/Process;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Runtime.exec([Ljava/lang/String;[Ljava/lang/String;Ljava/io/File;)Ljava/lang/Process;"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Runtime.exec(Ljava/lang/String;[Ljava/lang/String;)Ljava/lang/Process;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures["java/lang/Runtime.exec(Ljava/lang/String;[Ljava/lang/String;Ljava/io/File;)Ljava/lang/Process;"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  trapDeprecated,
+		}
+
 	MethodSignatures["java/lang/Runtime.exit(I)V"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  systemExitI, // javaLangSystem.go
+		}
+
+	MethodSignatures["java/lang/Runtime.freeMemory()J"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/lang/Runtime.gc()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  justReturn, // TODO: implement
 		}
 
 	MethodSignatures["java/lang/Runtime.getRuntime()Ljava/lang/Runtime;"] =

--- a/src/gfunction/javaLangSystem.go
+++ b/src/gfunction/javaLangSystem.go
@@ -275,7 +275,7 @@ func systemArrayCopy(params []interface{}) interface{} {
 	destType := *(stringPool.GetStringPointer(dest.KlassName))
 
 	if !strings.HasPrefix(srcType, types.Array) || !strings.HasPrefix(destType, types.Array) || srcType != destType {
-		errMsg := fmt.Sprintf("systemArrayCopy: invalid src or dest array")
+		errMsg := fmt.Sprintf("systemArrayCopy: invalid src (%s) or dest (%s) array", srcType, destType)
 		return getGErrBlk(excNames.ArrayStoreException, errMsg)
 	}
 

--- a/src/gfunction/javaLangSystem_test.go
+++ b/src/gfunction/javaLangSystem_test.go
@@ -231,7 +231,7 @@ func TestArrayCopyInvalidObject(t *testing.T) {
 	}
 
 	errMsg := err.(*GErrBlk).ErrMsg
-	if !strings.Contains(errMsg, "invalid src or dest array") {
+	if !strings.Contains(errMsg, "invalid src") {
 		t.Errorf("Expected error re invalid array type, got %s", errMsg)
 	}
 }


### PR DESCRIPTION
JACOBIN-747: _Remove left over line_ <--------- replaced with source file classloader.go from @platypusguy 

JACOBIN-746:
* Add traps to javaLangProcess.go (new)
* Add traps to javaLangRuntime.go
* Show relevant string info in a systemArrayCopy error message