### PR TITLE
JACOBIN-435 Conform to Java in formatting with %x

### DIFF
--- a/notes/coverage_by_function.txt
+++ b/notes/coverage_by_function.txt
@@ -1,0 +1,30 @@
+To see code coverage percentages by file instead of by directory in go test -cover, you need to use the -covermode=count flag and then process the output of the -coverprofile flag with the go tool cover command.
+
+Here's the two-step process:
+
+Step 1: Generate a Code Coverage Profile
+========================================
+
+First, run your tests and generate a coverage profile file. The -coverprofile flag tells the go test command to write the coverage data to a file.
+
+go test -covermode=count -coverprofile=coverage.out ./...
+    • go test: The command to run tests.
+    • -covermode=count: This is a key flag. It tracks the number of times each statement is executed, which is necessary for a detailed report.
+    • -coverprofile=coverage.out: This flag creates a file named coverage.out with the coverage data. You can name this file anything you want.
+    • ./...: This pattern tells the command to run tests for all packages in the current directory and its subdirectories.
+
+Step 2: Display the Per-File Report
+===================================
+
+Next, use the go tool cover command with the profile file you just created. The -func flag specifies that you want a function-level report, which includes the coverage for each file.
+
+go tool cover -func=coverage.out
+
+This command will produce a table that lists each Go source file, the number of functions in it, and the percentage of those functions that were covered by tests. The output will look something like this:
+github.com/your/package/path/file1.go:    FunctionName1    90.0%
+github.com/your/package/path/file2.go:    FunctionName2    75.5%
+...
+total:                (statements)    85.2%
+
+This is the standard and most effective way to see coverage at a granular, per-file level.
+

--- a/src/gfunction/javaLangDouble_test.go
+++ b/src/gfunction/javaLangDouble_test.go
@@ -1,0 +1,182 @@
+package gfunction
+
+import (
+    "jacobin/object"
+    "jacobin/types"
+    "jacobin/excNames"
+    "math"
+    "testing"
+    "fmt"
+)
+
+// helper to create a java/lang/Double object with a given value
+func makeDouble(val float64) *object.Object {
+    return Populator("java/lang/Double", types.Double, val)
+}
+
+func TestDouble_ValueOf_And_DoubleValue(t *testing.T) {
+    // valueOf(D) -> Double, then doubleValue()D -> primitive
+    d := 42.5
+    obj := doubleValueOf([]interface{}{d})
+    dobj, ok := obj.(*object.Object)
+    if !ok {
+        t.Fatalf("valueOf did not return object, got %T", obj)
+    }
+    out := doubleDoubleValue([]interface{}{dobj})
+    if got := out.(float64); got != d {
+        t.Fatalf("doubleDoubleValue mismatch: got %v want %v", got, d)
+    }
+}
+
+func TestDouble_ParseDouble_Valid_Invalid_Empty(t *testing.T) {
+    // valid
+    s := object.StringObjectFromGoString("3.5")
+    out := doubleParseDouble([]interface{}{s})
+    if got := out.(float64); got != 3.5 {
+        t.Fatalf("parseDouble valid: got %v", got)
+    }
+    // invalid -> NumberFormatException
+    sInv := object.StringObjectFromGoString("abc")
+    out = doubleParseDouble([]interface{}{sInv})
+    if geb, ok := out.(*GErrBlk); !ok || geb.ExceptionType != excNames.NumberFormatException {
+        if !ok {
+            t.Fatalf("parseDouble invalid: expected *GErrBlk, got %T", out)
+        }
+        t.Fatalf("parseDouble invalid: expected NumberFormatException, got %v", geb)
+    }
+    // empty -> NullPointerException according to implementation
+    sEmpty := object.StringObjectFromGoString("")
+    out = doubleParseDouble([]interface{}{sEmpty})
+    if geb, ok := out.(*GErrBlk); !ok || geb.ExceptionType != excNames.NullPointerException {
+        t.Fatalf("parseDouble empty: expected NullPointerException, got %T (%v)", out, out)
+    }
+}
+
+func TestDouble_ToLongBits_And_LongBitsToDouble(t *testing.T) {
+    // normal value round-trip
+    val := -123.75
+    bits := doubleToLongBits([]interface{}{val}).(int64)
+    back := doubleLongBitsToDouble([]interface{}{bits}).(float64)
+    if math.Float64bits(back) != math.Float64bits(val) {
+        t.Fatalf("round-trip bits mismatch: got %x want %x", math.Float64bits(back), math.Float64bits(val))
+    }
+
+    // NaN should map to canonical NaN pattern 0x7FF8000000000000 per implementation
+    nanBits := doubleToLongBits([]interface{}{math.NaN()}).(int64)
+    if uint64(nanBits) != 0x7FF8000000000000 {
+        t.Fatalf("NaN bits mismatch: got 0x%016X", uint64(nanBits))
+    }
+
+    // Check signed zero via longBitsToDouble
+    var one uint64 = 1
+    negZeroBits := int64(one << 63)
+    negZero := doubleLongBitsToDouble([]interface{}{negZeroBits}).(float64)
+    if !math.Signbit(negZero) {
+        t.Fatalf("expected negative zero sign bit")
+    }
+}
+
+func TestDouble_ToHexString(t *testing.T) {
+    d := 1.5
+    obj := makeDouble(d)
+    out := doubleToHexString([]interface{}{obj})
+    sObj := out.(*object.Object)
+    got := object.GoStringFromStringObject(sObj)
+    expected := fmt.Sprintf("0x%016X", math.Float64bits(d))
+    if got != expected {
+        t.Fatalf("toHexString got %q want %q", got, expected)
+    }
+}
+
+func TestDouble_ToString_Variants(t *testing.T) {
+    obj := makeDouble(123.25)
+    out := doubleToString([]interface{}{obj}).(*object.Object)
+    got := object.GoStringFromStringObject(out)
+    // %g formatting should produce "123.25" for this value
+    if got != "123.25" {
+        t.Fatalf("toString got %q", got)
+    }
+    // static variant uses %f default precision (6)
+    out2 := doubleToStringStatic([]interface{}{123.25}).(*object.Object)
+    got2 := object.GoStringFromStringObject(out2)
+    if got2 != "123.250000" {
+        t.Fatalf("toStringStatic got %q", got2)
+    }
+}
+
+func TestDouble_Compare_CompareTo_Equals(t *testing.T) {
+    a := makeDouble(1.0)
+    b := makeDouble(2.0)
+
+    cmp := doubleCompare([]interface{}{a, b}).(int64)
+    if cmp != -1 {
+        t.Fatalf("compare expected -1, got %d", cmp)
+    }
+
+    cto := doubleCompareTo([]interface{}{a, b}).(int64)
+    if cto != -1 {
+        t.Fatalf("compareTo expected -1, got %d", cto)
+    }
+
+    eq := doubleEquals([]interface{}{a, makeDouble(1.0)})
+    if eq != types.JavaBoolTrue {
+        t.Fatalf("equals expected true, got %v", eq)
+    }
+}
+
+func TestDouble_PrimitiveConversions(t *testing.T) {
+    obj := makeDouble(65.9)
+    if bv := doubleByteValue([]interface{}{obj}).(int64); bv != 65 { // byte cast then widen to int64
+        t.Fatalf("byteValue expected 65, got %d", bv)
+    }
+    if iv := doubleIntValue([]interface{}{obj}).(int32); iv != 65 {
+        t.Fatalf("intValue expected 65, got %d", iv)
+    }
+    if sv := doubleShortValue([]interface{}{obj}).(int16); sv != 65 {
+        t.Fatalf("shortValue expected 65, got %d", sv)
+    }
+    if lv := doubleLongValue([]interface{}{obj}).(int64); lv != 65 {
+        t.Fatalf("longValue expected 65, got %d", lv)
+    }
+    if fv := doubleFloatValue([]interface{}{obj}).(float64); fv != 65.9 {
+        t.Fatalf("floatValue expected 65.9, got %v", fv)
+    }
+}
+
+func TestDouble_Max_Min_Sum(t *testing.T) {
+    if mx := doubleMax([]interface{}{1.0, 2.5}).(float64); mx != 2.5 {
+        t.Fatalf("max expected 2.5, got %v", mx)
+    }
+    if mn := doubleMin([]interface{}{1.0, -2.5}).(float64); mn != -2.5 {
+        t.Fatalf("min expected -2.5, got %v", mn)
+    }
+    if sm := doubleSum([]interface{}{1.25, 2.75}).(float64); sm != 4.0 {
+        t.Fatalf("sum expected 4.0, got %v", sm)
+    }
+}
+
+func TestDouble_IsInfinite_IsFinite(t *testing.T) {
+    inf := makeDouble(math.Inf(1))
+    if v := doubleIsInfinite([]interface{}{inf}); v != types.JavaBoolTrue {
+        t.Fatalf("isInfinite expected true, got %v", v)
+    }
+    if v := doubleIsFinite([]interface{}{inf}); v != types.JavaBoolFalse {
+        t.Fatalf("isFinite expected false for Inf, got %v", v)
+    }
+    finite := makeDouble(0.0)
+    if v := doubleIsFinite([]interface{}{finite}); v != types.JavaBoolTrue {
+        t.Fatalf("isFinite expected true for 0.0, got %v", v)
+    }
+}
+
+func TestDouble_ValueOfString(t *testing.T) {
+    s := object.StringObjectFromGoString("-10.5")
+    out := doubleValueOfString([]interface{}{s})
+    dobj, ok := out.(*object.Object)
+    if !ok {
+        t.Fatalf("valueOf(String) did not return object, got %T", out)
+    }
+    if val := doubleDoubleValue([]interface{}{dobj}).(float64); val != -10.5 {
+        t.Fatalf("valueOf(String) value mismatch: %v", val)
+    }
+}

