### PR TITLE
JACOBIN-772 fix boolean handling and progress with strip trailing zeros

### DIFF
--- a/src/gfunction/javaMathBigDecimalFuncAtoM.go
+++ b/src/gfunction/javaMathBigDecimalFuncAtoM.go
@@ -200,7 +200,7 @@ func bigdecimalEquals(params []interface{}) interface{} {
 	scale2 := bd2.FieldTable["scale"].Fvalue.(int64)
 
 	if scale1 != scale2 {
-		return false // different scales means not equal
+		return object.BooleanObjectFromGoBoolean(false) // different scales means not equal
 	}
 
 	// Compare unscaled values (bigInt)
@@ -211,11 +211,11 @@ func bigdecimalEquals(params []interface{}) interface{} {
 	unscaled2 := bi2.FieldTable["value"].Fvalue.(*big.Int)
 
 	if unscaled1.Cmp(unscaled2) != 0 {
-		return false // different unscaled values means not equal
+		return object.BooleanObjectFromGoBoolean(false) // different unscaled values means not equal
 	}
 
 	// If both scale and unscaled value are the same, they are equal
-	return true
+	return object.BooleanObjectFromGoBoolean(true)
 }
 
 // bigdecimalFloatValue returns the BigDecimal as a float64 (same as doubleValue)

--- a/src/gfunction/javaMathBigDecimalFuncAtoM.go
+++ b/src/gfunction/javaMathBigDecimalFuncAtoM.go
@@ -200,7 +200,7 @@ func bigdecimalEquals(params []interface{}) interface{} {
 	scale2 := bd2.FieldTable["scale"].Fvalue.(int64)
 
 	if scale1 != scale2 {
-		return object.BooleanObjectFromGoBoolean(false) // different scales means not equal
+		return types.JavaBoolFalse // different scales means not equal
 	}
 
 	// Compare unscaled values (bigInt)
@@ -211,11 +211,11 @@ func bigdecimalEquals(params []interface{}) interface{} {
 	unscaled2 := bi2.FieldTable["value"].Fvalue.(*big.Int)
 
 	if unscaled1.Cmp(unscaled2) != 0 {
-		return object.BooleanObjectFromGoBoolean(false) // different unscaled values means not equal
+		return types.JavaBoolFalse // different unscaled values means not equal
 	}
 
 	// If both scale and unscaled value are the same, they are equal
-	return object.BooleanObjectFromGoBoolean(true)
+	return types.JavaBoolTrue
 }
 
 // bigdecimalFloatValue returns the BigDecimal as a float64 (same as doubleValue)

--- a/src/gfunction/javaMathBigDecimalFuncAtoM_test.go
+++ b/src/gfunction/javaMathBigDecimalFuncAtoM_test.go
@@ -331,20 +331,20 @@ func Test_gfunction_bigdecimal_all(t *testing.T) {
 		bdutInit()
 		a := bigDecimalObjectFromBigInt(big.NewInt(1000), 4, 2) // 10.00
 		b := bigDecimalObjectFromBigInt(big.NewInt(1000), 4, 2) // 10.00
-		res := bigdecimalEquals([]interface{}{a, b}).(*object.Object)
-		if !object.GoBooleanFromBooleanObject(res) {
+		res := bigdecimalEquals([]interface{}{a, b}).(int64)
+		if !object.GoBooleanFromJavaBoolean(res) {
 			t.Fatalf("expected true equals, got false")
 		}
 		// different scale
 		c := bigDecimalObjectFromBigInt(big.NewInt(1000), 4, 1)
-		res = bigdecimalEquals([]interface{}{a, c}).(*object.Object)
-		if object.GoBooleanFromBooleanObject(res) {
+		res = bigdecimalEquals([]interface{}{a, c}).(int64)
+		if object.GoBooleanFromJavaBoolean(res) {
 			t.Fatalf("expected false for different scale, got true")
 		}
 		// different value same scale
 		d := bigDecimalObjectFromBigInt(big.NewInt(2000), 4, 2)
-		res = bigdecimalEquals([]interface{}{a, d}).(*object.Object)
-		if object.GoBooleanFromBooleanObject(res) {
+		res = bigdecimalEquals([]interface{}{a, d}).(int64)
+		if object.GoBooleanFromJavaBoolean(res) {
 			t.Fatalf("expected false for different unscaled, got true")
 		}
 	})

--- a/src/gfunction/javaMathBigDecimalFuncAtoM_test.go
+++ b/src/gfunction/javaMathBigDecimalFuncAtoM_test.go
@@ -331,21 +331,21 @@ func Test_gfunction_bigdecimal_all(t *testing.T) {
 		bdutInit()
 		a := bigDecimalObjectFromBigInt(big.NewInt(1000), 4, 2) // 10.00
 		b := bigDecimalObjectFromBigInt(big.NewInt(1000), 4, 2) // 10.00
-		res := bigdecimalEquals([]interface{}{a, b})
-		if res != true {
-			t.Fatalf("expected true equals, got %v", res)
+		res := bigdecimalEquals([]interface{}{a, b}).(*object.Object)
+		if !object.GoBooleanFromBooleanObject(res) {
+			t.Fatalf("expected true equals, got false")
 		}
 		// different scale
 		c := bigDecimalObjectFromBigInt(big.NewInt(1000), 4, 1)
-		res2 := bigdecimalEquals([]interface{}{a, c})
-		if res2 != false {
-			t.Fatalf("expected false for different scale, got %v", res2)
+		res = bigdecimalEquals([]interface{}{a, c}).(*object.Object)
+		if object.GoBooleanFromBooleanObject(res) {
+			t.Fatalf("expected false for different scale, got true")
 		}
 		// different value same scale
 		d := bigDecimalObjectFromBigInt(big.NewInt(2000), 4, 2)
-		res3 := bigdecimalEquals([]interface{}{a, d})
-		if res3 != false {
-			t.Fatalf("expected false for different unscaled, got %v", res3)
+		res = bigdecimalEquals([]interface{}{a, d}).(*object.Object)
+		if object.GoBooleanFromBooleanObject(res) {
+			t.Fatalf("expected false for different unscaled, got true")
 		}
 	})
 

--- a/src/object/object.go
+++ b/src/object/object.go
@@ -170,3 +170,19 @@ func GetClassNameSuffix(arg *Object, inner bool) string {
 	}
 	return base
 }
+
+// Convert a Go boolean to a Jacobin Boolean object.
+func BooleanObjectFromGoBoolean(b bool) *Object {
+	if b {
+		return MakePrimitiveObject("java/lang/Boolean", "Z", true)
+	}
+	return MakePrimitiveObject("java/lang/Boolean", "Z", false)
+}
+
+// Convert a Jacobin Boolean object to a Go boolean.
+func GoBooleanFromBooleanObject(obj *Object) bool {
+	if obj == nil {
+		return false
+	}
+	return obj.FieldTable["value"].Fvalue.(bool)
+}

--- a/src/object/object.go
+++ b/src/object/object.go
@@ -171,18 +171,18 @@ func GetClassNameSuffix(arg *Object, inner bool) string {
 	return base
 }
 
-// Convert a Go boolean to a Jacobin Boolean object.
-func BooleanObjectFromGoBoolean(b bool) *Object {
-	if b {
-		return MakePrimitiveObject("java/lang/Boolean", "Z", true)
+// Convert a Go boolean to a Jacobin Boolean.
+func JavaBooleanFromGoBoolean(arg bool) int64 {
+	if arg {
+		return types.JavaBoolTrue
 	}
-	return MakePrimitiveObject("java/lang/Boolean", "Z", false)
+	return types.JavaBoolFalse
 }
 
-// Convert a Jacobin Boolean object to a Go boolean.
-func GoBooleanFromBooleanObject(obj *Object) bool {
-	if obj == nil {
-		return false
+// Convert a Jacobin Boolean to a Go boolean.
+func GoBooleanFromJavaBoolean(arg int64) bool {
+	if arg == types.JavaBoolTrue {
+		return true
 	}
-	return obj.FieldTable["value"].Fvalue.(bool)
+	return false
 }


### PR DESCRIPTION
 src/gfunction/javaMathBigDecimalFuncAtoM.go - bigdecimalEquals returns types.{JavaBoolTrue, JavaBoolFalse}.

src/gfunction/javaMathBigDecimalFuncAtoM_test.go - t.Run "bigdecimalStripTrailingZeros" handles returns types.{JavaBoolTrue, JavaBoolFalse}

src/gfunction/javaMathBigDecimalFuncNtoZ_test.go - progress with strip trailing zeros but needs more work.

src/object/object.go - new functions: JavaBooleanFromGoBoolean, GoBooleanFromJavaBoolean