### PR TITLE
JACOBIN-748 Move 3 jacotest cases along

### DIFF
--- a/src/gfunction/javaLangSystem.go
+++ b/src/gfunction/javaLangSystem.go
@@ -520,6 +520,7 @@ func systemGetProperties([]interface{}) interface{} {
 	propMap["path.separator"] = globals.GetSystemProperty("path.separator")
 	propMap["stdout.encoding"] = globals.GetSystemProperty("stdout.encoding")
 	propMap["stderr.encoding"] = globals.GetSystemProperty("stderr.encoding")
+	propMap["sun.jnu.encoding"] = globals.GetSystemProperty("sun.jnu.encoding")
 	propMap["user.dir"] = globals.GetSystemProperty("user.dir")
 	propMap["user.home"] = globals.GetSystemProperty("user.home")
 	propMap["user.name"] = globals.GetSystemProperty("user.name")

--- a/src/gfunction/jj.go
+++ b/src/gfunction/jj.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"fmt"
 	"jacobin/excNames"
+	"jacobin/globals"
 	"jacobin/object"
 	"jacobin/statics"
 	"jacobin/trace"
@@ -55,10 +56,16 @@ func Load_jj() {
 			GFunction:  jjGetFieldString,
 		}
 
-	MethodSignatures["jj._subProcess(Ljava/lang/Object;)I"] =
+	MethodSignatures["jj._subProcess(jjSubProcessObject;)I"] =
 		GMeth{
 			ParamSlots: 1,
 			GFunction:  jjSubProcess,
+		}
+
+	MethodSignatures["jj._getProgramName()Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  jjGetProgramName,
 		}
 }
 
@@ -356,4 +363,10 @@ func jjSubProcess(params []interface{}) interface{} {
 	}
 
 	return exitCode
+}
+
+func jjGetProgramName([]interface{}) interface{} {
+	glob := globals.GetGlobalRef()
+	str := glob.JacobinName
+	return object.StringObjectFromGoString(str)
 }

--- a/src/globals/globals.go
+++ b/src/globals/globals.go
@@ -99,8 +99,9 @@ type Globals struct {
 	AtomicIntegerLock sync.Mutex
 
 	// ---- misc properties
-	FileEncoding string // what file encoding are we using?
-	Headless     bool   // Headless?
+	FileEncoding     string // what file encoding are we using?
+	FileNameEncoding string // System.getProperty("sun.jnu.encoding")
+	Headless         bool   // Headless?
 
 	// Get around the golang circular dependency. To be set up in jvmStart.go
 	// Enables gfunctions to call these functions through a global variable.
@@ -196,6 +197,9 @@ func InitGlobals(progName string) Globals {
 	} else {
 		global.FileEncoding = "UTF-8"
 	}
+
+	// Make the encoding for filesystem names be the same as for file contents.
+	global.FileNameEncoding = global.FileEncoding
 
 	// Set up headlass boolean.
 	strHeadless := os.Getenv(StringEnvVarHeadless)
@@ -486,6 +490,8 @@ func getOsProperty(arg string) string {
 		value = getOSVersion()
 	case "path.separator":
 		value = string(os.PathSeparator)
+	case "sun.jnu.encoding":
+		value = global.FileNameEncoding
 	case "user.dir": // present working directory
 		value, _ = os.Getwd()
 	case "user.home":


### PR DESCRIPTION
modified:   gfunction/javaLangSystem.go - Since we cannot currently support ProcessHandle and its info() function, there is no way in Java to get the name of the JVM program (java[.exe] or jacobin[.exe]). None of the existing system properties names the running program. Therefore, I exposed a system property (sun.jnu.encoding) which carries this file name. Yes, I assume that it can be found in the PATH (proven).

modified:   globals/globals.go - corresponding update for javaLangSystem.go.

modified:   gfunction/jj.go - correct the method signature for method signature for `jj._subProcess(jjSubProcessObject;)I`. The parameter used to be `Ljava/lang/Object;`.