--- a/src/gfunction/javaLangFloat_test.go
+++ b/src/gfunction/javaLangFloat_test.go
@@ -1,0 +1,209 @@
+package gfunction
+
+import (
+    "fmt"
+    "jacobin/excNames"
+    "jacobin/object"
+    "jacobin/types"
+    "math"
+    "testing"
+)
+
+// helper to create a java/lang/Float object with a given value (stored as float64)
+// Note: internal helper getFloat64ValueFromObject expects field type == types.Double,
+// so we construct the Float object with Double field type to interoperate with Float methods.
+func makeFloat(val float64) *object.Object {
+    return object.MakePrimitiveObject("java/lang/Float", types.Double, val)
+}
+
+func TestFloat_ValueOf_And_FloatValue(t *testing.T) {
+    v := 12.75
+    // valueOf(F) should return a Float object holding the value; its field type is types.Float
+    obj := floatValueOf([]interface{}{v})
+    fobj, ok := obj.(*object.Object)
+    if !ok {
+        t.Fatalf("valueOf did not return object, got %T", obj)
+    }
+    // verify stored value matches
+    if got, ok2 := fobj.FieldTable["value"].Fvalue.(float64); !ok2 || got != v {
+        t.Fatalf("valueOf stored value mismatch: got %v", fobj.FieldTable["value"].Fvalue)
+    }
+    // Now test floatValue() using a compatible object created via makeFloat
+    out := floatFloatValue([]interface{}{makeFloat(v)})
+    if got := out.(float64); got != v {
+        t.Fatalf("floatFloatValue mismatch: got %v want %v", got, v)
+    }
+}
+
+func TestFloat_ParseFloat_Valid_Invalid_Empty(t *testing.T) {
+    // valid
+    s := object.StringObjectFromGoString("3.5")
+    out := floatParseFloat([]interface{}{s})
+    if got := out.(float64); float32(got) != float32(3.5) {
+        t.Fatalf("parseFloat valid: got %v", got)
+    }
+    // invalid -> NumberFormatException
+    sInv := object.StringObjectFromGoString("abc")
+    out = floatParseFloat([]interface{}{sInv})
+    if geb, ok := out.(*GErrBlk); !ok || geb.ExceptionType != excNames.NumberFormatException {
+        if !ok {
+            t.Fatalf("parseFloat invalid: expected *GErrBlk, got %T", out)
+        }
+        t.Fatalf("parseFloat invalid: expected NumberFormatException, got %v", geb)
+    }
+    // empty -> NullPointerException according to implementation
+    sEmpty := object.StringObjectFromGoString("")
+    out = floatParseFloat([]interface{}{sEmpty})
+    if geb, ok := out.(*GErrBlk); !ok || geb.ExceptionType != excNames.NullPointerException {
+        t.Fatalf("parseFloat empty: expected NullPointerException, got %T (%v)", out, out)
+    }
+}
+
+func TestFloat_IntBits_RoundTrip_And_NegZero(t *testing.T) {
+    // round-trip a normal value via bits
+    v := float32(-7.25)
+    bits := math.Float32bits(v)
+    gotF := floatIntBitsToFloat([]interface{}{int64(bits)}).(float64)
+    if math.Float32bits(float32(gotF)) != bits {
+        t.Fatalf("intBitsToFloat roundtrip mismatch: got %x want %x", math.Float32bits(float32(gotF)), bits)
+    }
+
+    // floatToIntBits should produce float32 bits of given float64 value
+    v2 := 5.5
+    bits2 := floatFloatToIntBits([]interface{}{v2}).(int64)
+    if uint32(bits2) != math.Float32bits(float32(v2)) {
+        t.Fatalf("floatToIntBits mismatch: got %08x want %08x", uint32(bits2), math.Float32bits(float32(v2)))
+    }
+
+    // negative zero: 0x80000000
+    negZeroBits := uint32(0x80000000)
+    gotNegZero := floatIntBitsToFloat([]interface{}{int64(negZeroBits)}).(float64)
+    if !math.Signbit(gotNegZero) {
+        t.Fatalf("expected negative zero sign bit")
+    }
+}
+
+func TestFloat_ToHexString_And_ToString(t *testing.T) {
+    v := 123.25
+    obj := makeFloat(v)
+    // toHexString prints Float64bits (per current implementation)
+    sObj := floatToHexString([]interface{}{obj}).(*object.Object)
+    gotHex := object.GoStringFromStringObject(sObj)
+    expectedHex := fmt.Sprintf("0x%016X", math.Float64bits(v))
+    if gotHex != expectedHex {
+        t.Fatalf("toHexString got %q want %q", gotHex, expectedHex)
+    }
+
+    // instance toString -> %g
+    sObj2 := floatToString([]interface{}{obj}).(*object.Object)
+    gotStr := object.GoStringFromStringObject(sObj2)
+    if gotStr != "123.25" {
+        t.Fatalf("toString got %q", gotStr)
+    }
+
+    // static toString(F) -> %f default precision (6)
+    sObj3 := floatToStringStatic([]interface{}{v}).(*object.Object)
+    gotStr2 := object.GoStringFromStringObject(sObj3)
+    if gotStr2 != "123.250000" {
+        t.Fatalf("toStringStatic got %q", gotStr2)
+    }
+}
+
+func TestFloat_Compare_CompareTo_Equals(t *testing.T) {
+    a := makeFloat(1.0)
+    b := makeFloat(2.0)
+
+    cmp := floatCompare([]interface{}{a, b}).(int64)
+    if cmp != -1 {
+        t.Fatalf("compare expected -1, got %d", cmp)
+    }
+
+    cto := floatCompareTo([]interface{}{a, b}).(int64)
+    if cto != -1 {
+        t.Fatalf("compareTo expected -1, got %d", cto)
+    }
+
+    eq := floatEquals([]interface{}{a, makeFloat(1.0)})
+    if eq != types.JavaBoolTrue {
+        t.Fatalf("equals expected true, got %v", eq)
+    }
+}
+
+func TestFloat_PrimitiveConversions(t *testing.T) {
+    obj := makeFloat(65.9)
+    if bv := floatByteValue([]interface{}{obj}).(int64); bv != 65 { // byte cast then widen
+        t.Fatalf("byteValue expected 65, got %d", bv)
+    }
+    if iv := floatIntValue([]interface{}{obj}).(int64); iv != 65 { // returned as int64 of int32
+        t.Fatalf("intValue expected 65, got %d", iv)
+    }
+    if sv := floatShortValue([]interface{}{obj}).(int16); sv != 65 {
+        t.Fatalf("shortValue expected 65, got %d", sv)
+    }
+    if lv := floatLongValue([]interface{}{obj}).(int64); lv != 65 {
+        t.Fatalf("longValue expected 65, got %d", lv)
+    }
+    if dv := floatDoubleValue([]interface{}{obj}).(float64); dv != 65.9 {
+        t.Fatalf("doubleValue expected 65.9, got %v", dv)
+    }
+}
+
+func TestFloat_Max_Min_Sum(t *testing.T) {
+    if mx := floatMax([]interface{}{1.0, 2.5}).(float64); mx != 2.5 {
+        t.Fatalf("max expected 2.5, got %v", mx)
+    }
+    if mn := floatMin([]interface{}{1.0, -2.5}).(float64); mn != -2.5 {
+        t.Fatalf("min expected -2.5, got %v", mn)
+    }
+    if sm := floatSum([]interface{}{1.25, 2.75}).(float64); sm != 4.0 {
+        t.Fatalf("sum expected 4.0, got %v", sm)
+    }
+}
+
+func TestFloat_IsInfinite_IsFinite(t *testing.T) {
+    inf := makeFloat(math.Inf(1))
+    if v := floatIsInfinite([]interface{}{inf}); v != types.JavaBoolTrue {
+        t.Fatalf("isInfinite expected true, got %v", v)
+    }
+    if v := floatIsFinite([]interface{}{inf}); v != types.JavaBoolFalse {
+        t.Fatalf("isFinite expected false for Inf, got %v", v)
+    }
+    finite := makeFloat(0.0)
+    if v := floatIsFinite([]interface{}{finite}); v != types.JavaBoolTrue {
+        t.Fatalf("isFinite expected true for 0.0, got %v", v)
+    }
+}
+
+func TestFloat_ValueOfString(t *testing.T) {
+    s := object.StringObjectFromGoString("-10.5")
+    out := floatValueOfString([]interface{}{s})
+    fobj, ok := out.(*object.Object)
+    if !ok {
+        t.Fatalf("valueOf(String) did not return object, got %T", out)
+    }
+    if val, ok := fobj.FieldTable["value"].Fvalue.(float64); !ok || val != -10.5 {
+        t.Fatalf("valueOfString value mismatch: %v", fobj.FieldTable["value"].Fvalue)
+    }
+}
+
+func TestFloat_Float16_Conversions(t *testing.T) {
+    // 0x3C00 is +1.0 in IEEE 754 half precision
+    one16 := int64(0x3C00)
+    out := floatFloat16ToFloat([]interface{}{one16}).(float64)
+    if float32(out) != float32(1.0) {
+        t.Fatalf("float16ToFloat for 1.0 failed: got %v", out)
+    }
+
+    // Convert 1.0f32 back to half
+    back := floatFloatToFloat16([]interface{}{1.0}).(int64)
+    if uint16(back) != 0x3C00 {
+        t.Fatalf("floatToFloat16 for 1.0 failed: got 0x%04X", uint16(back))
+    }
+
+    // Infinity mapping
+    inf16 := int64(0x7C00)
+    outInf := floatFloat16ToFloat([]interface{}{inf16}).(float64)
+    if !math.IsInf(outInf, 1) {
+        t.Fatalf("float16ToFloat for +Inf failed: got %v", outInf)
+    }
+}

