### PR TITLE
JACOBIN-726 Expand unit test coverage contributions in package gfunction

### DIFF
--- a/src/gfunction/javaIoBufferedReader_test.go
+++ b/src/gfunction/javaIoBufferedReader_test.go
@@ -1,0 +1,182 @@
+package gfunction
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"jacobin/excNames"
+	"jacobin/object"
+	"jacobin/types"
+)
+
+func TestBufferedReaderInit_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "test.txt")
+	content := []byte("Hello\nWorld\n")
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	fileObj := &object.Object{
+		FieldTable: map[string]object.Field{
+			FilePath: {Ftype: types.Array, Fvalue: object.JavaByteArrayFromGoString(filePath)},
+		},
+	}
+
+	brObj := &object.Object{FieldTable: map[string]object.Field{}}
+
+	params := []interface{}{brObj, fileObj}
+	res := bufferedReaderInit(params)
+	if res != nil {
+		t.Fatalf("Expected success, got error: %v", res)
+	}
+
+	if _, ok := brObj.FieldTable[FilePath]; !ok {
+		t.Errorf("FilePath field not set on BufferedReader object")
+	}
+	if fh, ok := brObj.FieldTable[FileHandle]; !ok {
+		t.Errorf("FileHandle field not set on BufferedReader object")
+	} else {
+		if f, ok := fh.Fvalue.(*os.File); ok {
+			_ = f.Close()
+		}
+	}
+}
+
+func TestBufferedReaderInit_FileNotFound(t *testing.T) {
+	fileObj := &object.Object{
+		FieldTable: map[string]object.Field{
+			FilePath: {Ftype: types.Array, Fvalue: object.JavaByteArrayFromGoString("/no/such/file")},
+		},
+	}
+	brObj := &object.Object{FieldTable: map[string]object.Field{}}
+
+	params := []interface{}{brObj, fileObj}
+	res := bufferedReaderInit(params)
+	if res == nil {
+		t.Errorf("Expected FileNotFoundException error, got nil")
+		return
+	}
+	errObj, ok := res.(*GErrBlk)
+	if !ok || errObj.ExceptionType != excNames.FileNotFoundException {
+		t.Errorf("Expected FileNotFoundException, got %#v", res)
+	}
+}
+
+func TestBufferedReaderInit_MissingFilePathField(t *testing.T) {
+	fileObj := &object.Object{FieldTable: map[string]object.Field{}}
+	brObj := &object.Object{FieldTable: map[string]object.Field{}}
+
+	params := []interface{}{brObj, fileObj}
+	res := bufferedReaderInit(params)
+	if res == nil {
+		t.Errorf("Expected InvalidTypeException error, got nil")
+		return
+	}
+	errObj, ok := res.(*GErrBlk)
+	if !ok || errObj.ExceptionType != excNames.InvalidTypeException {
+		t.Errorf("Expected InvalidTypeException, got %#v", res)
+	}
+}
+
+func TestBufferedReaderMarkSupported_False(t *testing.T) {
+	params := []interface{}{}
+	res := bufferedReaderMarkSupported(params)
+	if res != types.JavaBoolFalse {
+		t.Errorf("Expected JavaBoolFalse (0), got %v", res)
+	}
+}
+
+func TestBufferedReaderReadLine_FirstLine(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "test.txt")
+	content := []byte("line1\nline2\n")
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+	f, err := os.Open(filePath)
+	if err != nil {
+		t.Fatalf("Failed to open test file: %v", err)
+	}
+	defer f.Close()
+
+	brObj := &object.Object{
+		FieldTable: map[string]object.Field{
+			FileHandle: {Ftype: types.Ref, Fvalue: f},
+		},
+	}
+
+	params := []interface{}{brObj}
+	res := bufferedReaderReadLine(params)
+	if !object.IsStringObject(res) {
+		t.Fatalf("Expected Java String object, got %#v", res)
+	}
+	goStr := object.GoStringFromStringObject(res.(*object.Object))
+	if goStr != "line1" {
+		t.Errorf("Expected 'line1', got %q", goStr)
+	}
+}
+
+func TestBufferedReaderReadLine_AtEOF(t *testing.T) {
+	brObj := &object.Object{
+		FieldTable: make(map[string]object.Field),
+	}
+	eofSet(brObj, true)
+
+	params := []interface{}{brObj}
+	res := bufferedReaderReadLine(params)
+	if res != object.Null {
+		t.Errorf("Expected Null at EOF, got %#v", res)
+	}
+}
+
+func TestBufferedReaderReadLine_MissingFileHandle(t *testing.T) {
+	brObj := &object.Object{FieldTable: map[string]object.Field{}}
+	params := []interface{}{brObj}
+	res := bufferedReaderReadLine(params)
+	if res == nil {
+		t.Errorf("Expected IOException error, got nil")
+		return
+	}
+	errObj, ok := res.(*GErrBlk)
+	if !ok || errObj.ExceptionType != excNames.IOException {
+		t.Errorf("Expected IOException, got %#v", res)
+	}
+}
+
+func TestBufferedReaderReadLine_MultiLineSequential(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "test.txt")
+	content := []byte("first\nsecond\nthird")
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+	f, err := os.Open(filePath)
+	if err != nil {
+		t.Fatalf("Failed to open test file: %v", err)
+	}
+	defer f.Close()
+
+	brObj := &object.Object{
+		FieldTable: map[string]object.Field{
+			FileHandle: {Ftype: types.Ref, Fvalue: f},
+		},
+	}
+	params := []interface{}{brObj}
+
+	expected := []string{"first", "second", "third"}
+	for i, want := range expected {
+		res := bufferedReaderReadLine(params)
+		if res == object.Null {
+			t.Fatalf("Unexpected EOF on line %d", i+1)
+		}
+		if !object.IsStringObject(res) {
+			t.Fatalf("Expected Java String object, got %#v", res)
+		}
+		got := object.GoStringFromStringObject(res.(*object.Object))
+		if got != want {
+			t.Errorf("Line %d: expected %q, got %q", i+1, want, got)
+		}
+	}
+}

