### PR TITLE
JACOBIN-755 and JACOBIN-756

### DIFF
--- a/src/gfunction/javaUtilHexFormat.go
+++ b/src/gfunction/javaUtilHexFormat.go
@@ -352,9 +352,9 @@ func hfByteToHexDigits(params []interface{}) interface{} {
 	case int64:
 		digits := obj.FieldTable["digits"].Fvalue.([]types.JavaByte)
 		if digits[15] == 'F' { // uppercase
-			str = fmt.Sprintf("%02X", input)
+			str = fmt.Sprintf("%02X", uint64(input))
 		} else { // lowercase
-			str = fmt.Sprintf("%02x", input)
+			str = fmt.Sprintf("%02x", uint64(input))
 		}
 	default:
 		return trapFunction(params)
@@ -371,9 +371,9 @@ func hfCharToHexDigits(params []interface{}) interface{} {
 	case int64:
 		digits := obj.FieldTable["digits"].Fvalue.([]types.JavaByte)
 		if digits[15] == 'F' { // uppercase
-			str = fmt.Sprintf("%04X", input)
+			str = fmt.Sprintf("%04X", uint64(input))
 		} else { // lowercase
-			str = fmt.Sprintf("%04x", input)
+			str = fmt.Sprintf("%04x", uint64(input))
 		}
 	default:
 		return trapFunction(params)
@@ -390,9 +390,9 @@ func hfIntToHexDigits(params []interface{}) interface{} {
 	case int64:
 		digits := obj.FieldTable["digits"].Fvalue.([]types.JavaByte)
 		if digits[15] == 'F' { // uppercase
-			str = fmt.Sprintf("%08X", input)
+			str = fmt.Sprintf("%08X", uint32(input))
 		} else { // lowercase
-			str = fmt.Sprintf("%08x", input)
+			str = fmt.Sprintf("%08x", uint32(input))
 		}
 	default:
 		return trapFunction(params)
@@ -409,9 +409,9 @@ func hfLongToHexDigits(params []interface{}) interface{} {
 	case int64:
 		digits := obj.FieldTable["digits"].Fvalue.([]types.JavaByte)
 		if digits[15] == 'F' { // uppercase
-			str = fmt.Sprintf("%016X", input)
+			str = fmt.Sprintf("%016X", uint64(input))
 		} else { // lowercase
-			str = fmt.Sprintf("%016x", input)
+			str = fmt.Sprintf("%016x", uint64(input))
 		}
 		if len(params) > 2 {
 			outlen := int(params[2].(int64))
@@ -432,9 +432,9 @@ func hfShortToHexDigits(params []interface{}) interface{} {
 	case int64:
 		digits := obj.FieldTable["digits"].Fvalue.([]types.JavaByte)
 		if digits[15] == 'F' { // uppercase
-			str = fmt.Sprintf("%04X", input)
+			str = fmt.Sprintf("%04X", uint64(input))
 		} else { // lowercase
-			str = fmt.Sprintf("%04x", input)
+			str = fmt.Sprintf("%04x", uint64(input))
 		}
 	default:
 		return trapFunction(params)

--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -1308,7 +1308,7 @@ func doIushr(fr *frames.Frame, _ int64) int {
 func doLushr(fr *frames.Frame, _ int64) int {
 	shiftBy := pop(fr).(int64)
 	value := pop(fr).(int64)
-	shiftedVal := int64(uint64(value) >> (shiftBy & 0x1F))
+	shiftedVal := int64(uint64(value) >> (shiftBy & 0x3F))
 	push(fr, shiftedVal)
 	return 1
 }

--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -167,7 +167,7 @@ var DispatchTable = [203]BytecodeFunc{
 	doIshr,            // ISHR            0x7A
 	doIshr,            // LSHR            0x7B
 	doIushr,           // IUSHR           0x7C
-	doIushr,           // LUSHR           0x7D
+	doLushr,           // LUSHR           0x7D
 	doIand,            // IAND            0x7E
 	doIand,            // LAND            0x7F
 	doIor,             // IOR             0x80
@@ -627,10 +627,6 @@ func doBaload(fr *frames.Frame, _ int64) int {
 					object.JavaByteArrayFromGoByteArray(bAref.FieldTable["value"].Fvalue.([]byte))
 			}
 		}
-	// case *[]uint8:
-	// 	array = *(ref.(*[]uint8))
-	// case []uint8:
-	// 	array = ref.([]uint8)
 	case []int8:
 		arr := ref.([]int8)
 		val := arr[index]
@@ -1299,11 +1295,20 @@ func doIshr(fr *frames.Frame, _ int64) int {
 	return 1
 }
 
-// 0x7C, 0x7D IUSHR, LUSHR unsigned shift right of int/long
+// 0x7C IUSHR unsigned shift right of int (32 bits)
 func doIushr(fr *frames.Frame, _ int64) int {
 	shiftBy := pop(fr).(int64)
 	value := pop(fr).(int64)
 	shiftedVal := int64(uint32(value) >> (shiftBy & 0x1F))
+	push(fr, shiftedVal)
+	return 1
+}
+
+// 0x7D LUSHR unsigned shift right of long (64 bits)
+func doLushr(fr *frames.Frame, _ int64) int {
+	shiftBy := pop(fr).(int64)
+	value := pop(fr).(int64)
+	shiftedVal := int64(uint64(value) >> (shiftBy & 0x1F))
 	push(fr, shiftedVal)
 	return 1
 }


### PR DESCRIPTION
JACOBIN-755
javaUtilHexFormat.go - convert to unsigned before formatting with `%x`.

JACOBIN-756
Separation of IUSHR and LUSHR.