### PR TITLE
JACOBIN-766 File G-functions need to use []JavaByte ([]int8) instead of []uint8 for storing String bytes

### DIFF
--- a/src/gfunction/javaIoBufferedReader.go
+++ b/src/gfunction/javaIoBufferedReader.go
@@ -98,7 +98,7 @@ func bufferedReaderInit(params []interface{}) interface{} {
 		errMsg := "Reader object lacks a FilePath field"
 		return getGErrBlk(excNames.InvalidTypeException, errMsg)
 	}
-	inPathStr := string(fld1.Fvalue.([]byte))
+	inPathStr := object.GoStringFromJavaByteArray(fld1.Fvalue.([]types.JavaByte))
 	osFile, err := os.Open(inPathStr)
 	if err != nil {
 		errMsg := fmt.Sprintf("os.Open(%s) failed, reason: %s", inPathStr, err.Error())

--- a/src/gfunction/javaIoFile.go
+++ b/src/gfunction/javaIoFile.go
@@ -103,7 +103,7 @@ func fileInit(params []interface{}) interface{} {
 
 	// Fill in File attributes that might get accessed by OpenJDK library member functions.
 
-	fld = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoByteArray([]byte(absPathStr))}
+	fld = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(absPathStr)}
 	objFile.FieldTable[FilePath] = fld
 
 	fld = object.Field{Ftype: types.Int, Fvalue: os.PathSeparator}
@@ -132,16 +132,7 @@ func fileGetPath(params []interface{}) interface{} {
 		errMsg := "fileGetPath: File object lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
-
-	var bytes []types.JavaByte
-	switch fld.Fvalue.(type) {
-	case []byte:
-		bytes = object.JavaByteArrayFromGoByteArray(fld.Fvalue.([]byte))
-	case []types.JavaByte:
-		bytes = fld.Fvalue.([]types.JavaByte)
-	}
-
-	return object.StringObjectFromJavaByteArray(bytes)
+	return object.StringObjectFromJavaByteArray(fld.Fvalue.([]types.JavaByte))
 }
 
 // "java/io/File.isInvalid()Z"
@@ -167,12 +158,12 @@ func fileDelete(params []interface{}) interface{} {
 	}
 
 	// Get file path string.