--- a/src/gfunction/javaIoFileInputStream_test.go
+++ b/src/gfunction/javaIoFileInputStream_test.go
@@ -242,6 +242,17 @@ func TestFisReadOne_SuccessAndEOF(t *testing.T) {
 	if val != int64(-1) {
 		t.Errorf("Expected -1 at EOF, got %d", val)
 	}
+
+	// Work-around to prevent Windows from getting lost in TempDir RemoveAll cleanup
+	err := fisObj.FieldTable[FileHandle].Fvalue.(*os.File).Close()
+	if err != nil {
+		t.Fatalf("Failed to close file handle: %v", err)
+	}
+	err = os.Remove(path)
+	if err != nil {
+		t.Fatalf("Failed to remove test file: %v", err)
+	}
+
 }
 
 func TestFisReadOne_NoFileHandle(t *testing.T) {

--- a/src/gfunction/javaIoFileInputStream_test.go
+++ b/src/gfunction/javaIoFileInputStream_test.go
@@ -1,0 +1,388 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Tests for javaIoFileInputStream.go
+ * Generated according to user rules.
+ */
+
+package gfunction
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"jacobin/excNames"
+	"jacobin/object"
+	"jacobin/types"
+)
+
+func makeTempFile(t *testing.T, content []byte) (string, func()) {
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "testfile.txt")
+	err := os.WriteFile(tmpFile, content, 0644)
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	return tmpFile, func() { os.Remove(tmpFile) }
+}
+
+func newFileObjectWithPath(t *testing.T, path string) *object.Object {
+	fld := object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(path)}
+	obj := &object.Object{
+		FieldTable: map[string]object.Field{
+			FilePath: fld,
+		},
+	}
+	return obj
+}
+
+func newFileInputStreamObject() *object.Object {
+	return &object.Object{
+		FieldTable: make(map[string]object.Field),
+	}
+}
+
+func newJavaByteArrayObject(size int) *object.Object {
+	ba := make([]types.JavaByte, size)
+	return &object.Object{
+		FieldTable: map[string]object.Field{
+			"value": {Ftype: types.ByteArray, Fvalue: ba},
+		},
+	}
+}
+
+func TestInitFileInputStreamFile_Success(t *testing.T) {
+	content := []byte("hello world")
+	path, cleanup := makeTempFile(t, content)
+	defer cleanup()
+
+	fileObj := newFileObjectWithPath(t, path)
+	fisObj := newFileInputStreamObject()
+
+	params := []interface{}{fisObj, fileObj}
+
+	res := initFileInputStreamFile(params)
+	if res != nil {
+		t.Fatalf("Expected nil, got error: %v", res)
+	}
+
+	// Check FilePath copied
+	fld, ok := fisObj.FieldTable[FilePath]
+	if !ok {
+		t.Fatalf("FilePath not set in FileInputStream object")
+	}
+	gotPath := string(object.GoStringFromJavaByteArray(fld.Fvalue.([]types.JavaByte)))
+	if gotPath != path {
+		t.Errorf("FilePath mismatch: got %q want %q", gotPath, path)
+	}
+
+	// Check FileHandle is set and valid
+	fh, ok := fisObj.FieldTable[FileHandle]
+	if !ok {
+		t.Fatalf("FileHandle not set in FileInputStream object")
+	}
+	if fh.Ftype != types.FileHandle {
+		t.Errorf("FileHandle field type mismatch: got %v want %v", fh.Ftype, types.FileHandle)
+	}
+	fileHandle, ok := fh.Fvalue.(*os.File)
+	if !ok {
+		t.Fatalf("FileHandle Fvalue is not *os.File")
+	}
+	fileHandle.Close()
+}
+
+func TestInitFileInputStreamFile_FilePathMissing(t *testing.T) {
+	fisObj := newFileInputStreamObject()
+	fileObj := &object.Object{FieldTable: make(map[string]object.Field)} // No FilePath
+
+	params := []interface{}{fisObj, fileObj}
+	res := initFileInputStreamFile(params)
+	errObj, ok := res.(*GErrBlk)
+	if !ok {
+		t.Fatalf("Expected *GErrBlk error, got %T", res)
+	}
+	if errObj.ExceptionType != excNames.IOException {
+		t.Errorf("Expected IOException, got %v", errObj.ExceptionType)
+	}
+}
+
+func TestInitFileInputStreamString_Success(t *testing.T) {
+	content := []byte("file input stream test")
+	path, cleanup := makeTempFile(t, content)
+	defer cleanup()
+
+	strObj := object.StringObjectFromGoString(path)
+	fisObj := newFileInputStreamObject()
+	params := []interface{}{fisObj, strObj}
+
+	res := initFileInputStreamString(params)
+	if res != nil {
+		t.Fatalf("Expected nil, got error: %v", res)
+	}
+
+	// Check FilePath set
+	fld, ok := fisObj.FieldTable[FilePath]
+	if !ok {
+		t.Fatalf("FilePath not set in FileInputStream object")
+	}
+	gotPath := string(object.GoStringFromJavaByteArray(fld.Fvalue.([]types.JavaByte)))
+	if gotPath != path {
+		t.Errorf("FilePath mismatch: got %q want %q", gotPath, path)
+	}
+
+	// Check FileHandle is set and valid
+	fh, ok := fisObj.FieldTable[FileHandle]
+	if !ok {
+		t.Fatalf("FileHandle not set in FileInputStream object")
+	}
+	fileHandle, ok := fh.Fvalue.(*os.File)
+	if !ok {
+		t.Fatalf("FileHandle Fvalue is not *os.File")
+	}
+	fileHandle.Close()
+}
+
+func TestInitFileInputStreamString_FileNotFound(t *testing.T) {
+	fisObj := newFileInputStreamObject()
+	badPath := "/nonexistent/file/hopefully/not/there.txt"
+	strObj := object.StringObjectFromGoString(badPath)
+	params := []interface{}{fisObj, strObj}
+
+	res := initFileInputStreamString(params)
+	errObj, ok := res.(*GErrBlk)
+	if !ok {
+		t.Fatalf("Expected *GErrBlk error, got %T", res)
+	}
+	if errObj.ExceptionType != excNames.IOException {
+		t.Errorf("Expected IOException, got %v", errObj.ExceptionType)
+	}
+}
+
+func TestFisAvailable_Success(t *testing.T) {
+	content := []byte("hello available test")
+	path, cleanup := makeTempFile(t, content)
+	defer cleanup()
+
+	fisObj := newFileInputStreamObject()
+	fisObj.FieldTable[FileHandle] = object.Field{
+		Ftype:  types.FileHandle,
+		Fvalue: mustOpenFile(t, path),
+	}
+	defer fisObj.FieldTable[FileHandle].Fvalue.(*os.File).Close()
+
+	res := fisAvailable([]interface{}{fisObj})
+	avail, ok := res.(int64)
+	if !ok {
+		t.Fatalf("Expected int64, got %T", res)
+	}
+	if avail <= 0 {
+		t.Errorf("Expected positive available bytes, got %d", avail)
+	}
+}
+
+func mustOpenFile(t *testing.T, path string) *os.File {
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Failed to open file %s: %v", path, err)
+	}
+	return f
+}
+
+func TestFisAvailable_NoFileHandle(t *testing.T) {
+	fisObj := newFileInputStreamObject()
+	res := fisAvailable([]interface{}{fisObj})
+	errObj, ok := res.(*GErrBlk)
+	if !ok {
+		t.Fatalf("Expected *GErrBlk error, got %T", res)
+	}
+	if errObj.ExceptionType != excNames.IOException {
+		t.Errorf("Expected IOException, got %v", errObj.ExceptionType)
+	}
+}
+
+func TestFisReadOne_SuccessAndEOF(t *testing.T) {
+	content := []byte("a")
+	path, cleanup := makeTempFile(t, content)
+	defer cleanup()
+
+	fisObj := newFileInputStreamObject()
+	fisObj.FieldTable[FileHandle] = object.Field{
+		Ftype:  types.FileHandle,
+		Fvalue: mustOpenFile(t, path),
+	}
+	defer fisObj.FieldTable[FileHandle].Fvalue.(*os.File).Close()
+
+	res := fisReadOne([]interface{}{fisObj})
+	b, ok := res.(int64)
+	if !ok {
+		t.Fatalf("Expected int64, got %T", res)
+	}
+	if b != int64(content[0]) {
+		t.Errorf("Expected byte %d, got %d", content[0], b)
+	}
+
+	// Read until EOF (skip the single byte read previously)
+	// Close and reopen file to reset
+	fisObj.FieldTable[FileHandle].Fvalue.(*os.File).Close()
+	fld := fisObj.FieldTable[FileHandle]
+	fld.Fvalue = mustOpenFile(t, path)
+	fisObj.FieldTable[FileHandle] = fld
+
+	// Read all bytes
+	for i := 0; i < len(content); i++ {
+		fisReadOne([]interface{}{fisObj})
+	}
+
+	// Now read again, should return -1 at EOF
+	res = fisReadOne([]interface{}{fisObj})
+	val, ok := res.(int64)
+	if !ok {
+		t.Fatalf("Expected int64, got %T", res)
+	}
+	if val != int64(-1) {
+		t.Errorf("Expected -1 at EOF, got %d", val)
+	}
+}
+
+func TestFisReadOne_NoFileHandle(t *testing.T) {
+	fisObj := newFileInputStreamObject()
+	res := fisReadOne([]interface{}{fisObj})
+	errObj, ok := res.(*GErrBlk)
+	if !ok {
+		t.Fatalf("Expected *GErrBlk error, got %T", res)
+	}
+	if errObj.ExceptionType != excNames.IOException {
+		t.Errorf("Expected IOException, got %v", errObj.ExceptionType)
+	}
+}
+
+func TestFisReadByteArray_SuccessAndEOF(t *testing.T) {
+	content := []byte("abcdefg")
+	path, cleanup := makeTempFile(t, content)
+	defer cleanup()
+
+	fisObj := newFileInputStreamObject()
+	fisObj.FieldTable[FileHandle] = object.Field{
+		Ftype:  types.FileHandle,
+		Fvalue: mustOpenFile(t, path),
+	}
+	defer fisObj.FieldTable[FileHandle].Fvalue.(*os.File).Close()
+
+	javaByteArrayObj := newJavaByteArrayObject(10)
+	params := []interface{}{fisObj, javaByteArrayObj}
+
+	res := fisReadByteArray(params)
+	n, ok := res.(int64)
+	if !ok {
+		t.Fatalf("Expected int64, got %T", res)
+	}
+	if n <= 0 {
+		t.Errorf("Expected positive bytes read, got %d", n)
+	}
+}
+
+func TestFisReadByteArrayOffset_Success(t *testing.T) {
+	content := []byte("1234567890")
+	path, cleanup := makeTempFile(t, content)
+	defer cleanup()
+
+	fisObj := newFileInputStreamObject()
+	fisObj.FieldTable[FileHandle] = object.Field{
+		Ftype:  types.FileHandle,
+		Fvalue: mustOpenFile(t, path),
+	}
+	defer fisObj.FieldTable[FileHandle].Fvalue.(*os.File).Close()
+
+	javaByteArrayObj := newJavaByteArrayObject(20)
+	offset := int64(5)
+	length := int64(4)
+
+	params := []interface{}{fisObj, javaByteArrayObj, offset, length}
+
+	res := fisReadByteArrayOffset(params)
+	n, ok := res.(int64)
+	if !ok {
+		t.Fatalf("Expected int64, got %T", res)
+	}
+	if n <= 0 {
+		t.Errorf("Expected positive bytes read, got %d", n)
+	}
+
+	// Test invalid offset and length (too large)
+	paramsInvalid := []interface{}{fisObj, javaByteArrayObj, int64(1000), int64(10)}
+	resInvalid := fisReadByteArrayOffset(paramsInvalid)
+	errObj, ok := resInvalid.(*GErrBlk)
+	if !ok {
+		t.Fatalf("Expected *GErrBlk error, got %T", resInvalid)
+	}
+	if errObj.ExceptionType != excNames.IndexOutOfBoundsException {
+		t.Errorf("Expected IndexOutOfBoundsException, got %v", errObj.ExceptionType)
+	}
+}
+
+func TestFisSkip_Success(t *testing.T) {
+	content := []byte("1234567890")
+	path, cleanup := makeTempFile(t, content)
+	defer cleanup()
+
+	fisObj := newFileInputStreamObject()
+	fisObj.FieldTable[FileHandle] = object.Field{
+		Ftype:  types.FileHandle,
+		Fvalue: mustOpenFile(t, path),
+	}
+	defer fisObj.FieldTable[FileHandle].Fvalue.(*os.File).Close()
+
+	skipCount := int64(5)
+	params := []interface{}{fisObj, skipCount}
+
+	res := fisSkip(params)
+	n, ok := res.(int64)
+	if !ok {
+		t.Fatalf("Expected int64, got %T", res)
+	}
+	if n != skipCount {
+		t.Errorf("Expected skip count %d, got %d", skipCount, n)
+	}
+}
+
+func TestFisSkip_NoFileHandle(t *testing.T) {
+	fisObj := newFileInputStreamObject()
+	params := []interface{}{fisObj, int64(5)}
+	res := fisSkip(params)
+	errObj, ok := res.(*GErrBlk)
+	if !ok {
+		t.Fatalf("Expected *GErrBlk error, got %T", res)
+	}
+	if errObj.ExceptionType != excNames.IOException {
+		t.Errorf("Expected IOException, got %v", errObj.ExceptionType)
+	}
+}
+
+func TestFisClose_Success(t *testing.T) {
+	content := []byte("close test")
+	path, cleanup := makeTempFile(t, content)
+	defer cleanup()
+
+	fisObj := newFileInputStreamObject()
+	fisObj.FieldTable[FileHandle] = object.Field{
+		Ftype:  types.FileHandle,
+		Fvalue: mustOpenFile(t, path),
+	}
+
+	res := fisClose([]interface{}{fisObj})
+	if res != nil {
+		t.Fatalf("Expected nil, got error %v", res)
+	}
+}
+
+func TestFisClose_NoFileHandle(t *testing.T) {
+	fisObj := newFileInputStreamObject()
+	res := fisClose([]interface{}{fisObj})
+	errObj, ok := res.(*GErrBlk)
+	if !ok {
+		t.Fatalf("Expected *GErrBlk error, got %T", res)
+	}
+	if errObj.ExceptionType != excNames.IOException {
+		t.Errorf("Expected IOException, got %v", errObj.ExceptionType)
+	}
+}

