### PR TITLE
JACOBIN-726 more unit tests

### DIFF
--- a/src/gfunction/Traps_test.go
+++ b/src/gfunction/Traps_test.go
@@ -1,0 +1,75 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2025 by the Jacobin Authors.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)  Consult jacobin.org.
+ */
+
+package gfunction
+
+import (
+    "reflect"
+    "strings"
+    "testing"
+
+    "jacobin/excNames"
+)
+
+func TestLoad_Traps_RegistersSomeMethods(t *testing.T) {
+    saved := MethodSignatures
+    defer func() { MethodSignatures = saved }()
+    MethodSignatures = make(map[string]GMeth)
+
+    Load_Traps()
+
+    // Representative subset across class, function, deprecated
+    checks := []struct{
+        key   string
+        slots int
+        fn    func([]interface{}) interface{}
+    }{
+        {"java/io/BufferedOutputStream.<clinit>()V", 0, trapClass},
+        {"java/io/DefaultFileSystem.getFileSystem()Ljava/io/FileSystem;", 0, trapFunction},
+        {"java/io/FilterOutputStream.<init>(Ljava/io/OutputStream;)V", 1, trapFunction},
+        {"java/rmi/RMISecurityManager.<clinit>()V", 0, trapDeprecated},
+        {"java/rmi/RMISecurityManager.<init>()V", 0, trapDeprecated},
+    }
+
+    for _, c := range checks {
+        got, ok := MethodSignatures[c.key]
+        if !ok {
+            t.Fatalf("missing MethodSignatures entry for %s", c.key)
+        }
+        if got.ParamSlots != c.slots {
+            t.Fatalf("%s ParamSlots expected %d, got %d", c.key, c.slots, got.ParamSlots)
+        }
+        if got.GFunction == nil {
+            t.Fatalf("%s GFunction expected non-nil", c.key)
+        }
+        if reflect.ValueOf(got.GFunction).Pointer() != reflect.ValueOf(c.fn).Pointer() {
+            t.Fatalf("%s GFunction mismatch", c.key)
+        }
+    }
+}
+
+func TestTrapFunctions_ReturnUnsupported(t *testing.T) {
+    // trapClass
+    if blk, ok := trapClass(nil).(*GErrBlk); !ok || blk.ExceptionType != excNames.UnsupportedOperationException || !strings.Contains(blk.ErrMsg, "TRAP:") {
+        t.Fatalf("trapClass expected UnsupportedOperationException with TRAP: message, got %+v", blk)
+    }
+    // trapFunction
+    if blk, ok := trapFunction(nil).(*GErrBlk); !ok || blk.ExceptionType != excNames.UnsupportedOperationException || !strings.Contains(blk.ErrMsg, "TRAP:") {
+        t.Fatalf("trapFunction expected UnsupportedOperationException with TRAP: message, got %+v", blk)
+    }
+    // trapDeprecated
+    if blk, ok := trapDeprecated(nil).(*GErrBlk); !ok || blk.ExceptionType != excNames.UnsupportedOperationException || !strings.Contains(blk.ErrMsg, "TRAP:") {
+        t.Fatalf("trapDeprecated expected UnsupportedOperationException with TRAP: message, got %+v", blk)
+    }
+    // trapUndocumented
+    if blk, ok := trapUndocumented(nil).(*GErrBlk); !ok || blk.ExceptionType != excNames.UnsupportedOperationException || !strings.Contains(blk.ErrMsg, "TRAP:") {
+        t.Fatalf("trapUndocumented expected UnsupportedOperationException with TRAP: message, got %+v", blk)
+    }
+    // trapProtected
+    if blk, ok := trapProtected(nil).(*GErrBlk); !ok || blk.ExceptionType != excNames.UnsupportedOperationException || !strings.Contains(blk.ErrMsg, "TRAP:") {
+        t.Fatalf("trapProtected expected UnsupportedOperationException with TRAP: message, got %+v", blk)
+    }
+}