--- a/src/gfunction/javaLangInteger_test.go
+++ b/src/gfunction/javaLangInteger_test.go
@@ -304,3 +304,119 @@ func TestIntegerValueOfString(t *testing.T) {
 	res = integerValueOfString(params)
 	checkIntegerErrType(t, res, excNames.NumberFormatException)
 }
+
+
+func TestInteger_NumberOfLeadingAndTrailingZeros(t *testing.T) {
+    // 0x0000F000 -> leading zeros = 16, trailing zeros = 12 (32-bit semantics)
+    val := int64(0x0000F000)
+    if lz := integerNumberOfLeadingZeros([]interface{}{val}).(int64); lz != 16 {
+        t.Fatalf("numberOfLeadingZeros(0x0000F000)=%d", lz)
+    }
+    if tz := integerNumberOfTrailingZeros([]interface{}{val}).(int64); tz != 12 {
+        t.Fatalf("numberOfTrailingZeros(0x0000F000)=%d", tz)
+    }
+}
+
+func TestInteger_RotateLeftRight(t *testing.T) {
+    val := int64(0x12345678)
+    rl := integerRotateLeft([]interface{}{val, int64(8)}).(int64)
+    rr := integerRotateRight([]interface{}{val, int64(8)}).(int64)
+    if uint32(rl) != 0x34567812 {
+        t.Fatalf("rotateLeft(0x12345678,8)=0x%08x", uint32(rl))
+    }
+    if uint32(rr) != 0x78123456 {
+        t.Fatalf("rotateRight(0x12345678,8)=0x%08x", uint32(rr))
+    }
+}
+
+func TestInteger_Reverse_And_ReverseBytes(t *testing.T) {
+    // reverse bits of 1 -> 0x80000000
+    if got := uint32(integerReverse([]interface{}{int64(1)}).(int64)); got != 0x80000000 {
+        t.Fatalf("reverse(1)=0x%08x", got)
+    }
+    // reverse bytes of 0x12345678 -> 0x78563412
+    if got := uint32(integerReverseBytes([]interface{}{int64(0x12345678)}).(int64)); got != 0x78563412 {
+        t.Fatalf("reverseBytes(0x12345678)=0x%08x", got)
+    }
+}
+
+func TestInteger_ToHexOctalBinaryString(t *testing.T) {
+    // hex
+    if s := object.GoStringFromStringObject(integerToHexString([]interface{}{int64(26)}).(*object.Object)); s != "1a" {
+        t.Fatalf("toHexString(26)=%q", s)
+    }
+    // octal
+    if s := object.GoStringFromStringObject(integerToOctalString([]interface{}{int64(26)}).(*object.Object)); s != "32" {
+        t.Fatalf("toOctalString(26)=%q", s)
+    }
+    // binary unsigned: -1 -> 32 ones
+    s := object.GoStringFromStringObject(integerToBinaryString([]interface{}{int64(-1)}).(*object.Object))
+    if len(s) != 32 {
+        t.Fatalf("binary length for -1 expected 32, got %d", len(s))
+    }
+    for i := 0; i < len(s); i++ {
+        if s[i] != '1' {
+            t.Fatalf("expected all ones, got %q at %d", s[i], i)
+        }
+    }
+}
+
+func TestInteger_CompareUnsigned_And_UnsignedDivRem(t *testing.T) {
+    // compareUnsigned: (-1) > 0 as unsigned
+    if c := integerCompareUnsigned([]interface{}{int64(-1), int64(0)}).(int64); c != 1 {
+        t.Fatalf("compareUnsigned(-1,0)=%d", c)
+    }
+    if c := integerCompareUnsigned([]interface{}{int64(1), int64(-1)}).(int64); c != -1 {
+        t.Fatalf("compareUnsigned(1,-1)=%d", c)
+    }
+    // divideUnsigned and remainderUnsigned
+    if q := integerDivideUnsigned([]interface{}{int64(-2), int64(3)}).(int64); q != int64(uint32(0xFFFFFFFE)/3) {
+        t.Fatalf("divideUnsigned(-2,3)=%d", q)
+    }
+    if r := integerRemainderUnsigned([]interface{}{int64(-2), int64(3)}).(int64); r != int64(uint32(0xFFFFFFFE)%3) {
+        t.Fatalf("remainderUnsigned(-2,3)=%d", r)
+    }
+    // divide by zero -> ArithmeticException
+    if res := integerDivideUnsigned([]interface{}{int64(1), int64(0)}); res == nil {
+        t.Fatalf("expected error for divide by zero")
+    } else if geb, ok := res.(*GErrBlk); !ok || geb.ExceptionType != excNames.ArithmeticException {
+        t.Fatalf("expected ArithmeticException, got %T", res)
+    }
+}
+
+func TestInteger_HighestLowestOneBit_MaxMinSum(t *testing.T) {
+    if h := uint32(integerHighestOneBit([]interface{}{int64(0xF234)}).(int64)); h != 0x8000 {
+        t.Fatalf("highestOneBit(0xF234)=0x%08x", h)
+    }
+    if l := uint32(integerLowestOneBit([]interface{}{int64(0xF234)}).(int64)); l != 0x0004 {
+        t.Fatalf("lowestOneBit(0xF234)=0x%08x", l)
+    }
+    if m := integerMax([]interface{}{int64(-5), int64(3)}).(int64); m != 3 {
+        t.Fatalf("max(-5,3)=%d", m)
+    }
+    if n := integerMin([]interface{}{int64(-5), int64(3)}).(int64); n != -5 {
+        t.Fatalf("min(-5,3)=%d", n)
+    }
+    if s := integerSum([]interface{}{int64(7), int64(8)}).(int64); s != 15 {
+        t.Fatalf("sum(7,8)=%d", s)
+    }
+}
+
+func TestInteger_ToUnsignedString_Variants(t *testing.T) {
+    // toUnsignedString with negative -> decimal of uint32
+    s := object.GoStringFromStringObject(integerToUnsignedString([]interface{}{int64(-1)}).(*object.Object))
+    if s != "4294967295" {
+        t.Fatalf("toUnsignedString(-1)=%q", s)
+    }
+    // toUnsignedStringRadix hex
+    s2 := object.GoStringFromStringObject(integerToUnsignedStringRadix([]interface{}{int64(-1), int64(16)}).(*object.Object))
+    if s2 != "ffffffff" {
+        t.Fatalf("toUnsignedString(-1,16)=%q", s2)
+    }
+}
+
+func TestInteger_ToUnsignedLong(t *testing.T) {
+    if v := integerToUnsignedLong([]interface{}{int64(-1)}).(int64); v != 4294967295 {
+        t.Fatalf("toUnsignedLong(-1)=%d", v)
+    }
+}

