### PR TITLE
JACOBIN-758 doIastore and ArrayType fail to allow J/C/S types

### DIFF
--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -757,9 +757,9 @@ func doIastore(fr *frames.Frame, _ int64) int {
 			return exceptions.RESUME_HERE // caught
 		}
 		fld := obj.FieldTable["value"]
-		if fld.Ftype != types.IntArray {
+		if fld.Ftype != types.IntArray && fld.Ftype != types.LongArray && fld.Ftype != types.CharArray && fld.Ftype != types.ShortArray {
 			globals.GetGlobalRef().ErrorGoStack = string(debug.Stack())
-			errMsg := fmt.Sprintf("in %s.%s, I/C/S/LASTORE: field type expected=[I, observed=%s",
+			errMsg := fmt.Sprintf("in %s.%s, I/J/C/S/LASTORE: field type expected=[I|J|C|S, observed=%s",
 				util.ConvertInternalClassNameToUserFormat(fr.ClName), fr.MethName, fld.Ftype)
 			status := exceptions.ThrowEx(excNames.ArrayStoreException, errMsg, fr)
 			if status != exceptions.Caught {

--- a/src/object/arrays.go
+++ b/src/object/arrays.go
@@ -237,7 +237,7 @@ func ArrayLength(arrayRef *Object) int64 {
 	case types.FloatArray, types.DoubleArray:
 		array := o.Fvalue.([]float64)
 		size = int64(len(array))
-	case types.IntArray, types.CharArray:
+	case types.IntArray, types.LongArray, types.ShortArray, types.CharArray:
 		array := o.Fvalue.([]int64)
 		size = int64(len(array))
 	default:


### PR DESCRIPTION
	modified:   jvm/interpreter.go - doIastore
	modified:   object/arrays.go - ArrayType