--- a/src/gfunction/gfunctionExec_test.go
+++ b/src/gfunction/gfunctionExec_test.go
@@ -1,0 +1,197 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2025 by the Jacobin Authors.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)  Consult jacobin.org.
+ */
+
+package gfunction
+
+import (
+	"container/list"
+	"errors"
+	"jacobin/classloader"
+	"jacobin/excNames"
+	"jacobin/frames"
+	"jacobin/globals"
+	"jacobin/object"
+	"testing"
+)
+
+// helper to build a minimal frame stack with one frame at the front
+func makeFrameStack() *list.List {
+	fs := frames.CreateFrameStack()
+	f := frames.CreateFrame(0)
+	f.Thread = 1 // main thread for deterministic messages
+	f.ClName = "java/lang/Test"
+	f.MethName = "m"
+	f.MethType = "()V"
+	_ = frames.PushFrame(fs, f)
+	return fs
+}
+
+func TestRunGfunction_ParamOrderAndContext(t *testing.T) {
+	globals.InitGlobals("test")
+
+	fs := makeFrameStack()
+
+	// Capture the received params in the GFunction
+	var received []interface{}
+	gm := GMeth{
+		ParamSlots:   2,
+		NeedsContext: true,
+		GFunction: func(in []interface{}) interface{} {
+			// save a copy of the slice
+			received = append([]interface{}{}, in...)
+			return nil
+		},
+	}
+	mt := classloader.MTentry{Meth: gm, MType: 'G'}
+
+	// params in forward order as they would be pushed by bytecode: last arg at top
+	p := []interface{}{int64(1), int64(2)}
+	objRef := false
+
+	_ = RunGfunction(mt, fs, "pkg/Clazz", "method", "(II)V", &p, objRef, false)
+
+	if len(received) != 3 { // two args + context
+		t.Fatalf("expected 3 params passed to GFunction (2 args + context), got %d", len(received))
+	}
+
+	// Because NeedsContext=true, fs is appended then the slice is reversed, so fs should be first
+	if received[0] != fs {
+		t.Fatalf("expected context frame stack as first param after reversal; got %T", received[0])
+	}
+	// The remaining args should be reversed order of original
+	if v, ok := received[1].(int64); !ok || v != int64(2) {
+		t.Fatalf("expected second param to be 2, got %v (%T)", received[1], received[1])
+	}
+	if v, ok := received[2].(int64); !ok || v != int64(1) {
+		t.Fatalf("expected third param to be 1, got %v (%T)", received[2], received[2])
+	}
+}
+
+func TestRunGfunction_ReturnsValue_NonThreadSafe(t *testing.T) {
+	globals.InitGlobals("test")
+
+	fs := makeFrameStack()
+
+	gm := GMeth{
+		ParamSlots: 1,
+		GFunction: func(in []interface{}) interface{} {
+			if len(in) != 1 || in[0] != "x" {
+				t.Fatalf("unexpected params to GFunction: %#v", in)
+			}
+			return int64(42)
+		},
+	}
+	mt := classloader.MTentry{Meth: gm, MType: 'G'}
+
+	p := []interface{}{"x"}
+	ret := RunGfunction(mt, fs, "A/B", "c", "(Ljava/lang/String;)I", &p, false, false)
+
+	if v, ok := ret.(int64); !ok || v != 42 {
+		t.Fatalf("expected int64(42) return, got %v (%T)", ret, ret)
+	}
+}
+
+func TestRunGfunction_ReturnsError_PassesThrough(t *testing.T) {
+	globals.InitGlobals("test")
+
+	fs := makeFrameStack()
+
+	gm := GMeth{GFunction: func([]interface{}) interface{} {
+		return errors.New("native boom")
+	}}
+	mt := classloader.MTentry{Meth: gm, MType: 'G'}
+
+	var nilParams []interface{}
+	ret := RunGfunction(mt, fs, "P/Q", "r", "()V", &nilParams, false, false)
+
+	if err, ok := ret.(error); !ok {
+		t.Fatalf("expected error return, got %T: %v", ret, ret)
+	} else if err.Error() != "native boom" {
+		t.Fatalf("unexpected error message: %q", err.Error())
+	}
+}
+
+func TestRunGfunction_GErrBlk_ReturnsErrorInTestMode(t *testing.T) {
+	globals.InitGlobals("test")
+
+	fs := makeFrameStack()
+
+	gm := GMeth{GFunction: func([]interface{}) interface{} {
+		return &GErrBlk{ExceptionType: excNames.ArrayIndexOutOfBoundsException, ErrMsg: "array oob"}
+	}}
+	mt := classloader.MTentry{Meth: gm, MType: 'G'}
+
+	params := []interface{}{}
+	ret := RunGfunction(mt, fs, "X/Y", "z", "()V", &params, false, false)
+
+	if err, ok := ret.(error); !ok {
+		t.Fatalf("expected error return for GErrBlk in test mode, got %T: %v", ret, ret)
+	} else {
+		// The error message should contain our method FQN and original message
+		if !contains(err.Error(), "array oob") || !contains(err.Error(), "X/Y.z()V") {
+			t.Fatalf("error message missing expected content: %q", err.Error())
+		}
+	}
+}
+
+func TestRunGfunction_ThreadSafe_WithObjRef(t *testing.T) {
+	globals.InitGlobals("test")
+
+	fs := makeFrameStack()
+
+	// The thread-safe function will simply return a constant
+	gm := GMeth{
+		ThreadSafe: true,
+		GFunction: func(in []interface{}) interface{} {
+			// First param must be the object reference
+			if len(in) == 0 {
+				t.Fatalf("expected at least one param for thread-safe call")
+			}
+			if _, ok := in[0].(*object.Object); !ok {
+				t.Fatalf("first parameter to thread-safe GFunction not an *object.Object: %T", in[0])
+			}
+			return "ok"
+		},
+	}
+	mt := classloader.MTentry{Meth: gm, MType: 'G'}
+
+	obj := object.MakeEmptyObject()
+	params := []interface{}{obj}
+
+	ret := RunGfunction(mt, fs, "TS/C", "m", "()V", &params, true, false)
+
+	if s, ok := ret.(string); !ok || s != "ok" {
+		t.Fatalf("expected \"ok\" return from thread-safe GFunction, got %v (%T)", ret, ret)
+	}
+}
+
+// contains is a tiny helper to avoid importing strings just for Contains
+func contains(haystack, needle string) bool {
+	return len(needle) == 0 || (len(haystack) >= len(needle) && indexOf(haystack, needle) >= 0)
+}
+
+// indexOf naive substring search
+func indexOf(s, sub string) int {
+	// very small helper; ok for tests
+	outer := []rune(s)
+	inner := []rune(sub)
+	if len(inner) == 0 {
+		return 0
+	}
+	for i := 0; i+len(inner) <= len(outer); i++ {
+		match := true
+		for j := 0; j < len(inner); j++ {
+			if outer[i+j] != inner[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
+}

--- a/src/gfunction/javaAwtGraphicsEnvironment_test.go
+++ b/src/gfunction/javaAwtGraphicsEnvironment_test.go
@@ -1,0 +1,79 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2025 by the Jacobin Authors.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)  Consult jacobin.org.
+ */
+
+package gfunction
+
+import (
+    "jacobin/globals"
+    "testing"
+)
+
+func TestLoad_Awt_Graphics_Environment_RegistersMethods(t *testing.T) {
+    // Save and restore the global MethodSignatures map to avoid test pollution
+    saved := MethodSignatures
+    defer func() { MethodSignatures = saved }()
+
+    MethodSignatures = make(map[string]GMeth)
+
+    Load_Awt_Graphics_Environment()
+
+    // Expected keys
+    kClinit := "java/awt/GraphicsEnvironment.<clinit>()V"
+    kIsHeadless := "java/awt/GraphicsEnvironment.isHeadless()Z"
+    kIsHeadlessInstance := "java/awt/GraphicsEnvironment.isHeadlessInstance()Z"
+
+    // Check presence
+    if _, ok := MethodSignatures[kClinit]; !ok {
+        t.Fatalf("missing MethodSignatures entry for %s", kClinit)
+    }
+    if _, ok := MethodSignatures[kIsHeadless]; !ok {
+        t.Fatalf("missing MethodSignatures entry for %s", kIsHeadless)
+    }
+    if _, ok := MethodSignatures[kIsHeadlessInstance]; !ok {
+        t.Fatalf("missing MethodSignatures entry for %s", kIsHeadlessInstance)
+    }
+
+    // Validate clinit has nil function and zero params
+    if m := MethodSignatures[kClinit]; m.ParamSlots != 0 {
+        t.Fatalf("<clinit> ParamSlots expected 0, got %d", m.ParamSlots)
+    } else if m.GFunction != nil {
+        t.Fatalf("<clinit> GFunction expected nil, got non-nil")
+    }
+
+    // Validate isHeadless entries have zero params and non-nil functions
+    if m := MethodSignatures[kIsHeadless]; m.ParamSlots != 0 {
+        t.Fatalf("isHeadless ParamSlots expected 0, got %d", m.ParamSlots)
+    } else if m.GFunction == nil {
+        t.Fatalf("isHeadless GFunction expected non-nil")
+    }
+
+    if m := MethodSignatures[kIsHeadlessInstance]; m.ParamSlots != 0 {
+        t.Fatalf("isHeadlessInstance ParamSlots expected 0, got %d", m.ParamSlots)
+    } else if m.GFunction == nil {
+        t.Fatalf("isHeadlessInstance GFunction expected non-nil")
+    }
+}
+
+func TestAwtgeIsHeadless_ReflectsGlobals(t *testing.T) {
+    globals.InitGlobals("test")
+    glob := globals.GetGlobalRef()
+
+    // true case
+    glob.Headless = true
+    if v, ok := awtgeIsHeadless(nil).(bool); !ok {
+        t.Fatalf("awtgeIsHeadless did not return bool when Headless=true, got %T", awtgeIsHeadless(nil))
+    } else if !v {
+        t.Fatalf("awtgeIsHeadless expected true when globals.Headless=true")
+    }
+
+    // false case
+    glob.Headless = false
+    if v, ok := awtgeIsHeadless(nil).(bool); !ok {
+        t.Fatalf("awtgeIsHeadless did not return bool when Headless=false, got %T", awtgeIsHeadless(nil))
+    } else if v {
+        t.Fatalf("awtgeIsHeadless expected false when globals.Headless=false")
+    }
+}

--- a/src/gfunction/javaIoConsole.go
+++ b/src/gfunction/javaIoConsole.go
@@ -8,7 +8,6 @@ package gfunction
 
 import (
 	"fmt"
-	"golang.org/x/term"
 	"jacobin/classloader"
 	"jacobin/excNames"
 	"jacobin/object"
@@ -16,6 +15,8 @@ import (
 	"jacobin/types"
 	"os"
 	"syscall"
+
+	"golang.org/x/term"
 )
 
 // Implementation of some of the functions in Java/lang/Class.
@@ -104,7 +105,7 @@ func Load_Io_Console() {
 // "java/io/Console.<clinit>()V" - Initialise class Console.
 func consoleClinit([]interface{}) interface{} {
 	klass := classloader.MethAreaFetch("java/io/Console")
-	if klass == nil {
+	if klass == nil || klass.Data == nil {
 		errMsg := "consoleClinit: Could not find java/io/Console in the MethodArea"
 		return getGErrBlk(excNames.ClassNotLoadedException, errMsg)
 	}

--- a/src/gfunction/javaIoConsole_test.go
+++ b/src/gfunction/javaIoConsole_test.go
@@ -1,0 +1,207 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2025 by the Jacobin Authors.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)  Consult jacobin.org.
+ */
+
+package gfunction
+
+import (
+	"io"
+	"jacobin/classloader"
+	"os"
+	"reflect"
+	"testing"
+
+	"jacobin/excNames"
+	"jacobin/globals"
+	"jacobin/object"
+	"jacobin/statics"
+)
+
+func TestLoad_Io_Console_RegistersMethods(t *testing.T) {
+	// Save and restore the global MethodSignatures map to avoid test pollution
+	saved := MethodSignatures
+	defer func() { MethodSignatures = saved }()
+
+	MethodSignatures = make(map[string]GMeth)
+
+	Load_Io_Console()
+
+	// Expected keys and their characteristics
+	checks := []struct {
+		key   string
+		slots int
+		fn    func([]interface{}) interface{}
+	}{
+		{"java/io/Console.<clinit>()V", 0, consoleClinit},
+		{"java/io/Console.charset()Ljava/nio/charset/Charset;", 0, trapFunction},
+		{"java/io/Console.flush()V", 0, consoleFlush},
+		{"java/io/Console.format(Ljava/lang/String;[Ljava/lang/Object;)Ljava/io/Console;", 2, consolePrintf},
+		{"java/io/Console.printf(Ljava/lang/String;[Ljava/lang/Object;)Ljava/io/Console;", 2, consolePrintf},
+		{"java/io/Console.reader()Ljava/io/Reader;", 0, trapFunction},
+		{"java/io/Console.readLine()Ljava/lang/String;", 0, consoleReadLine},
+		{"java/io/Console.readLine(Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;", 2, consolePrintfReadLine},
+		{"java/io/Console.readPassword()[C", 0, consoleReadPassword},
+		{"java/io/Console.readPassword(Ljava/lang/String;[Ljava/lang/Object;)[C", 2, consolePrintfReadPassword},
+		{"java/io/Console.writer()Ljava/io/PrintWriter;", 0, trapFunction},
+	}
+
+	for _, c := range checks {
+		got, ok := MethodSignatures[c.key]
+		if !ok {
+			t.Fatalf("missing MethodSignatures entry for %s", c.key)
+		}
+		if got.ParamSlots != c.slots {
+			t.Fatalf("%s ParamSlots expected %d, got %d", c.key, c.slots, got.ParamSlots)
+		}
+		if got.GFunction == nil {
+			t.Fatalf("%s GFunction expected non-nil", c.key)
+		}
+		// function identity check via function pointer
+		if reflect.ValueOf(got.GFunction).Pointer() != reflect.ValueOf(c.fn).Pointer() {
+			t.Fatalf("%s GFunction mismatch", c.key)
+		}
+	}
+}
+
+func TestConsoleClinit_NoClass_ReturnsErrBlk(t *testing.T) {
+	globals.InitGlobals("test")
+	_ = classloader.Init()
+	classloader.LoadBaseClasses()
+
+	ret := consoleClinit(nil)
+	blk, ok := ret.(*GErrBlk)
+	if !ok {
+		t.Fatalf("expected *GErrBlk, got %T", ret)
+	}
+	if blk.ExceptionType != excNames.ClassNotLoadedException {
+		t.Fatalf("unexpected exception type: %d", blk.ExceptionType)
+	}
+}
+
+func TestConsolePrintf_WritesToSystemOut(t *testing.T) {
+	globals.InitGlobals("test")
+
+	// Pipe to capture writes to System.out
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	// Save and restore System.out static
+	// We will restore to os.Stdout to keep environment sane for other tests.
+	defer func() {
+		_ = statics.AddStatic("java/lang/System.out", statics.Static{Type: "GS", Value: os.Stdout})
+	}()
+	_ = statics.AddStatic("java/lang/System.out", statics.Static{Type: "GS", Value: w})
+
+	// Build params: [this, fmtString, argsArray]
+	fmtObj := object.StringObjectFromGoString("Hello %s!")
+	arg := object.StringObjectFromGoString("World")
+	argsArr := makeObjectRefArray(arg)
+
+	params := []interface{}{object.MakeEmptyObject(), fmtObj, argsArr}
+
+	ret := consolePrintf(params)
+	// Return is *os.File (stdout), but we care about content
+	if _, ok := ret.(*os.File); !ok {
+		t.Fatalf("consolePrintf expected to return *os.File, got %T", ret)
+	}
+
+	// Read what was written
+	_ = w.Sync()
+	_ = w.Close()
+	buf, _ := io.ReadAll(r)
+	if string(buf) != "Hello World!" {
+		t.Fatalf("unexpected output: %q", string(buf))
+	}
+}
+
+func TestConsoleReadLine_ReadsUntilNewline(t *testing.T) {
+	globals.InitGlobals("test")
+
+	// Pipe to feed input to System.in
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	defer func() {
+		_ = statics.AddStatic("java/lang/System.in", statics.Static{Type: "GS", Value: os.Stdin})
+	}()
+	_ = statics.AddStatic("java/lang/System.in", statics.Static{Type: "GS", Value: r})
+
+	// Write a line and close writer to simulate EOF after newline
+	if _, err := w.Write([]byte("abc\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_ = w.Close()
+
+	ret := consoleReadLine(nil)
+	sObj, ok := ret.(*object.Object)
+	if !ok {
+		t.Fatalf("expected *object.Object, got %T", ret)
+	}
+	got := object.GoStringFromStringObject(sObj)
+	if got != "abc" {
+		t.Fatalf("unexpected readLine content %q", got)
+	}
+}
+
+func TestConsolePrintfReadLine_PromptAndRead(t *testing.T) {
+	globals.InitGlobals("test")
+
+	// Setup System.out
+	rout, wout, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe out: %v", err)
+	}
+	defer rout.Close()
+	defer wout.Close()
+	defer func() {
+		_ = statics.AddStatic("java/lang/System.out", statics.Static{Type: "GS", Value: os.Stdout})
+	}()
+	_ = statics.AddStatic("java/lang/System.out", statics.Static{Type: "GS", Value: wout})
+
+	// Setup System.in
+	rin, win, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe in: %v", err)
+	}
+	defer rin.Close()
+	defer win.Close()
+	defer func() {
+		_ = statics.AddStatic("java/lang/System.in", statics.Static{Type: "GS", Value: os.Stdin})
+	}()
+	_ = statics.AddStatic("java/lang/System.in", statics.Static{Type: "GS", Value: rin})
+
+	// Prepare params: [this, fmtString, argsArray(empty)]
+	fmtObj := object.StringObjectFromGoString("Enter: ")
+	emptyArgs := makeObjectRefArray() // zero-length array
+	params := []interface{}{object.MakeEmptyObject(), fmtObj, emptyArgs}
+
+	// Provide input line
+	if _, err := win.Write([]byte("xyz\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_ = win.Close()
+
+	ret := consolePrintfReadLine(params)
+	sObj := ret.(*object.Object)
+	got := object.GoStringFromStringObject(sObj)
+	if got != "xyz" {
+		t.Fatalf("unexpected consolePrintfReadLine string: %q", got)
+	}
+
+	// Validate prompt was written
+	_ = wout.Close()
+	outBytes, _ := io.ReadAll(rout)
+	if string(outBytes) != "Enter: " {
+		t.Fatalf("unexpected prompt output: %q", string(outBytes))
+	}
+}

--- a/src/gfunction/javaIoConsole_test.go
+++ b/src/gfunction/javaIoConsole_test.go
@@ -111,13 +111,12 @@ func TestConsolePrintf_WritesToSystemOut(t *testing.T) {
 		t.Fatalf("consolePrintf expected to return *os.File, got %T", ret)
 	}
 
-	// Read what was written
-	_ = w.Sync()
-	_ = w.Close()
-	buf, _ := io.ReadAll(r)
-	if string(buf) != "Hello World!" {
-		t.Fatalf("unexpected output: %q", string(buf))
-	}
+ // Read what was written (Close signals EOF for the reader; Sync on pipes is not portable)
+ _ = w.Close()
+ buf, _ := io.ReadAll(r)
+ if string(buf) != "Hello World!" {
+     t.Fatalf("unexpected output: %q", string(buf))
+ }
 }
 
 func TestConsoleReadLine_ReadsUntilNewline(t *testing.T) {

--- a/src/gfunction/javaLangBoolean_test.go
+++ b/src/gfunction/javaLangBoolean_test.go
@@ -1,0 +1,165 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2025 by the Jacobin Authors.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)  Consult jacobin.org.
+ */
+
+package gfunction
+
+import (
+    "reflect"
+    "testing"
+
+    "jacobin/excNames"
+    "jacobin/globals"
+    "jacobin/object"
+    "jacobin/types"
+)
+
+func TestLoad_Lang_Boolean_RegistersMethods(t *testing.T) {
+    saved := MethodSignatures
+    defer func() { MethodSignatures = saved }()
+    MethodSignatures = make(map[string]GMeth)
+
+    Load_Lang_Boolean()
+
+    checks := []struct{
+        key   string
+        slots int
+        fn    func([]interface{}) interface{}
+    }{
+        {"java/lang/Boolean.<clinit>()V", 0, clinitGeneric},
+        {"java/lang/Boolean.<init>(Z)V", 1, trapDeprecated},
+        {"java/lang/Boolean.<init>(Ljava/lang/String;)V", 1, trapDeprecated},
+        {"java/lang/Boolean.booleanValue()Z", 0, booleanBooleanValue},
+        {"java/lang/Boolean.describeConstable()Ljava.util.Optional;", 0, trapFunction},
+        {"java/lang/Boolean.getBoolean(Ljava/lang/String;)Z", 1, booleanGetBoolean},
+        {"java/lang/Boolean.hashCode()I", 0, booleanHashCode},
+        {"java/lang/Boolean.hashCode(Z)I", 1, booleanHashCode},
+        {"java/lang/Boolean.parseBoolean(Ljava/lang/String;)Z", 1, booleanParseBoolean},
+        {"java/lang/Boolean.valueOf(Z)Ljava/lang/Boolean;", 1, booleanValueOf},
+        {"java/lang/Boolean.valueOf(Ljava/lang/String;)Ljava/lang/Boolean;", 1, booleanValueOf},
+    }
+
+    for _, c := range checks {
+        got, ok := MethodSignatures[c.key]
+        if !ok {
+            t.Fatalf("missing MethodSignatures entry for %s", c.key)
+        }
+        if got.ParamSlots != c.slots {
+            t.Fatalf("%s ParamSlots expected %d, got %d", c.key, c.slots, got.ParamSlots)
+        }
+        if got.GFunction == nil {
+            t.Fatalf("%s GFunction expected non-nil", c.key)
+        }
+        if reflect.ValueOf(got.GFunction).Pointer() != reflect.ValueOf(c.fn).Pointer() {
+            t.Fatalf("%s GFunction mismatch", c.key)
+        }
+    }
+}
+
+func TestBooleanBooleanValue_ValidAndInvalid(t *testing.T) {
+    globals.InitGlobals("test")
+
+    btrue := Populator("java/lang/Boolean", types.Bool, types.JavaBoolTrue)
+    ret := booleanBooleanValue([]interface{}{btrue})
+    if v, ok := ret.(int64); !ok || v != types.JavaBoolTrue {
+        t.Fatalf("booleanBooleanValue(true) got %v (%T)", ret, ret)
+    }
+
+    // Wrong field type -> error
+    bad := object.MakeEmptyObject()
+    bad.FieldTable["value"] = object.Field{Ftype: types.Int, Fvalue: float64(1)}
+    er := booleanBooleanValue([]interface{}{bad})
+    if _, ok := er.(*GErrBlk); !ok {
+        t.Fatalf("expected *GErrBlk for wrong field type, got %T", er)
+    }
+}
+
+func TestBooleanValueOf_FromBooleanAndString(t *testing.T) {
+    globals.InitGlobals("test")
+
+    // From boolean primitive
+    ret := booleanValueOf([]interface{}{types.JavaBoolFalse})
+    obj := ret.(*object.Object)
+    if obj.FieldTable["value"].Fvalue.(int64) != types.JavaBoolFalse {
+        t.Fatalf("valueOf(false) wrong value: %v", obj.FieldTable["value"].Fvalue)
+    }
+
+    // From string "true"
+    sTrue := object.StringObjectFromGoString("true")
+    ret = booleanValueOf([]interface{}{sTrue})
+    obj = ret.(*object.Object)
+    if obj.FieldTable["value"].Fvalue.(int64) != types.JavaBoolTrue {
+        t.Fatalf("valueOf(\"true\") wrong value")
+    }
+
+    // From string "false"
+    sFalse := object.StringObjectFromGoString("false")
+    ret = booleanValueOf([]interface{}{sFalse})
+    obj = ret.(*object.Object)
+    if obj.FieldTable["value"].Fvalue.(int64) != types.JavaBoolFalse {
+        t.Fatalf("valueOf(\"false\") wrong value")
+    }
+
+    // From invalid string -> error block
+    sinv := object.StringObjectFromGoString("maybe")
+    er := booleanValueOf([]interface{}{sinv})
+    if _, ok := er.(*GErrBlk); !ok {
+        t.Fatalf("expected *GErrBlk for invalid string valueOf, got %T", er)
+    }
+}
+
+func TestBooleanParseBoolean(t *testing.T) {
+    globals.InitGlobals("test")
+
+    sTrue := object.StringObjectFromGoString("true")
+    if v := booleanParseBoolean([]interface{}{sTrue}); v.(int64) != types.JavaBoolTrue {
+        t.Fatalf("parseBoolean(true) wrong")
+    }
+    sFalse := object.StringObjectFromGoString("false")
+    if v := booleanParseBoolean([]interface{}{sFalse}); v.(int64) != types.JavaBoolFalse {
+        t.Fatalf("parseBoolean(false) wrong")
+    }
+    sinv := object.StringObjectFromGoString("nope")
+    if blk, ok := booleanParseBoolean([]interface{}{sinv}).(*GErrBlk); !ok || blk.ExceptionType != excNames.IllegalArgumentException {
+        t.Fatalf("parseBoolean(invalid) expected IAE, got %T", blk)
+    }
+}
+
+func TestBooleanGetBoolean_UsesSystemProperties(t *testing.T) {
+    globals.InitGlobals("test")
+    globals.SetSystemProperty("my.flag", "true")
+    globals.SetSystemProperty("another.flag", "false")
+    globals.SetSystemProperty("bad.flag", "yes")
+
+    s := object.StringObjectFromGoString("my.flag")
+    if v := booleanGetBoolean([]interface{}{s}); v.(int64) != types.JavaBoolTrue {
+        t.Fatalf("getBoolean(true) wrong")
+    }
+
+    s = object.StringObjectFromGoString("another.flag")
+    if v := booleanGetBoolean([]interface{}{s}); v.(int64) != types.JavaBoolFalse {
+        t.Fatalf("getBoolean(false) wrong")
+    }
+
+    s = object.StringObjectFromGoString("bad.flag")
+    if blk, ok := booleanGetBoolean([]interface{}{s}).(*GErrBlk); !ok || blk.ExceptionType != excNames.IllegalArgumentException {
+        t.Fatalf("getBoolean(bad) expected IAE, got %T", blk)
+    }
+}
+
+func TestBooleanHashCode_FromPrimitiveInput(t *testing.T) {
+    globals.InitGlobals("test")
+    // booleanHashCode expects params[1] for the boolean case; pass a dummy first arg.
+    if v := booleanHashCode([]interface{}{nil, types.JavaBoolTrue}); v.(int64) != 1231 {
+        t.Fatalf("hashCode(true) expected 1231, got %v", v)
+    }
+    if v := booleanHashCode([]interface{}{nil, types.JavaBoolFalse}); v.(int64) != 1237 {
+        t.Fatalf("hashCode(false) expected 1237, got %v", v)
+    }
+    // invalid value -> error
+    if blk, ok := booleanHashCode([]interface{}{nil, int64(2)}).(*GErrBlk); !ok || blk.ExceptionType != excNames.IllegalArgumentException {
+        t.Fatalf("hashCode(invalid) expected IAE, got %T", blk)
+    }
+}

--- a/src/gfunction/javaLangByte_test.go
+++ b/src/gfunction/javaLangByte_test.go
@@ -1,0 +1,108 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2025 by the Jacobin Authors.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)  Consult jacobin.org.
+ */
+
+package gfunction
+
+import (
+    "reflect"
+    "testing"
+
+    "jacobin/excNames"
+    "jacobin/globals"
+    "jacobin/object"
+    "jacobin/types"
+)
+
+func TestLoad_Lang_Byte_RegistersMethods(t *testing.T) {
+    saved := MethodSignatures
+    defer func() { MethodSignatures = saved }()
+    MethodSignatures = make(map[string]GMeth)
+
+    Load_Lang_Byte()
+
+    checks := []struct{
+        key   string
+        slots int
+        fn    func([]interface{}) interface{}
+    }{
+        {"java/lang/Byte.<clinit>()V", 0, clinitGeneric},
+        {"java/lang/Byte.decode(Ljava/lang/String;)Ljava/lang/Byte;", 1, byteDecode},
+        {"java/lang/Byte.doubleValue()D", 0, byteDoubleValue},
+        {"java/lang/Byte.toString()Ljava/lang/String;", 0, byteToString},
+        {"java/lang/Byte.valueOf(B)Ljava/lang/Byte;", 1, byteValueOf},
+    }
+
+    for _, c := range checks {
+        got, ok := MethodSignatures[c.key]
+        if !ok {
+            t.Fatalf("missing MethodSignatures entry for %s", c.key)
+        }
+        if got.ParamSlots != c.slots {
+            t.Fatalf("%s ParamSlots expected %d, got %d", c.key, c.slots, got.ParamSlots)
+        }
+        if got.GFunction == nil {
+            t.Fatalf("%s GFunction expected non-nil", c.key)
+        }
+        if reflect.ValueOf(got.GFunction).Pointer() != reflect.ValueOf(c.fn).Pointer() {
+            t.Fatalf("%s GFunction mismatch", c.key)
+        }
+    }
+}
+
+func TestByteDecode_Various(t *testing.T) {
+    globals.InitGlobals("test")
+
+    // valid with leading #
+    s := object.StringObjectFromGoString("#0a")
+    ret := byteDecode([]interface{}{s})
+    obj := ret.(*object.Object)
+    if obj.FieldTable["value"].Fvalue.(int64) != 10 {
+        t.Fatalf("decode #0a expected 10, got %v", obj.FieldTable["value"].Fvalue)
+    }
+
+    // valid with 0x
+    s = object.StringObjectFromGoString("0x2f")
+    ret = byteDecode([]interface{}{s})
+    obj = ret.(*object.Object)
+    if obj.FieldTable["value"].Fvalue.(int64) != 47 {
+        t.Fatalf("decode 0x2f expected 47, got %v", obj.FieldTable["value"].Fvalue)
+    }
+
+    // too large
+    s = object.StringObjectFromGoString("1ff") // 511
+    if blk, ok := byteDecode([]interface{}{s}).(*GErrBlk); !ok || blk.ExceptionType != excNames.NumberFormatException {
+        t.Fatalf("decode too-large expected NFE, got %T", blk)
+    }
+
+    // invalid hex
+    s = object.StringObjectFromGoString("zz")
+    if blk, ok := byteDecode([]interface{}{s}).(*GErrBlk); !ok || blk.ExceptionType != excNames.NumberFormatException {
+        t.Fatalf("decode invalid hex expected NFE, got %T", blk)
+    }
+}
+
+func TestByteDoubleValue_ToString_ValueOf(t *testing.T) {
+    globals.InitGlobals("test")
+
+    b := Populator("java/lang/Byte", types.Byte, int64(127))
+
+    // doubleValue
+    if v := byteDoubleValue([]interface{}{b}); v.(float64) != float64(127) {
+        t.Fatalf("doubleValue wrong")
+    }
+
+    // toString
+    s := byteToString([]interface{}{b}).(*object.Object)
+    if str := object.GoStringFromStringObject(s); str != "127" {
+        t.Fatalf("toString wrong: %q", str)
+    }
+
+    // valueOf
+    vobj := byteValueOf([]interface{}{int64(5)}).(*object.Object)
+    if v := vobj.FieldTable["value"].Fvalue.(int64); v != 5 {
+        t.Fatalf("valueOf 5 wrong: %v", v)
+    }
+}

--- a/src/gfunction/javaLangCharacter_test.go
+++ b/src/gfunction/javaLangCharacter_test.go
@@ -1,0 +1,92 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2025 by the Jacobin Authors.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)  Consult jacobin.org.
+ */
+
+package gfunction
+
+import (
+    "reflect"
+    "testing"
+
+    "jacobin/globals"
+    "jacobin/object"
+    "jacobin/types"
+)
+
+func TestLoad_Lang_Character_RegistersMethods(t *testing.T) {
+    saved := MethodSignatures
+    defer func() { MethodSignatures = saved }()
+    MethodSignatures = make(map[string]GMeth)
+
+    Load_Lang_Character()
+
+    checks := []struct{
+        key   string
+        slots int
+        fn    func([]interface{}) interface{}
+    }{
+        {"java/lang/Character.<clinit>()V", 0, clinitGeneric},
+        {"java/lang/Character.isDigit(C)Z", 1, charIsDigit},
+        {"java/lang/Character.isLetter(C)Z", 1, charIsLetter},
+        {"java/lang/Character.charValue()C", 0, charValue},
+        {"java/lang/Character.toLowerCase(C)C", 1, charToLowerCase},
+        {"java/lang/Character.toUpperCase(C)C", 1, charToUpperCase},
+        {"java/lang/Character.valueOf(C)Ljava/lang/Character;", 1, characterValueOf},
+    }
+
+    for _, c := range checks {
+        got, ok := MethodSignatures[c.key]
+        if !ok {
+            t.Fatalf("missing MethodSignatures entry for %s", c.key)
+        }
+        if got.ParamSlots != c.slots {
+            t.Fatalf("%s ParamSlots expected %d, got %d", c.key, c.slots, got.ParamSlots)
+        }
+        if got.GFunction == nil {
+            t.Fatalf("%s GFunction expected non-nil", c.key)
+        }
+        if reflect.ValueOf(got.GFunction).Pointer() != reflect.ValueOf(c.fn).Pointer() {
+            t.Fatalf("%s GFunction mismatch", c.key)
+        }
+    }
+}
+
+func TestCharacter_IsDigit_IsLetter(t *testing.T) {
+    globals.InitGlobals("test")
+
+    if v := charIsDigit([]interface{}{int64('0')}).(int64); v != types.JavaBoolTrue {
+        t.Fatalf("isDigit('0') expected true")
+    }
+    if v := charIsDigit([]interface{}{int64('A')}).(int64); v != types.JavaBoolFalse {
+        t.Fatalf("isDigit('A') expected false")
+    }
+
+    if v := charIsLetter([]interface{}{int64('A')}).(int64); v != types.JavaBoolTrue {
+        t.Fatalf("isLetter('A') expected true")
+    }
+    if v := charIsLetter([]interface{}{int64('1')}).(int64); v != types.JavaBoolFalse {
+        t.Fatalf("isLetter('1') expected false")
+    }
+}
+
+func TestCharacter_ToLower_ToUpper_ValueOf_CharValue(t *testing.T) {
+    globals.InitGlobals("test")
+
+    if v := charToLowerCase([]interface{}{int64('Z')}).(int64); v != int64('z') {
+        t.Fatalf("toLowerCase('Z') expected 'z'")
+    }
+    if v := charToUpperCase([]interface{}{int64('a')}).(int64); v != int64('A') {
+        t.Fatalf("toUpperCase('a') expected 'A'")
+    }
+
+    obj := characterValueOf([]interface{}{int64('Q')}).(*object.Object)
+    if vv := obj.FieldTable["value"].Fvalue.(int64); vv != int64('Q') {
+        t.Fatalf("valueOf('Q') wrong: %v", vv)
+    }
+
+    if cv := charValue([]interface{}{obj}).(int64); cv != int64('Q') {
+        t.Fatalf("charValue expected 'Q', got %v", cv)
+    }
+}

--- a/src/gfunction/javaLangReflectField_test.go
+++ b/src/gfunction/javaLangReflectField_test.go
@@ -1,0 +1,115 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2025 by the Jacobin Authors.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)  Consult jacobin.org.
+ */
+
+package gfunction
+
+import (
+    "jacobin/globals"
+    "jacobin/object"
+    "jacobin/util"
+    "testing"
+)
+
+func TestNewField_Basics_Getters(t *testing.T) {
+    globals.InitGlobals("test")
+
+    cls := object.MakeEmptyObject()
+    f := NewField(cls, "count")
+
+    if f == nil {
+        t.Fatalf("NewField returned nil")
+    }
+    if f.Class != cls {
+        t.Fatalf("NewField Class mismatch")
+    }
+    if f.Name != "count" {
+        t.Fatalf("NewField Name mismatch: %q", f.Name)
+    }
+
+    // default zero values
+    if f.Modifiers != 0 {
+        t.Fatalf("expected default Modifiers=0, got %d", f.Modifiers)
+    }
+    if f.Type != nil {
+        t.Fatalf("expected default Type=nil")
+    }
+
+    // Set Modifiers and Type and validate getters
+    f.Modifiers = 0x0010 // arbitrary example (final) value constant-like
+    typ := object.MakeEmptyObject()
+    f.Type = typ
+
+    if got := f.GetDeclaringClass(); got != cls {
+        t.Fatalf("GetDeclaringClass mismatch")
+    }
+    if got := f.GetName(); got != "count" {
+        t.Fatalf("GetName mismatch: %q", got)
+    }
+    if got := f.GetModifiers(); got != 0x0010 {
+        t.Fatalf("GetModifiers mismatch: %d", got)
+    }
+    if got := f.GetType(); got != typ {
+        t.Fatalf("GetType mismatch")
+    }
+}
+
+func TestField_Equals(t *testing.T) {
+    globals.InitGlobals("test")
+
+    cls := object.MakeEmptyObject()
+    typ := object.MakeEmptyObject()
+
+    f1 := NewField(cls, "name")
+    f1.Type = typ
+
+    // Same underlying references
+    f2 := NewField(cls, "name")
+    f2.Type = typ
+
+    if !f1.Equals(f2) {
+        t.Fatalf("Fields with same Class/Name/Type should be equal")
+    }
+
+    // Different name
+    f3 := NewField(cls, "other")
+    f3.Type = typ
+    if f1.Equals(f3) {
+        t.Fatalf("Fields with different Name should not be equal")
+    }
+
+    // Different class
+    cls2 := object.MakeEmptyObject()
+    f4 := NewField(cls2, "name")
+    f4.Type = typ
+    if f1.Equals(f4) {
+        t.Fatalf("Fields with different Class should not be equal")
+    }
+
+    // Different type
+    typ2 := object.MakeEmptyObject()
+    f5 := NewField(cls, "name")
+    f5.Type = typ2
+    if f1.Equals(f5) {
+        t.Fatalf("Fields with different Type should not be equal")
+    }
+}
+
+func TestField_HashCode_DelegatesToClassHash(t *testing.T) {
+    globals.InitGlobals("test")
+
+    cls := object.MakeEmptyObject()
+    f := NewField(cls, "value")
+
+    want, _ := util.HashAnything(cls)
+    if got := f.HashCode(); got != want {
+        t.Fatalf("HashCode mismatch: got %d, want %d", got, want)
+    }
+
+    // stability across calls
+    if got2 := f.HashCode(); got2 != want {
+        t.Fatalf("HashCode not stable across calls: got %d, want %d", got2, want)
+    }
+}

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -779,7 +779,7 @@ func Load_Lang_String() {
 // "java/lang/String.<clinit>()V" -- String class initialisation
 func stringClinit([]interface{}) interface{} {
 	klass := classloader.MethAreaFetch(types.StringClassName)
-	if klass == nil {
+	if klass == nil || klass.Data == nil {
 		errMsg := fmt.Sprintf("stringClinit: Could not find class %s in the MethodArea", types.StringClassName)
 		return getGErrBlk(excNames.ClassNotLoadedException, errMsg)
 	}

--- a/src/gfunction/javaLangSystem.go
+++ b/src/gfunction/javaLangSystem.go
@@ -231,7 +231,7 @@ func Load_Lang_System() {
 
 func systemClinit([]interface{}) interface{} {
 	klass := classloader.MethAreaFetch("java/lang/System")
-	if klass == nil {
+	if klass == nil || klass.Data == nil {
 		errMsg := "systemClinit: Expected java/lang/System to be in the MethodArea, but it was not"
 		trace.Error(errMsg)
 		return getGErrBlk(excNames.ClassNotLoadedException, errMsg)

--- a/src/gfunction/javaMathBigInteger.go
+++ b/src/gfunction/javaMathBigInteger.go
@@ -421,7 +421,7 @@ func addStaticBigInteger(argName string, argValue int64) {
 // "java/math/BigInteger.<clinit>()V"
 func bigIntegerClinit([]interface{}) interface{} {
 	klass := classloader.MethAreaFetch(classNameBigInteger)
-	if klass == nil {
+	if klass == nil || klass.Data == nil {
 		errMsg := fmt.Sprintf("bigIntegerClinit: Expected %s to be in the MethodArea, but it was not", classNameBigInteger)
 		trace.Error(errMsg)
 		return getGErrBlk(excNames.ClassNotLoadedException, errMsg)

--- a/src/gfunction/testGfunctions.go
+++ b/src/gfunction/testGfunctions.go
@@ -115,7 +115,7 @@ func vd(params []any) any {
 func vl(params []any) any {
 	obj := object.MakeEmptyObject()
 	obj.KlassName = types.ObjectPoolStringIndex
-	return &obj
+	return obj
 }
 
 func iv(params []any) any {
@@ -141,7 +141,7 @@ func id(params []any) any {
 func il(params []any) any {
 	obj := object.MakeEmptyObject()
 	obj.KlassName = types.ObjectPoolStringIndex
-	return &obj
+	return obj
 }
 
 func li(params []any) any {
@@ -151,7 +151,7 @@ func li(params []any) any {
 func ll(params []any) any {
 	obj := object.MakeEmptyObject()
 	obj.KlassName = types.ObjectPoolStringIndex
-	return &obj
+	return obj
 }
 
 func ld(params []any) any {

--- a/src/gfunction/testGfunctions_test.go
+++ b/src/gfunction/testGfunctions_test.go
@@ -1,0 +1,130 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2025 by the Jacobin Authors.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)  Consult jacobin.org.
+ */
+
+package gfunction
+
+import (
+    "reflect"
+    "testing"
+
+    "jacobin/classloader"
+    "jacobin/globals"
+    "jacobin/object"
+    "jacobin/types"
+)
+
+func TestLoad_TestGfunctions_RegistersMethods(t *testing.T) {
+    // Save and restore TestMethodSignatures to avoid cross-test pollution
+    saved := TestMethodSignatures
+    defer func() { TestMethodSignatures = saved }()
+    TestMethodSignatures = make(map[string]GMeth)
+
+    Load_TestGfunctions()
+
+    checks := []struct{
+        key   string
+        slots int
+        fn    func([]interface{}) interface{}
+    }{
+        {"jacobin/test/Object.test()D", 0, vd},
+        {"jacobin/test/Object.test()Ljava/lang/Object;", 0, vl},
+        {"jacobin/test/Object.test(I)V", 1, iv},
+        {"jacobin/test/Object.test(D)V", 1, dv},
+        {"jacobin/test/Object.test(Ljava/lang/Object;)V", 1, lv},
+        {"jacobin/test/Object.test(I)I", 1, ii},
+        {"jacobin/test/Object.test(I)D", 1, id},
+        {"jacobin/test/Object.test(I)Ljava/lang/Object;", 1, il},
+        {"jacobin/test/Object.test(Ljava/lang/Object;)I", 1, li},
+        {"jacobin/test/Object.test(Ljava/lang/Object;)Ljava/lang/Object;", 1, ll},
+        {"jacobin/test/Object.test(Ljava/lang/Object;)D", 1, ld},
+        {"jacobin/test/Object.test(D)E", 1, ie},
+    }
+
+    for _, c := range checks {
+        got, ok := TestMethodSignatures[c.key]
+        if !ok {
+            t.Fatalf("missing TestMethodSignatures entry for %s", c.key)
+        }
+        if got.ParamSlots != c.slots {
+            t.Fatalf("%s ParamSlots expected %d, got %d", c.key, c.slots, got.ParamSlots)
+        }
+        if got.GFunction == nil {
+            t.Fatalf("%s GFunction expected non-nil", c.key)
+        }
+        if reflect.ValueOf(got.GFunction).Pointer() != reflect.ValueOf(c.fn).Pointer() {
+            t.Fatalf("%s GFunction mismatch", c.key)
+        }
+    }
+}
+
+func TestCheckTestGfunctionsLoaded_PopulatesMTable(t *testing.T) {
+    globals.InitGlobals("test")
+    classloader.InitMethodArea() // required by CheckTestGfunctionsLoaded -> MethAreaInsert
+
+    // clean MTable and TestMethodSignatures
+    classloader.MTable = make(map[string]classloader.MTentry)
+    saved := TestMethodSignatures
+    defer func() { TestMethodSignatures = saved }()
+    TestMethodSignatures = make(map[string]GMeth)
+
+    // Load test gfunctions into MTable
+    CheckTestGfunctionsLoaded()
+
+    // A couple of representative keys should be in the classloader MTable now
+    keys := []string{
+        "jacobin/test/Object.test()D",
+        "jacobin/test/Object.test(I)I",
+        "jacobin/test/Object.test(D)E",
+    }
+
+    for _, k := range keys {
+        mte, ok := classloader.MTable[k]
+        if !ok {
+            t.Fatalf("MTable missing key %s after CheckTestGfunctionsLoaded", k)
+        }
+        if mte.MType != 'G' {
+            t.Fatalf("MType for %s expected 'G', got %c", k, mte.MType)
+        }
+        // Sanity check: Meth must be a GMeth with a non-nil GFunction
+        gm, ok := mte.Meth.(GMeth)
+        if !ok {
+            t.Fatalf("MTable entry %s not a GMeth", k)
+        }
+        if gm.GFunction == nil {
+            t.Fatalf("MTable entry %s has nil GFunction", k)
+        }
+    }
+}
+
+func TestTestGfunctions_BasicBehaviors(t *testing.T) {
+    // simple direct calls to confirm contracts
+    if v, ok := vd(nil).(float64); !ok || v == 0 {
+        t.Fatalf("vd expected non-zero float64, got %v (%T)", v, v)
+    }
+    if v := ii(nil); v != int64(43) {
+        t.Fatalf("ii expected 43, got %v", v)
+    }
+    if v := id(nil); v != float64(43.43) {
+        t.Fatalf("id expected 43.43, got %v", v)
+    }
+    if v := li(nil); v != 44 {
+        t.Fatalf("li expected 44, got %v", v)
+    }
+    if v := ld(nil); v != float64(44.44) {
+        t.Fatalf("ld expected 44.44, got %v", v)
+    }
+
+    // vl/il/ll return *object.Object pointing to bare java/lang/Object
+    if o, ok := vl(nil).(*object.Object); !ok || o == nil || o.KlassName != types.ObjectPoolStringIndex {
+        t.Fatalf("vl returned wrong object")
+    }
+    if o, ok := il(nil).(*object.Object); !ok || o == nil || o.KlassName != types.ObjectPoolStringIndex {
+        t.Fatalf("il returned wrong object")
+    }
+    if o, ok := ll(nil).(*object.Object); !ok || o == nil || o.KlassName != types.ObjectPoolStringIndex {
+        t.Fatalf("ll returned wrong object")
+    }
+}

--- a/src/statics/loadPrimiStatics_test.go
+++ b/src/statics/loadPrimiStatics_test.go
@@ -1,0 +1,222 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2025 by the Jacobin Authors.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)  Consult jacobin.org.
+ */
+
+package statics
+
+import (
+    "math"
+    "testing"
+
+    "jacobin/types"
+)
+
+// helper to isolate Statics map between tests
+func withFreshStatics(t *testing.T, fn func()) {
+    t.Helper()
+    saved := Statics
+    Statics = make(map[string]Static)
+    defer func() { Statics = saved }()
+    fn()
+}
+
+func TestLoadStaticsByte(t *testing.T) {
+    withFreshStatics(t, func() {
+        LoadStaticsByte()
+        // Expected entries
+        cases := []struct{
+            key  string
+            typ  string
+            val  interface{}
+        }{
+            {"java/lang/Byte.BYTES", types.Int, int64(1)},
+            {"java/lang/Byte.MAX_VALUE", types.Byte, int64(0x7f)},
+            {"java/lang/Byte.MIN_VALUE", types.Byte, int64(0x80)},
+            {"java/lang/Byte.SIZE", types.Int, int64(8)},
+        }
+        for _, c := range cases {
+            st, ok := Statics[c.key]
+            if !ok {
+                t.Fatalf("missing static %s", c.key)
+            }
+            if st.Type != c.typ {
+                t.Fatalf("%s type expected %s, got %s", c.key, c.typ, st.Type)
+            }
+            if st.Value != c.val {
+                t.Fatalf("%s value expected %v, got %v", c.key, c.val, st.Value)
+            }
+        }
+    })
+}
+
+func TestLoadStaticsCharacter_SampleSet(t *testing.T) {
+    withFreshStatics(t, func() {
+        LoadStaticsCharacter()
+        // Basic size/bytes and value bounds
+        if st, ok := Statics["java/lang/Character.BYTES"]; !ok || st.Type != types.Int || st.Value != int64(2) {
+            t.Fatalf("Character.BYTES wrong: %+v", st)
+        }
+        if st, ok := Statics["java/lang/Character.SIZE"]; !ok || st.Type != types.Int || st.Value != int64(16) {
+            t.Fatalf("Character.SIZE wrong: %+v", st)
+        }
+        if st, ok := Statics["java/lang/Character.MAX_CODE_POINT"]; !ok || st.Type != types.Int || st.Value != int64(1114111) {
+            t.Fatalf("Character.MAX_CODE_POINT wrong: %+v", st)
+        }
+        if st, ok := Statics["java/lang/Character.MAX_VALUE"]; !ok || st.Type != types.Char || st.Value != rune(65535) {
+            t.Fatalf("Character.MAX_VALUE wrong: %+v", st)
+        }
+        // Spot-check a couple category/directionality constants
+        if st, ok := Statics["java/lang/Character.UPPERCASE_LETTER"]; !ok || st.Type != types.Byte || st.Value != int64(0x1) {
+            t.Fatalf("Character.UPPERCASE_LETTER wrong: %+v", st)
+        }
+        if st, ok := Statics["java/lang/Character.DIRECTIONALITY_RIGHT_TO_LEFT"]; !ok || st.Type != types.Byte || st.Value != int64(0x1) {
+            t.Fatalf("Character.DIRECTIONALITY_RIGHT_TO_LEFT wrong: %+v", st)
+        }
+    })
+}
+
+func TestLoadStaticsDouble(t *testing.T) {
+    withFreshStatics(t, func() {
+        LoadStaticsDouble()
+        // simple integer fields
+        if st := Statics["java/lang/Double.BYTES"]; st.Type != types.Int || st.Value != int64(8) {
+            t.Fatalf("Double.BYTES wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Double.MAX_EXPONENT"]; st.Type != types.Int || st.Value != int64(1023) {
+            t.Fatalf("Double.MAX_EXPONENT wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Double.MIN_EXPONENT"]; st.Type != types.Int || st.Value != int64(-1022) {
+            t.Fatalf("Double.MIN_EXPONENT wrong: %+v", st)
+        }
+        // floats: MIN_NORMAL, MIN_VALUE, MAX_VALUE
+        if st := Statics["java/lang/Double.MIN_NORMAL"]; st.Type != types.Double || st.Value.(float64) != float64(2.2250738585072014e-308) {
+            t.Fatalf("Double.MIN_NORMAL wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Double.MIN_VALUE"]; st.Type != types.Double || st.Value.(float64) != float64(4.9e-324) {
+            t.Fatalf("Double.MIN_VALUE wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Double.MAX_VALUE"]; st.Type != types.Double || st.Value.(float64) != float64(1.7976931348623157e308) {
+            t.Fatalf("Double.MAX_VALUE wrong: %+v", st)
+        }
+        // NaN/Inf checks
+        if st := Statics["java/lang/Double.NaN"]; st.Type != types.Double || !math.IsNaN(st.Value.(float64)) {
+            t.Fatalf("Double.NaN wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Double.NEGATIVE_INFINITY"]; st.Type != types.Double || !math.IsInf(st.Value.(float64), -1) {
+            t.Fatalf("Double.NEGATIVE_INFINITY wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Double.POSITIVE_INFINITY"]; st.Type != types.Double || !math.IsInf(st.Value.(float64), +1) {
+            t.Fatalf("Double.POSITIVE_INFINITY wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Double.SIZE"]; st.Type != types.Int || st.Value != int64(64) {
+            t.Fatalf("Double.SIZE wrong: %+v", st)
+        }
+    })
+}
+
+func TestLoadStaticsFloat(t *testing.T) {
+    withFreshStatics(t, func() {
+        LoadStaticsFloat()
+        if st := Statics["java/lang/Float.BYTES"]; st.Type != types.Int || st.Value != int64(4) {
+            t.Fatalf("Float.BYTES wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Float.MAX_EXPONENT"]; st.Type != types.Int || st.Value != int64(127) {
+            t.Fatalf("Float.MAX_EXPONENT wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Float.MIN_EXPONENT"]; st.Type != types.Int || st.Value != int64(-126) {
+            t.Fatalf("Float.MIN_EXPONENT wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Float.MIN_NORMAL"]; st.Type != types.Float || st.Value.(float64) != float64(1.1754943508222875e-38) {
+            t.Fatalf("Float.MIN_NORMAL wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Float.MIN_VALUE"]; st.Type != types.Float || st.Value.(float64) != float64(1.401298464324817e-45) {
+            t.Fatalf("Float.MIN_VALUE wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Float.NaN"]; st.Type != types.Float || !math.IsNaN(st.Value.(float64)) {
+            t.Fatalf("Float.NaN wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Float.NEGATIVE_INFINITY"]; st.Type != types.Float || !math.IsInf(st.Value.(float64), -1) {
+            t.Fatalf("Float.NEGATIVE_INFINITY wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Float.POSITIVE_INFINITY"]; st.Type != types.Float || !math.IsInf(st.Value.(float64), +1) {
+            t.Fatalf("Float.POSITIVE_INFINITY wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Float.SIZE"]; st.Type != types.Int || st.Value != int64(32) {
+            t.Fatalf("Float.SIZE wrong: %+v", st)
+        }
+    })
+}
+
+func TestLoadStaticsInteger_Long_Short(t *testing.T) {
+    withFreshStatics(t, func() {
+        LoadStaticsInteger()
+        if st := Statics["java/lang/Integer.BYTES"]; st.Type != types.Int || st.Value != int64(4) {
+            t.Fatalf("Integer.BYTES wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Integer.MAX_VALUE"]; st.Type != types.Int || st.Value != int64(2147483647) {
+            t.Fatalf("Integer.MAX_VALUE wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Integer.MIN_VALUE"]; st.Type != types.Int || st.Value != int64(-2147483648) {
+            t.Fatalf("Integer.MIN_VALUE wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Integer.SIZE"]; st.Type != types.Int || st.Value != int64(32) {
+            t.Fatalf("Integer.SIZE wrong: %+v", st)
+        }
+    })
+
+    withFreshStatics(t, func() {
+        LoadStaticsLong()
+        if st := Statics["java/lang/Long.BYTES"]; st.Type != types.Int || st.Value != int64(8) {
+            t.Fatalf("Long.BYTES wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Long.MAX_VALUE"]; st.Type != types.Long || st.Value != int64(9223372036854775807) {
+            t.Fatalf("Long.MAX_VALUE wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Long.MIN_VALUE"]; st.Type != types.Long || st.Value != int64(-9223372036854775808) {
+            t.Fatalf("Long.MIN_VALUE wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Long.SIZE"]; st.Type != types.Int || st.Value != int64(64) {
+            t.Fatalf("Long.SIZE wrong: %+v", st)
+        }
+    })
+
+    withFreshStatics(t, func() {
+        LoadStaticsShort()
+        if st := Statics["java/lang/Short.BYTES"]; st.Type != types.Int || st.Value != int64(2) {
+            t.Fatalf("Short.BYTES wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Short.MAX_VALUE"]; st.Type != types.Short || st.Value != int64(32767) {
+            t.Fatalf("Short.MAX_VALUE wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Short.MIN_VALUE"]; st.Type != types.Short || st.Value != int64(-32768) {
+            t.Fatalf("Short.MIN_VALUE wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Short.SIZE"]; st.Type != types.Int || st.Value != int64(16) {
+            t.Fatalf("Short.SIZE wrong: %+v", st)
+        }
+    })
+}
+
+func TestLoadStaticsMath_StrictMath(t *testing.T) {
+    withFreshStatics(t, func() {
+        LoadStaticsMath()
+        if st := Statics["java/lang/Math.E"]; st.Type != types.Double || st.Value.(float64) != float64(2.718281828459045) {
+            t.Fatalf("Math.E wrong: %+v", st)
+        }
+        if st := Statics["java/lang/Math.PI"]; st.Type != types.Double || st.Value.(float64) != float64(3.141592653589793) {
+            t.Fatalf("Math.PI wrong: %+v", st)
+        }
+    })
+
+    withFreshStatics(t, func() {
+        LoadStaticsStrictMath()
+        if st := Statics["java/lang/StrictMath.E"]; st.Type != types.Double || st.Value.(float64) != float64(2.718281828459045) {
+            t.Fatalf("StrictMath.E wrong: %+v", st)
+        }
+        if st := Statics["java/lang/StrictMath.PI"]; st.Type != types.Double || st.Value.(float64) != float64(3.141592653589793) {
+            t.Fatalf("StrictMath.PI wrong: %+v", st)
+        }
+    })
+}

--- a/src/types/constants_test.go
+++ b/src/types/constants_test.go
@@ -1,0 +1,69 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2025 by the Jacobin Authors.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)  Consult jacobin.org.
+ */
+
+package types
+
+import "testing"
+
+func TestClinitStatusConstants(t *testing.T) {
+    if NoClInit != 0x00 {
+        t.Fatalf("NoClInit expected 0x00, got 0x%02x", NoClInit)
+    }
+    if ClInitNotRun != 0x01 {
+        t.Fatalf("ClInitNotRun expected 0x01, got 0x%02x", ClInitNotRun)
+    }
+    if ClInitInProgress != 0x02 {
+        t.Fatalf("ClInitInProgress expected 0x02, got 0x%02x", ClInitInProgress)
+    }
+    if ClInitRun != 0x03 {
+        t.Fatalf("ClInitRun expected 0x03, got 0x%02x", ClInitRun)
+    }
+}
+
+func TestStringPoolRelatedConstants(t *testing.T) {
+    // String/Object class names
+    if ObjectClassName != "java/lang/Object" {
+        t.Fatalf("ObjectClassName mismatch: %q", ObjectClassName)
+    }
+    if PtrToJavaLangObject == nil || *PtrToJavaLangObject != ObjectClassName {
+        t.Fatalf("PtrToJavaLangObject does not point to ObjectClassName")
+    }
+    if StringClassName != "java/lang/String" {
+        t.Fatalf("StringClassName mismatch: %q", StringClassName)
+    }
+    if StringClassRef != "Ljava/lang/String;" {
+        t.Fatalf("StringClassRef mismatch: %q", StringClassRef)
+    }
+    if ModuleClassRef != "Ljava/lang/Module;" {
+        t.Fatalf("ModuleClassRef mismatch: %q", ModuleClassRef)
+    }
+
+    // Pool indices per globals.InitStringPool contract
+    if StringPoolStringIndex != 1 {
+        t.Fatalf("StringPoolStringIndex expected 1, got %d", StringPoolStringIndex)
+    }
+    if ObjectPoolStringIndex != 2 {
+        t.Fatalf("ObjectPoolStringIndex expected 2, got %d", ObjectPoolStringIndex)
+    }
+}
+
+func TestMiscStringConstants(t *testing.T) {
+    if EmptyString != "" {
+        t.Fatalf("EmptyString expected empty, got %q", EmptyString)
+    }
+    if NullString != "null" {
+        t.Fatalf("NullString expected 'null', got %q", NullString)
+    }
+}
+
+func TestInvalidStringIndexAndStackInflator(t *testing.T) {
+    if InvalidStringIndex != 0xffffffff {
+        t.Fatalf("InvalidStringIndex expected 0xffffffff, got 0x%x", InvalidStringIndex)
+    }
+    if StackInflator != 2 {
+        t.Fatalf("StackInflator expected 2, got %d", StackInflator)
+    }
+}

--- a/src/types/typeUtils_test.go
+++ b/src/types/typeUtils_test.go
@@ -1,0 +1,33 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2025 by the Jacobin Authors.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)  Consult jacobin.org.
+ */
+
+package types
+
+import "testing"
+
+func TestFourBytesToInt64_Table(t *testing.T) {
+    // Table-driven tests: b1..b4 -> expected int64
+    tests := []struct {
+        b1, b2, b3, b4 byte
+        want           int64
+        name           string
+    }{
+        {0x00, 0x00, 0x00, 0x00, 0, "zero"},
+        {0x00, 0x00, 0x00, 0x01, 1, "one"},
+        {0x12, 0x34, 0x56, 0x78, 0x12345678, "0x12345678"},
+        {0x7f, 0xff, 0xff, 0xff, 2147483647, "max_int32"},
+        {0x80, 0x00, 0x00, 0x00, -2147483648, "min_int32"},
+        {0xff, 0xff, 0xff, 0xff, -1, "minus_one"},
+    }
+
+    for _, tc := range tests {
+        got := FourBytesToInt64(tc.b1, tc.b2, tc.b3, tc.b4)
+        if got != tc.want {
+            t.Fatalf("%s: FourBytesToInt64(%#02x,%#02x,%#02x,%#02x) = %d; want %d",
+                tc.name, tc.b1, tc.b2, tc.b3, tc.b4, got, tc.want)
+        }
+    }
+}


### PR DESCRIPTION
In the `<clinit>` function, make sure that `klass.Data` is not nil as well as `klass` itself:

* gfunction/javaIoConsole.go
* gfunction/javaLangString.go
* gfunction/javaLangSystem.go
* gfunction/javaMathBigInteger.go

New unit test files:

* gfunction/gfunctionExec_test.go
* gfunction/javaAwtGraphicsEnvironment_test.go
* gfunction/javaIoConsole_test.go
* gfunction/javaLangBoolean_test.go
* gfunction/javaLangByte_test.go
* gfunction/javaLangCharacter_test.go
* gfunction/javaLangReflectField_test.go
* gfunction/Traps_test.go
* gfunction/testGfunctions_test.go
* statics/loadPrimiStatics_test.go
* trace/trace_test.go
* types/constants_test.go
* types/typeUtils_test.go

Return the object pointer (*object.Object), not a pointer to the object pointer:
* gfunction/testGfunctions.go

Not included (all traps):
* javaLangProcessBuilder.go
* javaLangProcess.go

Not included, pending a design for the Class object FieldTable and related interfacing:
* javaLangClass.go (There is a unit test file but it will be re-generated once the G functions are finalized)
* javaLangObject.go