--- a/src/gfunction/javaLangLong_test.go
+++ b/src/gfunction/javaLangLong_test.go
@@ -1,0 +1,80 @@
+package gfunction
+
+import (
+    "jacobin/excNames"
+    "jacobin/object"
+    "testing"
+)
+
+func TestLong_ValueOf_And_DoubleValue(t *testing.T) {
+    // valueOf(J) -> Long object, then doubleValue() -> primitive double
+    obj := longValueOf([]interface{}{int64(42)})
+    lobj, ok := obj.(*object.Object)
+    if !ok {
+        t.Fatalf("valueOf did not return object, got %T", obj)
+    }
+    out := longDoubleValue([]interface{}{lobj})
+    if got := out.(float64); got != 42.0 {
+        t.Fatalf("doubleValue mismatch: got %v want %v", got, 42.0)
+    }
+}
+
+func TestLong_ParseLong_Valid_And_Invalid(t *testing.T) {
+    // NOTE: current implementation reads params[1] for the string argument
+    s := object.StringObjectFromGoString("12345")
+    out := longParseLong([]interface{}{nil, s})
+    if got := out.(int64); got != 12345 {
+        t.Fatalf("parseLong valid: got %d", got)
+    }
+    // invalid -> NumberFormatException
+    sinv := object.StringObjectFromGoString("abc")
+    out = longParseLong([]interface{}{nil, sinv})
+    if geb, ok := out.(*GErrBlk); !ok || geb.ExceptionType != excNames.NumberFormatException {
+        if !ok {
+            t.Fatalf("parseLong invalid: expected *GErrBlk, got %T", out)
+        }
+        t.Fatalf("parseLong invalid: expected NumberFormatException, got %v", geb)
+    }
+}
+
+func TestLong_RotateLeft_Right(t *testing.T) {
+    // Use a known pattern and compare by unsigned bit pattern
+    val := int64(0x0123456789abcdef)
+    // rotate left by 8 -> 0x23456789abcdef01
+    outL := longRotateLeft([]interface{}{val, int64(8)})
+    gotL := uint64(outL.(int64))
+    var expectedL uint64 = 0x23456789abcdef01
+    if gotL != expectedL {
+        t.Fatalf("rotateLeft mismatch: got 0x%016x want 0x%016x", gotL, expectedL)
+    }
+    // rotate right by 12 -> expected using uint64 rotation
+    outR := longRotateRight([]interface{}{val, int64(12)})
+    gotR := uint64(outR.(int64))
+    // compute expected separately without constant overflow
+    var base uint64 = 0x0123456789abcdef
+    expectedR := (base >> 12) | (base << (64 - 12))
+    if gotR != expectedR {
+        t.Fatalf("rotateRight mismatch: got 0x%016x want 0x%016x", gotR, expectedR)
+    }
+}
+
+func TestLong_ToHexString_And_ToString(t *testing.T) {
+    // toHexString pads to 16 digits per implementation
+    out := longToHexString([]interface{}{int64(1)})
+    sObj := out.(*object.Object)
+    if got := object.GoStringFromStringObject(sObj); got != "0000000000000001" {
+        t.Fatalf("toHexString(1) got %q", got)
+    }
+    out = longToHexString([]interface{}{int64(-1)})
+    sObj = out.(*object.Object)
+    if got := object.GoStringFromStringObject(sObj); got != "ffffffffffffffff" {
+        t.Fatalf("toHexString(-1) got %q", got)
+    }
+
+    // toString decimal
+    out = longToString([]interface{}{int64(-123)})
+    sObj = out.(*object.Object)
+    if got := object.GoStringFromStringObject(sObj); got != "-123" {
+        t.Fatalf("toString(-123) got %q", got)
+    }
+}

