### PR TITLE
JACOBIN-765 random integer values should be limited to 32 bits

### DIFF
--- a/src/gfunction/javaIoFile.go
+++ b/src/gfunction/javaIoFile.go
@@ -54,6 +54,12 @@ func Load_Io_File() {
 			GFunction:  fileCreate,
 		}
 
+	MethodSignatures["java/io/File.getName()Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  fileGetPath,
+		}
+
 	MethodSignatures["java/io/File.isInvalid()Z"] =
 		GMeth{
 			ParamSlots: 0,
@@ -97,19 +103,19 @@ func fileInit(params []interface{}) interface{} {
 
 	// Fill in File attributes that might get accessed by OpenJDK library member functions.
 
-	fld = object.Field{Ftype: types.ByteArray, Fvalue: []byte(absPathStr)}
+	fld = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoByteArray([]byte(absPathStr))}
 	objFile.FieldTable[FilePath] = fld
 
 	fld = object.Field{Ftype: types.Int, Fvalue: os.PathSeparator}
 	objFile.FieldTable["separatorChar"] = fld
 
-	fld = object.Field{Ftype: types.ByteArray, Fvalue: []byte{os.PathSeparator}}
+	fld = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoByteArray([]byte{os.PathSeparator})}
 	objFile.FieldTable["separator"] = fld
 
 	fld = object.Field{Ftype: types.Int, Fvalue: os.PathListSeparator}
 	objFile.FieldTable["pathSeparatorChar"] = fld
 
-	fld = object.Field{Ftype: types.ByteArray, Fvalue: []byte{os.PathListSeparator}}
+	fld = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoByteArray([]byte{os.PathListSeparator})}
 	objFile.FieldTable["pathSeparator"] = fld
 
 	// Set status to "checked" (=1).

--- a/src/gfunction/javaUtilRandom.go
+++ b/src/gfunction/javaUtilRandom.go
@@ -142,7 +142,7 @@ func Load_Util_Random() {
 	MethodSignatures["java/util/Random.nextInt()I"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  randomNextIntLong,
+			GFunction:  randomNextInt,
 		}
 
 	MethodSignatures["java/util/Random.nextInt(I)I"] =
@@ -154,7 +154,7 @@ func Load_Util_Random() {
 	MethodSignatures["java/util/Random.nextLong()J"] =
 		GMeth{
 			ParamSlots: 0,
-			GFunction:  randomNextIntLong,
+			GFunction:  randomNextLong,
 		}
 
 	MethodSignatures["java/util/Random.setSeed(J)V"] =
@@ -241,9 +241,16 @@ func randomSetSeed(params []interface{}) interface{} {
 	return nil
 }
 
-// randomNextIntLong returns the next pseudorandom, uniformly distributed int64 value.
-// ChatGPT: func (r *Random) NextInt() int {
-func randomNextIntLong(params []interface{}) interface{} {
+// randomNextInt returns the next pseudorandom, uniformly distributed int31 value as an int64.
+func randomNextInt(params []interface{}) interface{} {
+	obj := params[0].(*object.Object)
+	r := GetStructFromRandomObject(obj)
+	output := int64(r.rand.Int31())
+	return output
+}
+
+// randomNextLong returns the next pseudorandom, uniformly distributed int63 value as an int64.
+func randomNextLong(params []interface{}) interface{} {
 	obj := params[0].(*object.Object)
 	r := GetStructFromRandomObject(obj)
 	output := r.rand.Int63()
@@ -260,7 +267,7 @@ func randomNextIntBound(params []interface{}) interface{} {
 		errMsg := fmt.Sprintf("randomNextIntBound: Bound must be positive, observed: %d", bound)
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
-	output := r.rand.Int63n(bound)
+	output := int64(r.rand.Int31n(int32(bound)))
 	return output
 }
 


### PR DESCRIPTION
modified: gfunction/javaUtilRandom.go - fix routines returning random integers

modified: gfunction/javaIoFile.go 
- added function `File.getName` for an OpenJDK JVM caller; had hoped this would fix an issue.
- found a few places where "byte" was used instead of "JavaByte".