--- a/src/gfunction/javaIoFile_test.go
+++ b/src/gfunction/javaIoFile_test.go
@@ -1,0 +1,307 @@
+package gfunction
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"jacobin/excNames"
+	"jacobin/object"
+	"jacobin/types"
+)
+
+func TestFileInit_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "file.txt")
+	err := os.WriteFile(testFile, []byte("content"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	pathObj := object.StringObjectFromGoString(testFile)
+	fileObj := &object.Object{FieldTable: make(map[string]object.Field)}
+
+	params := []interface{}{fileObj, pathObj}
+
+	res := fileInit(params)
+	if res != nil {
+		t.Fatalf("Expected nil error, got %#v", res)
+	}
+
+	fld, ok := fileObj.FieldTable[FilePath]
+	if !ok {
+		t.Errorf("FilePath field missing after fileInit")
+	} else {
+		bytes, ok := fld.Fvalue.([]types.JavaByte)
+		if !ok {
+			t.Errorf("FilePath field value is not []types.JavaByte")
+		} else {
+			goStr := object.GoStringFromStringObject(object.StringObjectFromJavaByteArray(bytes))
+			abs, err := filepath.Abs(testFile)
+			if err != nil {
+				t.Fatalf("filepath.Abs error in test: %v", err)
+			}
+			if goStr != abs {
+				t.Errorf("FilePath mismatch, want %q got %q", abs, goStr)
+			}
+		}
+	}
+
+	statusFld, ok := fileObj.FieldTable[FileStatus]
+	if !ok {
+		t.Errorf("FileStatus field missing after fileInit")
+	} else if statusFld.Fvalue.(int64) != 1 {
+		t.Errorf("FileStatus expected 1, got %v", statusFld.Fvalue)
+	}
+}
+
+func TestFileInit_NullPath(t *testing.T) {
+	fileObj := &object.Object{FieldTable: make(map[string]object.Field)}
+	params := []interface{}{fileObj, object.Null}
+
+	res := fileInit(params)
+	if res == nil {
+		t.Fatal("Expected NullPointerException error, got nil")
+	}
+	errObj, ok := res.(*GErrBlk)
+	if !ok {
+		t.Fatalf("Expected *GErrBlk, got %#v", res)
+	}
+	if errObj.ExceptionType != excNames.NullPointerException {
+		t.Errorf("Expected NullPointerException, got %v", errObj.ExceptionType)
+	}
+}
+
+func TestFileInit_EmptyPath(t *testing.T) {
+	fileObj := &object.Object{FieldTable: make(map[string]object.Field)}
+	emptyStrObj := object.StringObjectFromGoString("")
+	params := []interface{}{fileObj, emptyStrObj}
+
+	res := fileInit(params)
+	if res == nil {
+		t.Fatal("Expected NullPointerException error, got nil")
+	}
+	errObj, ok := res.(*GErrBlk)
+	if !ok {
+		t.Fatalf("Expected *GErrBlk, got %#v", res)
+	}
+	if errObj.ExceptionType != excNames.NullPointerException {
+		t.Errorf("Expected NullPointerException, got %v", errObj.ExceptionType)
+	}
+}
+
+func TestFileGetPath_Success(t *testing.T) {
+	pathStr := "/tmp/testpath"
+	byteArr := object.JavaByteArrayFromGoString(pathStr)
+	fileObj := &object.Object{
+		FieldTable: map[string]object.Field{
+			FilePath: {Ftype: types.Array, Fvalue: byteArr},
+		},
+	}
+	params := []interface{}{fileObj}
+
+	res := fileGetPath(params)
+	if !object.IsStringObject(res) {
+		t.Fatalf("Expected StringObject, got %#v", res)
+	}
+
+	goStr := object.GoStringFromStringObject(res.(*object.Object))
+	if goStr != pathStr {
+		t.Errorf("Expected %q, got %q", pathStr, goStr)
+	}
+}
+
+func TestFileGetPath_MissingFilePath(t *testing.T) {
+	fileObj := &object.Object{FieldTable: make(map[string]object.Field)}
+	params := []interface{}{fileObj}
+
+	res := fileGetPath(params)
+	if res == nil {
+		t.Fatal("Expected IOException error, got nil")
+	}
+	errObj, ok := res.(*GErrBlk)
+	if !ok {
+		t.Fatalf("Expected *GErrBlk, got %#v", res)
+	}
+	if errObj.ExceptionType != excNames.IOException {
+		t.Errorf("Expected IOException, got %v", errObj.ExceptionType)
+	}
+}
+
+func TestFileIsInvalid_ZeroStatus(t *testing.T) {
+	fileObj := &object.Object{
+		FieldTable: map[string]object.Field{
+			FileStatus: {Ftype: types.Int, Fvalue: int64(0)},
+		},
+	}
+	params := []interface{}{fileObj}
+
+	res := fileIsInvalid(params)
+	if val, ok := res.(int64); !ok || val != types.JavaBoolTrue {
+		t.Errorf("Expected JavaBoolTrue (1) for invalid file status, got %#v", res)
+	}
+}
+
+func TestFileIsInvalid_NonZeroStatus(t *testing.T) {
+	fileObj := &object.Object{
+		FieldTable: map[string]object.Field{
+			FileStatus: {Ftype: types.Int, Fvalue: int64(1)},
+		},
+	}
+	params := []interface{}{fileObj}
+
+	res := fileIsInvalid(params)
+	if val, ok := res.(int64); !ok || val != types.JavaBoolFalse {
+		t.Errorf("Expected JavaBoolFalse (0) for valid file status, got %#v", res)
+	}
+}
+
+func TestFileIsInvalid_MissingField(t *testing.T) {
+	fileObj := &object.Object{FieldTable: make(map[string]object.Field)}
+	params := []interface{}{fileObj}
+
+	res := fileIsInvalid(params)
+	if res == nil {
+		t.Fatal("Expected IOException error, got nil")
+	}
+	errObj, ok := res.(*GErrBlk)
+	if !ok {
+		t.Fatalf("Expected *GErrBlk, got %#v", res)
+	}
+	if errObj.ExceptionType != excNames.IOException {
+		t.Errorf("Expected IOException, got %v", errObj.ExceptionType)
+	}
+}
+
+func TestFileDelete_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "delete.txt")
+	err := os.WriteFile(testFile, []byte("to delete"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	fileObj := &object.Object{
+		FieldTable: map[string]object.Field{
+			FilePath: {Ftype: types.Array, Fvalue: object.JavaByteArrayFromGoString(testFile)},
+		},
+	}
+	params := []interface{}{fileObj}
+
+	res := fileDelete(params)
+	if val, ok := res.(int64); !ok || val != types.JavaBoolTrue {
+		t.Errorf("Expected JavaBoolTrue (1) on successful delete, got %#v", res)
+	}
+
+	_, err = os.Stat(testFile)
+	if !os.IsNotExist(err) {
+		t.Errorf("File still exists after delete")
+	}
+}
+
+func TestFileDelete_CloseFileHandle(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "delete2.txt")
+	err := os.WriteFile(testFile, []byte("to delete"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	f, err := os.Open(testFile)
+	if err != nil {
+		t.Fatalf("Failed to open test file: %v", err)
+	}
+
+	fileObj := &object.Object{
+		FieldTable: map[string]object.Field{
+			FilePath:   {Ftype: types.Array, Fvalue: object.JavaByteArrayFromGoString(testFile)},
+			FileHandle: {Ftype: types.Ref, Fvalue: f},
+		},
+	}
+	params := []interface{}{fileObj}
+
+	res := fileDelete(params)
+	if val, ok := res.(int64); !ok || val != types.JavaBoolTrue {
+		t.Errorf("Expected JavaBoolTrue (1) on successful delete, got %#v", res)
+	}
+
+	_, err = os.Stat(testFile)
+	if !os.IsNotExist(err) {
+		t.Errorf("File still exists after delete")
+	}
+}
+
+func TestFileDelete_MissingFilePath(t *testing.T) {
+	fileObj := &object.Object{FieldTable: make(map[string]object.Field)}
+	params := []interface{}{fileObj}
+
+	res := fileDelete(params)
+	if res == nil {
+		t.Fatal("Expected IOException error, got nil")
+	}
+	errObj, ok := res.(*GErrBlk)
+	if !ok {
+		t.Fatalf("Expected *GErrBlk, got %#v", res)
+	}
+	if errObj.ExceptionType != excNames.IOException {
+		t.Errorf("Expected IOException, got %v", errObj.ExceptionType)
+	}
+}
+
+func TestFileCreate_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	newFile := filepath.Join(tmpDir, "newfile.txt")
+
+	fileObj := &object.Object{
+		FieldTable: map[string]object.Field{
+			FilePath: {Ftype: types.Array, Fvalue: object.JavaByteArrayFromGoString(newFile)},
+		},
+	}
+	params := []interface{}{fileObj}
+
+	res := fileCreate(params)
+	if val, ok := res.(int64); !ok || val != types.JavaBoolTrue {
+		t.Errorf("Expected JavaBoolTrue (1) on successful create, got %#v", res)
+	}
+
+	fh, ok := fileObj.FieldTable[FileHandle]
+	if !ok {
+		t.Errorf("FileHandle field missing after fileCreate")
+	}
+	if _, ok := fh.Fvalue.(*os.File); !ok {
+		t.Errorf("FileHandle field value is not *os.File")
+	}
+}
+
+func TestFileCreate_MissingFilePath(t *testing.T) {
+	fileObj := &object.Object{FieldTable: make(map[string]object.Field)}
+	params := []interface{}{fileObj}
+
+	res := fileCreate(params)
+	if res == nil {
+		t.Fatal("Expected IOException error, got nil")
+	}
+	errObj, ok := res.(*GErrBlk)
+	if !ok {
+		t.Fatalf("Expected *GErrBlk, got %#v", res)
+	}
+	if errObj.ExceptionType != excNames.IOException {
+		t.Errorf("Expected IOException, got %v", errObj.ExceptionType)
+	}
+}
+
+func TestFileCreate_Failure(t *testing.T) {
+	// Attempt to create file in directory without permissions to simulate failure
+	// Note: This test might require root permissions or will be skipped.
+	fileObj := &object.Object{
+		FieldTable: map[string]object.Field{
+			FilePath: {Ftype: types.Array, Fvalue: object.JavaByteArrayFromGoString("/root/forbiddenfile")},
+		},
+	}
+	params := []interface{}{fileObj}
+
+	res := fileCreate(params)
+	if val, ok := res.(int64); !ok || val != types.JavaBoolFalse {
+		t.Errorf("Expected JavaBoolFalse (0) on failure to create file, got %#v", res)
+	}
+}

--- a/src/gfunction/javaIoFile_test.go
+++ b/src/gfunction/javaIoFile_test.go
@@ -91,7 +91,7 @@ func TestFileInit_EmptyPath(t *testing.T) {
 }
 
 func TestFileGetPath_Success(t *testing.T) {
-	pathStr := "/tmp/testpath"
+	pathStr := t.TempDir()
 	byteArr := object.JavaByteArrayFromGoString(pathStr)
 	fileObj := &object.Object{
 		FieldTable: map[string]object.Field{
@@ -270,6 +270,16 @@ func TestFileCreate_Success(t *testing.T) {
 	}
 	if _, ok := fh.Fvalue.(*os.File); !ok {
 		t.Errorf("FileHandle field value is not *os.File")
+	}
+
+	// Work-around to prevent Windows from getting lost in TempDir RemoveAll cleanup
+	err := fh.Fvalue.(*os.File).Close()
+	if err != nil {
+		t.Fatalf("Failed to close file handle: %v", err)
+	}
+	err = os.Remove(newFile)
+	if err != nil {
+		t.Fatalf("Failed to remove test file: %v", err)
 	}
 }
 

--- a/src/gfunction/javaIoPrintStream.go
+++ b/src/gfunction/javaIoPrintStream.go
@@ -8,10 +8,10 @@ package gfunction
 
 import (
 	"fmt"
+	"io"
 	"jacobin/excNames"
 	"jacobin/object"
 	"jacobin/types"
-	"os"
 	"strconv"
 )
 
@@ -254,14 +254,24 @@ func Load_Io_PrintStream() {
 // PrintlnV = java/io/Prinstream.println() -- println() prints a newline (V = void)
 // "java/io/PrintStream.println()V"
 func PrintlnV(params []interface{}) interface{} {
-	fmt.Fprintln(params[0].(*os.File), "")
+	writer, ok := params[0].(io.Writer)
+	if !ok {
+		errMsg := fmt.Sprintf("PrintlnV: Expected io.Writer, observed %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	fmt.Fprintln(writer, "")
 	return nil
 }
 
 // "java/io/PrintStream.println(C)V"
 func PrintlnChar(params []interface{}) interface{} {
+	writer, ok := params[0].(io.Writer)
+	if !ok {
+		errMsg := fmt.Sprintf("PrintlnChar: Expected io.Writer, observed %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
 	bb := byte(params[1].(int64))
-	fmt.Fprintln(params[0].(*os.File), string(bb))
+	fmt.Fprintln(writer, string(bb))
 	return nil
 }
 
@@ -269,16 +279,26 @@ func PrintlnChar(params []interface{}) interface{} {
 // "java/io/PrintStream.println(I)V"
 // "java/io/PrintStream.println(S)V"
 func PrintlnBIS(params []interface{}) interface{} {
+	writer, ok := params[0].(io.Writer)
+	if !ok {
+		errMsg := fmt.Sprintf("PrintlnBIS: Expected io.Writer, observed %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
 	intToPrint, ok := params[1].(int64) // contains an int
 	if !ok {
 		intToPrint = int64(params[1].(int8))
 	}
-	fmt.Fprintln(params[0].(*os.File), intToPrint)
+	fmt.Fprintln(writer, intToPrint)
 	return nil
 }
 
 // "java/io/PrintStream.println(Z)V"
 func PrintlnBoolean(params []interface{}) interface{} {
+	writer, ok := params[0].(io.Writer)
+	if !ok {
+		errMsg := fmt.Sprintf("PrintlnBoolean: Expected io.Writer, observed %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
 	var boolToPrint bool
 	boolAsInt64 := params[1].(int64) // contains an int64
 	if boolAsInt64 > 0 {
@@ -286,35 +306,55 @@ func PrintlnBoolean(params []interface{}) interface{} {
 	} else {
 		boolToPrint = false
 	}
-	fmt.Fprintln(params[0].(*os.File), boolToPrint)
+	fmt.Fprintln(writer, boolToPrint)
 	return nil
 }
 
 // "java/io/PrintStream.println(J)V"
 func PrintlnLong(params []interface{}) interface{} {
+	writer, ok := params[0].(io.Writer)
+	if !ok {
+		errMsg := fmt.Sprintf("PrintlnLong: Expected io.Writer, observed %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
 	longToPrint := params[1].(int64) // contains to an int64--the equivalent of a Java long
-	fmt.Fprintln(params[0].(*os.File), longToPrint)
+	fmt.Fprintln(writer, longToPrint)
 	return nil
 }
 
 // PrintlnDouble = java/io/Prinstream.print(double)
 func PrintlnDouble(params []interface{}) interface{} {
+	writer, ok := params[0].(io.Writer)
+	if !ok {
+		errMsg := fmt.Sprintf("PrintlnDouble: Expected io.Writer, observed %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
 	xx := params[1].(float64) // contains to a float64--the equivalent of a Java double
-	fmt.Fprintln(params[0].(*os.File), strconv.FormatFloat(xx, 'g', -1, 64))
+	fmt.Fprintln(writer, strconv.FormatFloat(xx, 'g', -1, 64))
 	return nil
 }
 
 // PrintlnFloat = java/io/Prinstream.print(float)
 func PrintlnFloat(params []interface{}) interface{} {
+	writer, ok := params[0].(io.Writer)
+	if !ok {
+		errMsg := fmt.Sprintf("PrintlnFloat: Expected io.Writer, observed %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
 	xx := params[1].(float64) // contains to a float64--the equivalent of a Java double
-	fmt.Fprintln(params[0].(*os.File), strconv.FormatFloat(xx, 'g', -1, 32))
+	fmt.Fprintln(writer, strconv.FormatFloat(xx, 'g', -1, 32))
 	return nil
 }
 
 // "java/io/PrintStream.print(C)V"
 func PrintChar(params []interface{}) interface{} {
+	writer, ok := params[0].(io.Writer)
+	if !ok {
+		errMsg := fmt.Sprintf("PrintChar: Expected io.Writer, observed %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
 	bb := byte(params[1].(int64))
-	fmt.Fprint(params[0].(*os.File), string(bb))
+	fmt.Fprint(writer, string(bb))
 	return nil
 }
 
@@ -322,17 +362,27 @@ func PrintChar(params []interface{}) interface{} {
 // "java/io/PrintStream.print(I)V"
 // "java/io/PrintStream.print(S)V"
 func PrintBIS(params []interface{}) interface{} {
+	writer, ok := params[0].(io.Writer)
+	if !ok {
+		errMsg := fmt.Sprintf("PrintBIS: Expected io.Writer, observed %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
 	intToPrint, ok := params[1].(int64) // contains an int
 	if !ok {
 		intToPrint = int64(params[1].(int8))
 	}
-	fmt.Fprint(params[0].(*os.File), intToPrint)
+	fmt.Fprint(writer, intToPrint)
 	return nil
 }
 
 // PrintBoolean = java/io/Prinstream.print(boolean)
 // "java/io/PrintStream.print(Z)V"
 func PrintBoolean(params []interface{}) interface{} {
+	writer, ok := params[0].(io.Writer)
+	if !ok {
+		errMsg := fmt.Sprintf("PrintBoolean: Expected io.Writer, observed %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
 	var boolToPrint bool
 	boolAsInt64 := params[1].(int64) // contains an int64
 	if boolAsInt64 > 0 {
@@ -340,7 +390,7 @@ func PrintBoolean(params []interface{}) interface{} {
 	} else {
 		boolToPrint = false
 	}
-	fmt.Fprint(params[0].(*os.File), boolToPrint)
+	fmt.Fprint(writer, boolToPrint)
 	return nil
 }
 
@@ -348,28 +398,49 @@ func PrintBoolean(params []interface{}) interface{} {
 // Long in Java are 64-bit ints, so we just duplicated the logic for println(int)
 // "java/io/PrintStream.print(J)V"
 func PrintLong(params []interface{}) interface{} {
+	writer, ok := params[0].(io.Writer)
+	if !ok {
+		errMsg := fmt.Sprintf("PrintLong: Expected io.Writer, observed %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
 	longToPrint := params[1].(int64) // contains to an int64--the equivalent of a Java long
-	fmt.Fprint(params[0].(*os.File), longToPrint)
+	fmt.Fprint(writer, longToPrint)
 	return nil
 }
 
 // PrintDouble = java/io/Prinstream.print(double)
 func PrintDouble(params []interface{}) interface{} {
+	writer, ok := params[0].(io.Writer)
+	if !ok {
+		errMsg := fmt.Sprintf("PrintDouble: Expected io.Writer, observed %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
 	xx := params[1].(float64) // contains to a float64--the equivalent of a Java double
-	fmt.Fprint(params[0].(*os.File), strconv.FormatFloat(xx, 'g', -1, 64))
+	fmt.Fprint(writer, strconv.FormatFloat(xx, 'g', -1, 64))
 	return nil
 }
 
 // PrintFloat = java/io/Prinstream.print(float)
 func PrintFloat(params []interface{}) interface{} {
+	writer, ok := params[0].(io.Writer)
+	if !ok {
+		errMsg := fmt.Sprintf("PrintFloat: Expected io.Writer, observed %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
 	xx := params[1].(float64) // contains to a float64--the equivalent of a Java double
-	fmt.Fprint(params[0].(*os.File), strconv.FormatFloat(xx, 'g', -1, 32))
+	fmt.Fprint(writer, strconv.FormatFloat(xx, 'g', -1, 32))
 	return nil
 }
 
 // Printf -- handle the variable args and then call golang's own printf function
 // "java/io/PrintStream.printf(Ljava/lang/String;[Ljava/lang/Object;)Ljava/io/PrintStream;"
 func Printf(params []interface{}) interface{} {
+	writer, ok := params[0].(io.Writer)
+	if !ok {
+		errMsg := fmt.Sprintf("Printf: Expected io.Writer, observed %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
 	var intfSprintf = new([]interface{})
 	*intfSprintf = append(*intfSprintf, params[1]) // The format string
 	*intfSprintf = append(*intfSprintf, params[2]) // The object array
@@ -381,20 +452,20 @@ func Printf(params []interface{}) interface{} {
 	}
 	objPtr := retval.(*object.Object)
 	str := object.GoStringFromStringObject(objPtr)
-	switch params[0].(type) {
-	case *os.File:
-		break
-	default:
-		errMsg := fmt.Sprintf("Printf: Expected parameter type *os.File, observed: %T", params[0])
-		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
-	}
-	fmt.Fprint(params[0].(*os.File), str)
-	return params[0] // Return the PrintStream object
 
+	fmt.Fprint(writer, str)
+
+	return params[0] // Return the PrintStream object
 }
 
 // "java/io/PrintStream.println(Ljava/lang/String;)V"
 func _printString(params []interface{}, newLine bool) interface{} {
+	writer, ok := params[0].(io.Writer)
+	if !ok {
+		errMsg := fmt.Sprintf("_printString: Expected io.Writer, observed %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
 	var str string
 	param1, ok := params[1].(*object.Object)
 	if !ok {
@@ -428,9 +499,9 @@ func _printString(params []interface{}, newLine bool) interface{} {
 	}
 
 	if newLine {
-		fmt.Fprintln(params[0].(*os.File), str)
+		fmt.Fprintln(writer, str)
 	} else {
-		fmt.Fprint(params[0].(*os.File), str)
+		fmt.Fprint(writer, str)
 	}
 
 	return nil
@@ -449,6 +520,12 @@ func PrintlnString(params []interface{}) interface{} {
 
 // Called by PrintObject and PrintlnObject
 func _printObject(params []interface{}, newLine bool) interface{} {
+	writer, ok := params[0].(io.Writer)
+	if !ok {
+		errMsg := fmt.Sprintf("_printObject: Expected io.Writer, observed %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
 	var strBuffer string
 
 	// Watch out for a null object.
@@ -469,10 +546,10 @@ func _printObject(params []interface{}, newLine bool) interface{} {
 			}
 			strBuffer = strBuffer[:len(strBuffer)-2] + "}"
 			if newLine {
-				fmt.Fprintln(params[0].(*os.File), strBuffer)
+				fmt.Fprintln(writer, strBuffer)
 				return nil
 			} else {
-				fmt.Fprint(params[0].(*os.File), strBuffer)
+				fmt.Fprint(writer, strBuffer)
 				return nil
 			}
 		default:
@@ -482,9 +559,9 @@ func _printObject(params []interface{}, newLine bool) interface{} {
 	}
 
 	if newLine {
-		fmt.Fprintln(params[0].(*os.File), strBuffer)
+		fmt.Fprintln(writer, strBuffer)
 	} else {
-		fmt.Fprint(params[0].(*os.File), strBuffer)
+		fmt.Fprint(writer, strBuffer)
 	}
 
 	return nil
@@ -495,7 +572,12 @@ func _printObject(params []interface{}, newLine bool) interface{} {
 func PrintObject(params []interface{}) interface{} {
 	// Check for null object.
 	if params[1] == nil || object.IsNull(params[1]) {
-		fmt.Fprint(params[0].(*os.File), types.NullString)
+		writer, ok := params[0].(io.Writer)
+		if !ok {
+			errMsg := fmt.Sprintf("PrintObject: Expected io.Writer, observed %T", params[0])
+			return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+		}
+		fmt.Fprint(writer, types.NullString)
 		return nil
 	}
 
@@ -513,7 +595,12 @@ func PrintObject(params []interface{}) interface{} {
 func PrintlnObject(params []interface{}) interface{} {
 	// Check for null object.
 	if params[1] == nil || object.IsNull(params[1]) {
-		fmt.Fprintln(params[0].(*os.File), types.NullString)
+		writer, ok := params[0].(io.Writer)
+		if !ok {
+			errMsg := fmt.Sprintf("PrintlnObject: Expected io.Writer, observed %T", params[0])
+			return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+		}
+		fmt.Fprintln(writer, types.NullString)
 		return nil
 	}
 
@@ -528,6 +615,12 @@ func PrintlnObject(params []interface{}) interface{} {
 
 // Print a linked list like this: [A, B, C]
 func _printLinkedList(params []interface{}, newLine bool) interface{} {
+	writer, ok := params[0].(io.Writer)
+	if !ok {
+		errMsg := fmt.Sprintf("_printLinkedList: Expected io.Writer, observed %T", params[0])
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+
 	var strBuffer string
 
 	// Get linked list object.
@@ -558,7 +651,7 @@ func _printLinkedList(params []interface{}, newLine bool) interface{} {
 		// Start with the front element.
 		// Continue to the end.
 		element := llst.Front()
-		fmt.Fprint(params[0].(*os.File), "[")
+		fmt.Fprint(writer, "[")
 		for ix := 0; ix < llst.Len(); ix++ {
 			strBuffer += object.StringifyAnythingGo(element.Value)
 			strBuffer += ", "
@@ -570,9 +663,9 @@ func _printLinkedList(params []interface{}, newLine bool) interface{} {
 	strBuffer = strBuffer[:len(strBuffer)-2] + "]"
 
 	if newLine {
-		fmt.Fprintln(params[0].(*os.File), strBuffer)
+		fmt.Fprintln(writer, strBuffer)
 	} else {
-		fmt.Fprint(params[0].(*os.File), strBuffer)
+		fmt.Fprint(writer, strBuffer)
 	}
 
 	return nil

--- a/src/gfunction/javaIoPrintStream_test.go
+++ b/src/gfunction/javaIoPrintStream_test.go
@@ -1,0 +1,205 @@
+package gfunction_test
+
+import (
+	"bytes"
+	"jacobin/gfunction"
+	"jacobin/globals"
+	"jacobin/object"
+	"jacobin/types"
+	"strconv"
+	"testing"
+)
+
+// Helper to create a Java String object
+func makeStringObject(s string) *object.Object {
+	return object.StringObjectFromGoString(s)
+}
+
+func TestPrintStreamPrintlnFunctions(t *testing.T) {
+	buf := new(bytes.Buffer)
+
+	// println()
+	buf.Reset()
+	gfunction.PrintlnV([]interface{}{buf})
+	if got := buf.String(); got != "\n" {
+		t.Errorf("PrintlnV() = %q; want newline", got)
+	}
+
+	// println(String)
+	buf.Reset()
+	gfunction.PrintlnString([]interface{}{buf, makeStringObject("hello")})
+	if got := buf.String(); got != "hello\n" {
+		t.Errorf("PrintlnString() = %q; want 'hello\\n'", got)
+	}
+
+	// println(byte), println(int), println(short) all use PrintlnBIS
+	for _, val := range []int64{65, -1, 0} {
+		buf.Reset()
+		gfunction.PrintlnBIS([]interface{}{buf, val})
+		want := strconv.FormatInt(val, 10) + "\n"
+		if got := buf.String(); got != want && val != 65 {
+			// Actually, PrintlnBIS uses fmt.Fprintln on int64 so the output is a decimal string plus newline
+			want = strconv.FormatInt(val, 10) + "\n"
+		}
+		if got := buf.String(); got != want {
+			t.Errorf("PrintlnBIS(%d) = %q; want %q", val, got, want)
+		}
+	}
+
+	// println(boolean)
+	buf.Reset()
+	gfunction.PrintlnBoolean([]interface{}{buf, int64(1)})
+	if got := buf.String(); got != "true\n" {
+		t.Errorf("PrintlnBoolean(true) = %q; want 'true\\n'", got)
+	}
+	buf.Reset()
+	gfunction.PrintlnBoolean([]interface{}{buf, int64(0)})
+	if got := buf.String(); got != "false\n" {
+		t.Errorf("PrintlnBoolean(false) = %q; want 'false\\n'", got)
+	}
+
+	// println(long)
+	buf.Reset()
+	gfunction.PrintlnLong([]interface{}{buf, int64(1234567890)})
+	if got := buf.String(); got != "1234567890\n" {
+		t.Errorf("PrintlnLong() = %q; want '1234567890\\n'", got)
+	}
+
+	// println(double)
+	buf.Reset()
+	gfunction.PrintlnDouble([]interface{}{buf, 3.1415926535})
+	if got := buf.String(); got != "3.1415926535\n" {
+		t.Errorf("PrintlnDouble() = %q; want '3.1415926535\\n'", got)
+	}
+
+	// println(float)
+	buf.Reset()
+	gfunction.PrintlnFloat([]interface{}{buf, 2.71828})
+	if got := buf.String(); got != "2.71828\n" {
+		t.Errorf("PrintlnFloat() = %q; want '2.71828\\n'", got)
+	}
+
+	// println(char)
+	buf.Reset()
+	gfunction.PrintlnChar([]interface{}{buf, int64('Z')})
+	if got := buf.String(); got != "Z\n" {
+		t.Errorf("PrintlnChar() = %q; want 'Z\\n'", got)
+	}
+}
+
+func TestPrintStreamPrintFunctions(t *testing.T) {
+	buf := new(bytes.Buffer)
+
+	// print(String)
+	buf.Reset()
+	gfunction.PrintString([]interface{}{buf, makeStringObject("test string")})
+	if got := buf.String(); got != "test string" {
+		t.Errorf("PrintString() = %q; want 'test string'", got)
+	}
+
+	// print(byte), print(int), print(short) use PrintBIS
+	for _, val := range []int64{65, -2, 0} {
+		buf.Reset()
+		gfunction.PrintBIS([]interface{}{buf, val})
+		want := strconv.FormatInt(val, 10)
+		if got := buf.String(); got != want {
+			t.Errorf("PrintBIS(%d) = %q; want %q", val, got, want)
+		}
+	}
+
+	// print(boolean)
+	buf.Reset()
+	gfunction.PrintBoolean([]interface{}{buf, int64(1)})
+	if got := buf.String(); got != "true" {
+		t.Errorf("PrintBoolean(true) = %q; want 'true'", got)
+	}
+	buf.Reset()
+	gfunction.PrintBoolean([]interface{}{buf, int64(0)})
+	if got := buf.String(); got != "false" {
+		t.Errorf("PrintBoolean(false) = %q; want 'false'", got)
+	}
+
+	// print(long)
+	buf.Reset()
+	gfunction.PrintLong([]interface{}{buf, int64(9876543210)})
+	if got := buf.String(); got != "9876543210" {
+		t.Errorf("PrintLong() = %q; want '9876543210'", got)
+	}
+
+	// print(double)
+	buf.Reset()
+	gfunction.PrintDouble([]interface{}{buf, 6.62607015})
+	if got := buf.String(); got != "6.62607015" {
+		t.Errorf("PrintDouble() = %q; want '6.62607015'", got)
+	}
+
+	// print(float)
+	buf.Reset()
+	gfunction.PrintFloat([]interface{}{buf, 1.41421})
+	if got := buf.String(); got != "1.41421" {
+		t.Errorf("PrintFloat() = %q; want '1.41421'", got)
+	}
+
+	// print(char)
+	buf.Reset()
+	gfunction.PrintChar([]interface{}{buf, int64('Y')})
+	if got := buf.String(); got != "Y" {
+		t.Errorf("PrintChar() = %q; want 'Y'", got)
+	}
+}
+
+func TestPrintStreamPrintf(t *testing.T) {
+	// Create a buffer to capture output instead of writing to os.Stdout
+	var buf bytes.Buffer
+	ps := &buf
+
+	// Prepare format string object
+	fmtStr := object.StringObjectFromGoString("Hello %d and %d!\n")
+
+	// Prepare argument objects (Java Strings)
+	globals.InitStringPool()
+	arg1 := object.MakePrimitiveObject(types.Int, types.Int, int64(1))
+	arg2 := object.MakePrimitiveObject(types.Int, types.Int, int64(2))
+	args := []*object.Object{arg1, arg2}
+	iArr := object.MakePrimitiveObject("java/lang/Object", types.RefArray, args)
+
+	// Params: first PrintStream, then format string, then each arg separately
+	params := []interface{}{ps, fmtStr, iArr}
+
+	// Call the Printf function under test
+	ret := gfunction.Printf(params)
+	if ret != ps {
+		t.Errorf("Printf did not return the PrintStream object as expected, errMsg: %s", ret)
+	}
+
+	// Check the output captured in buf
+	want := "Hello 1 and 2!\n"
+	got := buf.String()
+	if got != want {
+		t.Errorf("Printf output mismatch:\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestPrintStreamPrintObjectNull(t *testing.T) {
+	buf := new(bytes.Buffer)
+
+	// print(null Object)
+	buf.Reset()
+	err := gfunction.PrintObject([]interface{}{buf, nil})
+	if err != nil {
+		t.Fatalf("PrintObject with nil returned error: %v", err)
+	}
+	if got := buf.String(); got != "null" {
+		t.Errorf("PrintObject(nil) output = %q; want 'null'", got)
+	}
+
+	// println(null Object)
+	buf.Reset()
+	err = gfunction.PrintlnObject([]interface{}{buf, nil})
+	if err != nil {
+		t.Fatalf("PrintlnObject with nil returned error: %v", err)
+	}
+	if got := buf.String(); got != "null\n" {
+		t.Errorf("PrintlnObject(nil) output = %q; want 'null\\n'", got)
+	}
+}

--- a/src/gfunction/javaIoRandomAccessFile_test.go
+++ b/src/gfunction/javaIoRandomAccessFile_test.go
@@ -1,0 +1,249 @@
+package gfunction
+
+import (
+	"io"
+	"jacobin/globals"
+	"os"
+	"testing"
+
+	"jacobin/object"
+	"jacobin/types"
+)
+
+// helper to create a new RandomAccessFile object with initialized FieldTable
+func newRAFObject() *object.Object {
+	return &object.Object{FieldTable: make(map[string]object.Field)}
+}
+
+func TestClinitGeneric(t *testing.T) {
+	ret := clinitGeneric(nil)
+	if ret != nil {
+		t.Errorf("clinitGeneric should return nil, got %v", ret)
+	}
+}
+
+func TestJustReturn(t *testing.T) {
+	ret := justReturn(nil)
+	if ret != nil {
+		t.Errorf("justReturn should return nil, got %v", ret)
+	}
+}
+
+func TestRafInitStringAndGetFilePointer(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "raf_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	rafObj := newRAFObject()
+
+	pathStrObj := object.StringObjectFromGoString(tmpFile.Name())
+	modeStrObj := object.StringObjectFromGoString("r")
+
+	params := []interface{}{rafObj, pathStrObj, modeStrObj}
+	ret := rafInitString(params)
+	if ret != nil {
+		t.Fatalf("rafInitString returned error: %v", ret)
+	}
+
+	fld, ok := rafObj.FieldTable[FilePath]
+	if !ok {
+		t.Fatal("FilePath field not set")
+	}
+	gotPath := string(fld.Fvalue.([]byte))
+	if gotPath != tmpFile.Name() {
+		t.Fatalf("FilePath mismatch, want %s, got %s", tmpFile.Name(), gotPath)
+	}
+
+	fld, ok = rafObj.FieldTable[FileHandle]
+	if !ok {
+		t.Fatal("FileHandle field not set")
+	}
+	fh, ok := fld.Fvalue.(*os.File)
+	if !ok {
+		t.Fatalf("FileHandle field has wrong type %T", fld.Fvalue)
+	}
+
+	getPointerParams := []interface{}{rafObj}
+	pos := rafGetFilePointer(getPointerParams)
+	offset, ok := pos.(int64)
+	if !ok {
+		t.Fatalf("rafGetFilePointer returned wrong type %T", pos)
+	}
+	if offset != 0 {
+		t.Errorf("Initial file pointer expected 0, got %d", offset)
+	}
+
+	fh.Close()
+}
+
+func TestRafInitFile(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "raf_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	fileObj := &object.Object{FieldTable: make(map[string]object.Field)}
+	fileObj.FieldTable[FilePath] = object.Field{
+		Ftype:  types.ByteArray,
+		Fvalue: object.JavaByteArrayFromGoString(tmpFile.Name()),
+	}
+
+	rafObj := newRAFObject()
+
+	modeStrObj := object.StringObjectFromGoString("r")
+
+	params := []interface{}{rafObj, fileObj, modeStrObj}
+	ret := rafInitFile(params)
+	if ret != nil {
+		t.Fatalf("rafInitFile returned error: %v", ret)
+	}
+
+	fld, ok := rafObj.FieldTable[FilePath]
+	if !ok {
+		t.Fatal("FilePath field not set")
+	}
+	gotPath := string(fld.Fvalue.([]byte))
+	if gotPath != tmpFile.Name() {
+		t.Fatalf("FilePath mismatch, want %s, got %s", tmpFile.Name(), gotPath)
+	}
+
+	fld, ok = rafObj.FieldTable[FileHandle]
+	if !ok {
+		t.Fatal("FileHandle field not set")
+	}
+	fh, ok := fld.Fvalue.(*os.File)
+	if !ok {
+		t.Fatalf("FileHandle field has wrong type %T", fld.Fvalue)
+	}
+
+	fh.Close()
+}
+
+func TestFisClose(t *testing.T) {
+	rafObj := newRAFObject()
+
+	// Set FileHandle with a pipe writer to avoid closing os.Stdout accidentally
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	rafObj.FieldTable[FileHandle] = object.Field{Ftype: types.FileHandle, Fvalue: w}
+
+	ret := fisClose([]interface{}{rafObj})
+	if ret != nil {
+		t.Errorf("fisClose returned error: %v", ret)
+	}
+
+	// Writing after close should fail
+	_, err = w.Write([]byte("test"))
+	if err == nil {
+		t.Errorf("Write succeeded after close, expected failure")
+	}
+}
+
+func TestFisReadOne(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "raf_read_one")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	content := []byte{0x42}
+	if _, err := tmpFile.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	tmpFile.Sync()
+	tmpFile.Seek(0, io.SeekStart)
+
+	rafObj := newRAFObject()
+	rafObj.FieldTable[FileHandle] = object.Field{Ftype: types.FileHandle, Fvalue: tmpFile}
+
+	ret := fisReadOne([]interface{}{rafObj})
+
+	intRet, ok := ret.(int64)
+	if !ok {
+		t.Fatalf("fisReadOne returned wrong type %T", ret)
+	}
+	if intRet != int64(content[0]) {
+		t.Errorf("fisReadOne expected %d, got %d", content[0], intRet)
+	}
+}
+
+func TestFisReadByteArray(t *testing.T) {
+	globals.InitStringPool()
+	tmpFile, err := os.CreateTemp("", "raf_read_ba")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	content := []byte("hello")
+	if _, err := tmpFile.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	tmpFile.Sync()
+	tmpFile.Seek(0, io.SeekStart)
+
+	rafObj := newRAFObject()
+	rafObj.FieldTable[FileHandle] = object.Field{Ftype: types.FileHandle, Fvalue: tmpFile}
+
+	byteArray := make([]types.JavaByte, len(content))
+
+	javaByteArrayObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, byteArray)
+	params := []interface{}{rafObj, javaByteArrayObj}
+	ret := fisReadByteArray(params)
+
+	numRead, ok := ret.(int64)
+	if !ok {
+		t.Fatalf("fisReadByteArray returned wrong type %T", ret)
+	}
+	if numRead != int64(len(content)) {
+		t.Errorf("fisReadByteArray expected read %d bytes, got %d", len(content), numRead)
+	}
+}
+
+func TestFisReadByteArrayOffset(t *testing.T) {
+	globals.InitStringPool()
+	tmpFile, err := os.CreateTemp("", "raf_read_ba_offset")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	content := []byte("hello world")
+	if _, err := tmpFile.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	tmpFile.Sync()
+	tmpFile.Seek(0, io.SeekStart)
+
+	rafObj := newRAFObject()
+	rafObj.FieldTable[FileHandle] = object.Field{Ftype: types.FileHandle, Fvalue: tmpFile}
+
+	byteArray := make([]types.JavaByte, len(content))
+	javaByteArrayObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, byteArray)
+
+	offset := int64(2)
+	length := int64(5)
+
+	params := []interface{}{rafObj, javaByteArrayObj, offset, length}
+	ret := fisReadByteArrayOffset(params)
+
+	numRead, ok := ret.(int64)
+	if !ok {
+		t.Fatalf("fisReadByteArrayOffset returned wrong type %T", ret)
+	}
+	if numRead != length {
+		t.Errorf("fisReadByteArrayOffset expected read %d bytes, got %d", length, numRead)
+	}
+}

--- a/src/jvm/cli.go
+++ b/src/jvm/cli.go
@@ -195,7 +195,8 @@ Jacobin-specific options:
                           * cloadi - classloader initialization
                           * inst - bytecode interpreter trace
                           * class - class & method support for the interpreter
-                          * verbose - inst, class, and more details of the interpreter `
+                          * verbose - inst, class, and more details of the interpreter
+    -JJ:galt              Do not use this unless you are a Jacobin developer! `
 
 	_, _ = fmt.Fprintln(outStream, userMessage)
 }


### PR DESCRIPTION
New unit tests:
* gfunction/javaIoFileInputStream_test.go
* gfunction/javaIoFile_test.go
* gfunction/javaIoPrintStream_test.go
* gfunction/javaIoRandomAccessFile_test.go

Modified:
* gfunction/javaIoPrintStream.go - refactored to refer to file handles as `io.Writer` so that the unit tests could employ a `bytes.Buffer` for capture.
* jvm/cli.go - add a brief mention of `-jj:galt` in the `-h` option execution.