--- a/src/gfunction/javaLangMath_test.go
+++ b/src/gfunction/javaLangMath_test.go
@@ -1,0 +1,259 @@
+package gfunction
+
+import (
+    "jacobin/excNames"
+    "math"
+    "math/big"
+    "testing"
+)
+
+func TestMath_Abs(t *testing.T) {
+    if got := absFloat64([]interface{}{float64(-3.5)}).(float64); got != 3.5 {
+        t.Fatalf("absFloat64(-3.5)=%v", got)
+    }
+    if got := absInt64([]interface{}{int64(-42)}).(int64); got != 42 {
+        t.Fatalf("absInt64(-42)=%v", got)
+    }
+}
+
+func TestMath_Trigonometry_Basics(t *testing.T) {
+    if got := cosFloat64([]interface{}{float64(0)}).(float64); got != 1.0 {
+        t.Fatalf("cos(0)=%v", got)
+    }
+    if got := sinFloat64([]interface{}{float64(0)}).(float64); got != 0.0 {
+        t.Fatalf("sin(0)=%v", got)
+    }
+    if got := tanFloat64([]interface{}{float64(0)}).(float64); got != 0.0 {
+        t.Fatalf("tan(0)=%v", got)
+    }
+    // atan2(y=0,x=-1) == pi
+    if got := atan2Float64([]interface{}{float64(0), float64(-1)}).(float64); math.Abs(got-math.Pi) > 1e-12 {
+        t.Fatalf("atan2(0,-1)=%v", got)
+    }
+}
+
+func TestMath_Add_Sub_Mul_High(t *testing.T) {
+    if got := addExactII([]interface{}{int64(2), int64(3)}).(int64); got != 5 {
+        t.Fatalf("addExactII=%v", got)
+    }
+    if got := subtractExactJJ([]interface{}{int64(5), int64(8)}).(int64); got != -3 {
+        t.Fatalf("subtractExactJJ=%v", got)
+    }
+    if got := multiplyExactII([]interface{}{int64(-7), int64(6)}).(int64); got != -42 {
+        t.Fatalf("multiplyExactII=%v", got)
+    }
+    // multiplyHigh: check against big-int computation done by implementation with two known values
+    // use positive operands that fit in int64 to avoid literal overflow
+    aVal := uint64(0x0123456789abcdef)
+    bVal := uint64(0x1111111122222222)
+    hi := multiplyHighJJ([]interface{}{int64(aVal), int64(bVal)})
+    // compute expected using big integers
+    a := new(big.Int).SetUint64(aVal)
+    b := new(big.Int).SetUint64(bVal)
+    p := new(big.Int).Mul(a, b)
+    expected := new(big.Int).Rsh(p, 64).Int64()
+    if hi.(int64) != expected {
+        t.Fatalf("multiplyHighJJ mismatch: got %x want %x", hi.(int64), expected)
+    }
+}
+
+func TestMath_FloorDiv_Mod(t *testing.T) {
+    // simple positive
+    if got := floorDivII([]interface{}{int64(7), int64(3)}); got.(int64) != 2 {
+        t.Fatalf("floorDiv 7/3=%v", got)
+    }
+    if got := floorModII([]interface{}{int64(7), int64(3)}).(int64); got != 1 {
+        t.Fatalf("floorMod 7,3=%v", got)
+    }
+    // negative dividend: floorDiv should round toward -inf
+    fd := floorDivII([]interface{}{int64(-7), int64(3)})
+    if fd.(int64) != -3 { // since -7/3 = -2 with trunc, floor is -3
+        t.Fatalf("floorDiv -7/3=%v", fd)
+    }
+    if got := floorModII([]interface{}{int64(-7), int64(3)}).(int64); got != 2 { // -7 = (-3)*3 + 2
+        t.Fatalf("floorMod -7,3=%v", got)
+    }
+    // divide by zero -> ArithmeticException
+    dz := floorDivII([]interface{}{int64(1), int64(0)})
+    if geb, ok := dz.(*GErrBlk); !ok || geb.ExceptionType != excNames.ArithmeticException {
+        t.Fatalf("floorDiv divide-by-zero expected ArithmeticException, got %T (%v)", dz, dz)
+    }
+}
+
+func TestMath_Rounding(t *testing.T) {
+    if got := floorFloat64([]interface{}{float64(3.9)}).(float64); got != 3.0 {
+        t.Fatalf("floor 3.9=%v", got)
+    }
+    if got := ceilFloat64([]interface{}{float64(3.1)}).(float64); got != 4.0 {
+        t.Fatalf("ceil 3.1=%v", got)
+    }
+    if got := rintFloat64([]interface{}{float64(2.3)}).(float64); got != 2.0 {
+        t.Fatalf("rint 2.3=%v", got)
+    }
+    if got := roundInt64([]interface{}{float64(-2.3)}).(int64); got != -2 {
+        t.Fatalf("round -2.3=%v", got)
+    }
+}
+
+func TestMath_Exponent_Log_Pow(t *testing.T) {
+    if got := expFloat64([]interface{}{float64(1)}).(float64); math.Abs(got-math.E) > 1e-12 {
+        t.Fatalf("exp(1)=%v", got)
+    }
+    if got := expm1Float64([]interface{}{float64(1)}).(float64); math.Abs(got-(math.E-1)) > 1e-12 {
+        t.Fatalf("expm1(1)=%v", got)
+    }
+    if got := logFloat64([]interface{}{math.E}).(float64); math.Abs(got-1.0) > 1e-12 {
+        t.Fatalf("log(e)=%v", got)
+    }
+    if got := log10Float64([]interface{}{float64(1000)}).(float64); math.Abs(got-3.0) > 1e-12 {
+        t.Fatalf("log10(1000)=%v", got)
+    }
+    if got := log1pFloat64([]interface{}{float64(0)}).(float64); got != 0.0 {
+        t.Fatalf("log1p(0)=%v", got)
+    }
+    if got := powFloat64([]interface{}{float64(2), float64(10)}).(float64); got != 1024.0 {
+        t.Fatalf("pow(2,10)=%v", got)
+    }
+}
+
+func TestMath_Max_Min(t *testing.T) {
+    if got := maxII([]interface{}{int64(2), int64(5)}).(int64); got != 5 {
+        t.Fatalf("maxII=%v", got)
+    }
+    if got := minII([]interface{}{int64(2), int64(5)}).(int64); got != 2 {
+        t.Fatalf("minII=%v", got)
+    }
+    if got := maxDD([]interface{}{float64(3.5), float64(3.6)}).(float64); got != 3.6 {
+        t.Fatalf("maxDD=%v", got)
+    }
+    if got := minDD([]interface{}{float64(3.5), float64(3.6)}).(float64); got != 3.5 {
+        t.Fatalf("minDD=%v", got)
+    }
+}
+
+func TestMath_NextAfter_Up_Down(t *testing.T) {
+    base := 1.0
+    up := nextUpFloat64([]interface{}{base}).(float64)
+    if !(up > base) {
+        t.Fatalf("nextUp not greater than base: %v <= %v", up, base)
+    }
+    down := nextDownFloat64([]interface{}{base}).(float64)
+    if !(down < base) {
+        t.Fatalf("nextDown not less than base: %v >= %v", down, base)
+    }
+    na := nextAfterDD([]interface{}{float64(0), float64(1)}).(float64)
+    if !(na > 0) {
+        t.Fatalf("nextAfter(0->1) not > 0: %v", na)
+    }
+}
+
+func TestMath_FMA_Hypot_Remainder(t *testing.T) {
+    if got := fmaDDD([]interface{}{float64(2), float64(3), float64(4)}).(float64); got != 10.0 {
+        t.Fatalf("fma(2,3,4)=%v", got)
+    }
+    if got := hypotFloat64([]interface{}{float64(3), float64(4)}).(float64); math.Abs(got-5.0) > 1e-12 {
+        t.Fatalf("hypot(3,4)=%v", got)
+    }
+    if got := IEEEremainderFloat64([]interface{}{float64(5), float64(2)}).(float64); math.Abs(got-1.0) > 1e-12 {
+        t.Fatalf("Remainder(5,2)=%v", got)
+    }
+}
+
+func TestMath_Scalb_Signum_Sqrt(t *testing.T) {
+    if got := scalbDI([]interface{}{float64(1.5), int64(1)}).(float64); math.Abs(got-3.0) > 1e-12 {
+        t.Fatalf("scalb(1.5,1)=%v", got)
+    }
+    if got := signumFloat64([]interface{}{float64(-0.1)}).(float64); got != -1.0 {
+        t.Fatalf("signum(-0.1)=%v", got)
+    }
+    if got := signumFloat64([]interface{}{float64(0.0)}).(float64); got != 0.0 {
+        t.Fatalf("signum(0)=%v", got)
+    }
+    if got := sqrtFloat64([]interface{}{float64(144)}).(float64); got != 12.0 {
+        t.Fatalf("sqrt(144)=%v", got)
+    }
+}
+
+func TestMath_Degree_Radian_and_ToIntExact(t *testing.T) {
+    // 180 deg -> pi radians; using PI constant in code
+    if got := toRadiansFloat64([]interface{}{float64(180.0)}).(float64); math.Abs(got-math.Pi) > 1e-12 {
+        t.Fatalf("toRadians(180)=%v", got)
+    }
+    if got := toDegreesFloat64([]interface{}{math.Pi}).(float64); math.Abs(got-180.0) > 1e-12 {
+        t.Fatalf("toDegrees(pi)=%v", got)
+    }
+    if got := toIntExactInt64([]interface{}{int64(-123)}).(int64); got != -123 {
+        t.Fatalf("toIntExact(-123)=%v", got)
+    }
+}
+
+func TestMath_GetExponent_Ulp_Specials(t *testing.T) {
+    // Normal number: exponent of 1.0 is 0
+    {
+            v := getExponentFloat64([]interface{}{float64(1.0)})
+            var got int64
+            switch x := v.(type) {
+            case int64:
+                got = x
+            case int:
+                got = int64(x)
+            default:
+                t.Fatalf("unexpected type for exponent: %T", v)
+            }
+            if got != 0 {
+                t.Fatalf("getExponent(1.0)=%v", got)
+            }
+        }
+    // NaN / Inf: returns MAX_DOUBLE_EXPONENT+1 == 1024
+    {
+        v := getExponentFloat64([]interface{}{math.NaN()})
+        var got int64
+        switch x := v.(type) {
+        case int64:
+            got = x
+        case int:
+            got = int64(x)
+        default:
+            t.Fatalf("unexpected type for exponent NaN: %T", v)
+        }
+        if got != MAX_DOUBLE_EXPONENT+1 {
+            t.Fatalf("getExponent(NaN)=%v", got)
+        }
+    }
+    {
+        v := getExponentFloat64([]interface{}{math.Inf(1)})
+        var got int64
+        switch x := v.(type) {
+        case int64:
+            got = x
+        case int:
+            got = int64(x)
+        default:
+            t.Fatalf("unexpected type for exponent Inf: %T", v)
+        }
+        if got != MAX_DOUBLE_EXPONENT+1 {
+            t.Fatalf("getExponent(Inf)=%v", got)
+        }
+    }
+
+    // ULP: finite positive value should be positive and small
+    if got := ulpFloat64([]interface{}{float64(1.0)}).(float64); !(got > 0 && got < 1e-15) {
+        t.Fatalf("ulp(1.0)=%v", got)
+    }
+    // ULP of +/-Inf is +Inf
+    if res := ulpFloat64([]interface{}{math.Inf(-1)}).(float64); !math.IsInf(res, 1) {
+        t.Fatalf("ulp(-Inf) expected +Inf, got %v", res)
+    }
+    // NaN returns NaN
+    if res := ulpFloat64([]interface{}{math.NaN()}).(float64); !math.IsNaN(res) {
+        t.Fatalf("ulp(NaN) expected NaN, got %v", res)
+    }
+}
+
+func TestMath_Random_Range(t *testing.T) {
+    // random in [0,1)
+    v := randomFloat64(nil).(float64)
+    if !(v >= 0.0 && v < 1.0) {
+        t.Fatalf("random out of range: %v", v)
+    }
+}