-	bytes, ok := params[0].(*object.Object).FieldTable[FilePath].Fvalue.([]byte)
+	fld, ok := params[0].(*object.Object).FieldTable[FilePath]
 	if !ok {
 		errMsg := "fileDelete: File object lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
-	pathStr := string(bytes)
+	pathStr := object.GoStringFromJavaByteArray(fld.Fvalue.([]types.JavaByte))
 
 	err := os.Remove(pathStr)
 	if err != nil {
@@ -185,13 +176,13 @@ func fileDelete(params []interface{}) interface{} {
 
 // "java/io/File.createNewFile()Z"
 func fileCreate(params []interface{}) interface{} {
-	// Get path string.
+	// Get file path string.
 	fld, ok := params[0].(*object.Object).FieldTable[FilePath]
 	if !ok {
 		errMsg := "fileCreate: File object lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
-	pathStr := string(fld.Fvalue.([]byte))
+	pathStr := object.GoStringFromJavaByteArray(fld.Fvalue.([]types.JavaByte))
 
 	// Create the file.
 	osFile, err := os.Create(pathStr)

--- a/src/gfunction/javaIoFileInputStream.go
+++ b/src/gfunction/javaIoFileInputStream.go
@@ -129,7 +129,7 @@ func initFileInputStreamFile(params []interface{}) interface{} {
 	}
 
 	// Get the file path.
-	pathStr := string(fld.Fvalue.([]byte))
+	pathStr := object.GoStringFromJavaByteArray(fld.Fvalue.([]types.JavaByte))
 
 	// Open the file for read-only, yielding a file handle.
 	osFile, err := os.Open(pathStr)
@@ -160,7 +160,7 @@ func initFileInputStreamString(params []interface{}) interface{} {
 	}
 
 	// Copy the file path field into the FileInputStream object.
-	fld := object.Field{Ftype: types.ByteArray, Fvalue: []byte(pathStr)}
+	fld := object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(pathStr)}
 	params[0].(*object.Object).FieldTable[FilePath] = fld
 
 	// Copy the file handle into the FileInputStream object.
@@ -183,7 +183,7 @@ func fisAvailable(params []interface{}) interface{} {
 	// Compute total file size.
 	fileInfo, err := osFile.Stat()
 	if err != nil {
-		path := string(params[0].(*object.Object).FieldTable["path"].Fvalue.([]byte))
+		path := object.GoStringFromJavaByteArray(params[0].(*object.Object).FieldTable["path"].Fvalue.([]types.JavaByte))
 		errMsg := fmt.Sprintf("fisAvailable: osFile.Stat(%s) failed, reason: %s", path, err.Error())
 		return getGErrBlk(excNames.IOException, errMsg)
 	}

--- a/src/gfunction/javaIoFileOutputStream.go
+++ b/src/gfunction/javaIoFileOutputStream.go
@@ -93,7 +93,7 @@ func initFileOutputStreamFile(params []interface{}) interface{} {
 		errMsg := "initFileOutputStreamFile: File object lacks a FilePath field"
 		return getGErrBlk(excNames.IOException, errMsg)
 	}
-	pathStr := string(fld.Fvalue.([]byte))
+	pathStr := object.GoStringFromJavaByteArray(fld.Fvalue.([]types.JavaByte))
 
 	// Open the file for write-only, yielding a file handle.
 	osFile, err := os.Create(pathStr)
@@ -123,7 +123,7 @@ func initFileOutputStreamFileBoolean(params []interface{}) interface{} {
 	}
 
 	// Get the file path.
-	pathStr := string(fld.Fvalue.([]byte))
+	pathStr := object.GoStringFromJavaByteArray(fld.Fvalue.([]types.JavaByte))
 
 	// Get the boolean argument.
 	boolarg, ok := params[2].(int64)

--- a/src/gfunction/javaIoFileOutputStream_test.go
+++ b/src/gfunction/javaIoFileOutputStream_test.go
@@ -19,7 +19,7 @@ func TestInitFileOutputStreamFile(t *testing.T) {
 	filePath := filepath.Join(tmpDir, "testfile.txt")
 	fileObj := &object.Object{
 		FieldTable: map[string]object.Field{
-			"FilePath": {Ftype: types.ByteArray, Fvalue: []byte(filePath)},
+			"FilePath": {Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(filePath)},
 		},
 	}
 	emptyObj := object.MakeEmptyObject()
@@ -44,7 +44,7 @@ func TestInitFileOutputStreamFileBoolean(t *testing.T) {
 	filePath := filepath.Join(tmpDir, "testfile.txt")
 	fileObj := &object.Object{
 		FieldTable: map[string]object.Field{
-			"FilePath": {Ftype: types.ByteArray, Fvalue: []byte(filePath)},
+			"FilePath": {Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(filePath)},
 		},
 	}
 	emptyObj := object.MakeEmptyObject()

--- a/src/gfunction/javaIoFileReader.go
+++ b/src/gfunction/javaIoFileReader.go
@@ -65,7 +65,7 @@ func initFileReader(params []interface{}) interface{} {
 		errMsg := "initFileReader: File object lacks a FilePath field"
 		return getGErrBlk(excNames.InvalidTypeException, errMsg)
 	}
-	inPathStr := string(fld1.Fvalue.([]byte))
+	inPathStr := object.GoStringFromJavaByteArray(fld1.Fvalue.([]types.JavaByte))
 	osFile, err := os.Open(inPathStr)
 	if err != nil {
 		errMsg := fmt.Sprintf("initFileReader: os.Open(%s) failed, reason: %s", inPathStr, err.Error())
@@ -93,7 +93,7 @@ func initFileReaderString(params []interface{}) interface{} {
 	}
 
 	// Copy java/io/File path
-	fld := object.Field{Ftype: types.ByteArray, Fvalue: []byte(pathStr)}
+	fld := object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(pathStr)}
 	params[0].(*object.Object).FieldTable[FilePath] = fld
 
 	// Field FileHandle = Golang *os.File

--- a/src/gfunction/javaIoFilterInputStream.go
+++ b/src/gfunction/javaIoFilterInputStream.go
@@ -101,7 +101,7 @@ func initFilterInputStreamFile(params []interface{}) interface{} {
 	}
 
 	// Get the file path.
-	pathStr := string(fld.Fvalue.([]byte))
+	pathStr := object.GoStringFromJavaByteArray(fld.Fvalue.([]types.JavaByte))
 
 	// Open the file for read-only, yielding a file handle.
 	osFile, err := os.Open(pathStr)

--- a/src/gfunction/javaIoRandomAccessFile.go
+++ b/src/gfunction/javaIoRandomAccessFile.go
@@ -127,7 +127,7 @@ func rafInitFile(params []interface{}) interface{} {
 		errMsg := "rafInitFile: java/io/File object is missing the FilePath field"
 		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
-	pathStr := string(fld.Fvalue.([]byte))
+	pathStr := object.GoStringFromJavaByteArray(fld.Fvalue.([]types.JavaByte))
 
 	// Mode.
 	var modeInt int


### PR DESCRIPTION
	modified:   gfunction/javaIoBufferedReader.go
	modified:   gfunction/javaIoFile.go
	modified:   gfunction/javaIoFileInputStream.go
	modified:   gfunction/javaIoFileOutputStream.go
	modified:   gfunction/javaIoFileOutputStream_test.go
	modified:   gfunction/javaIoFileReader.go
	modified:   gfunction/javaIoFilterInputStream.go
	modified:   gfunction/javaIoRandomAccessFile.go