--- a/src/gfunction/stringFormatter_test.go
+++ b/src/gfunction/stringFormatter_test.go
@@ -1,0 +1,100 @@
+package gfunction
+
+import (
+    "jacobin/object"
+    "jacobin/types"
+    "runtime"
+    "strings"
+    "testing"
+)
+
+// helper: build a reference array [Ljava/lang/Object; from provided element objects
+func makeObjectRefArray(elems ...*object.Object) *object.Object {
+    arr := object.Make1DimRefArray("Ljava/lang/Object;", int64(len(elems)))
+    fv := arr.FieldTable["value"]
+    fv.Fvalue = elems
+    arr.FieldTable["value"] = fv
+    return arr
+}
+
+func TestStringFormatter_Newline_And_Boolean(t *testing.T) {
+    // format with %n and %b on a non-boolean arg (should be true)
+    fmtObj := object.StringObjectFromGoString("Line1%nLine2 %b")
+    // one integer argument
+    intObj := Populator("java/lang/Integer", types.Int, int64(1))
+    argsArr := makeObjectRefArray(intObj)
+
+    out := StringFormatter([]interface{}{fmtObj, argsArr})
+    s := object.GoStringFromStringObject(out.(*object.Object))
+
+    nl := "\n"
+    if runtime.GOOS == "windows" {
+        nl = "\r\n"
+    }
+    expected := "Line1" + nl + "Line2 true"
+    if s != expected {
+        t.Fatalf("unexpected output: %q want %q", s, expected)
+    }
+}
+
+func TestStringFormatter_String_And_Uppercase(t *testing.T) {
+    fmtObj := object.StringObjectFromGoString("%s %S")
+    s1 := object.StringObjectFromGoString("hello")
+    s2 := object.StringObjectFromGoString("world")
+    argsArr := makeObjectRefArray(s1, s2)
+
+    out := StringFormatter([]interface{}{fmtObj, argsArr})
+    got := object.GoStringFromStringObject(out.(*object.Object))
+    if got != "hello WORLD" {
+        t.Fatalf("got %q", got)
+    }
+}
+
+func TestStringFormatter_Hash_For_String(t *testing.T) {
+    // "abc" Java hashCode is 96354 decimal -> 0x17832
+    fmtObj := object.StringObjectFromGoString("%h %H")
+    s := object.StringObjectFromGoString("abc")
+    argsArr := makeObjectRefArray(s, s)
+
+    out := StringFormatter([]interface{}{fmtObj, argsArr})
+    got := object.GoStringFromStringObject(out.(*object.Object))
+    if got != "17862 17862" {
+        t.Fatalf("got %q want %q", got, "17862 17862")
+    }
+}
+
+func TestStringFormatter_Object_ToString_Like(t *testing.T) {
+    fmtObj := object.StringObjectFromGoString("obj=%s")
+    o := object.MakeEmptyObject()
+    o.KlassName = object.StringPoolIndexFromGoString("com/example/Dummy")
+    argsArr := makeObjectRefArray(o)
+
+    out := StringFormatter([]interface{}{fmtObj, argsArr})
+    got := object.GoStringFromStringObject(out.(*object.Object))
+    if !strings.HasPrefix(got, "obj=Dummy@") {
+        t.Fatalf("expected Dummy@..., got %q", got)
+    }
+}
+
+func TestStringFormatter_Numeric_Passthrough(t *testing.T) {
+    fmtObj := object.StringObjectFromGoString("%04x")
+    i := Populator("java/lang/Integer", types.Int, int64(26))
+    argsArr := makeObjectRefArray(i)
+    out := StringFormatter([]interface{}{fmtObj, argsArr})
+    got := object.GoStringFromStringObject(out.(*object.Object))
+    if !(got == "001a" || got == "1a") {
+        t.Fatalf("got %q want one of %q or %q", got, "001a", "1a")
+    }
+}
+
+func TestStringFormatter_FloatZeroPad(t *testing.T) {
+    fmtObj := object.StringObjectFromGoString("%020.12f")
+    d := Populator("java/lang/Double", types.Double, float64(123.4567))
+    argsArr := makeObjectRefArray(d)
+    out := StringFormatter([]interface{}{fmtObj, argsArr})
+    got := object.GoStringFromStringObject(out.(*object.Object))
+    expected := "0000123.456700000000"
+    if got != expected {
+        t.Fatalf("got %q want %q", got, expected)
+    }
+}

--- a/src/gfunction/stringFormatter_test.go
+++ b/src/gfunction/stringFormatter_test.go
@@ -98,3 +98,29 @@ func TestStringFormatter_FloatZeroPad(t *testing.T) {
         t.Fatalf("got %q want %q", got, expected)
     }
 }
+
+
+func TestStringFormatter_HexNegativeInt_ZeroPad(t *testing.T) {
+    fmtObj := object.StringObjectFromGoString("%08x")
+    i := Populator("java/lang/Integer", types.Int, int64(-64))
+    argsArr := makeObjectRefArray(i)
+    out := StringFormatter([]interface{}{fmtObj, argsArr})
+    got := object.GoStringFromStringObject(out.(*object.Object))
+   	expected := "ffffffc0"
+    if got != expected {
+        t.Fatalf("got %q want %q", got, expected)
+    }
+}
+
+
+func TestStringFormatter_HexByte_Negative_TwoDigits(t *testing.T) {
+    fmtObj := object.StringObjectFromGoString("%02x")
+    b := Populator("java/lang/Byte", types.Byte, int64(-1))
+    argsArr := makeObjectRefArray(b)
+    out := StringFormatter([]interface{}{fmtObj, argsArr})
+    got := object.GoStringFromStringObject(out.(*object.Object))
+    expected := "ff"
+    if got != expected {
+        t.Fatalf("got %q want %q", got, expected)
+    }
+}


### PR DESCRIPTION
Hip-hip-hooray! Thanks to Junie, %x formats to hex digits when an integer or byte is negative, just like the OpenJDK JVM. 

- modified:   gfunction/stringFormatter.go
- modified:   gfunction/stringFormatter_test.go

Bonus: JACOBIN-726 (expand unit testing)
- modified:   gfunction/gfunction_test.go (added unit tests)
- new file:   gfunction/javaLangDouble_test.go
- new file:   gfunction/javaLangFloat_test.go
- modified:   gfunction/javaLangInteger_test.go (added unit tests)
- new file:   gfunction/javaLangLong_test.go
- new file:   gfunction/javaLangMath_test.go
- modified:   gfunction/javaLangString_test.go (added unit tests)

