### PR TITLE
Mostly, JACOBIN-778/779 G functions + unit tests for classes SimpleDateFormat, Date, and TimeZone

### DIFF
--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -148,6 +148,9 @@ func MTableLoadGFunctions(MTable *classloader.MT) {
 		Load_Math_Math_Context()
 		Load_Math_Rounding_Mode()
 
+		// java/text/*
+		Load_Math_SimpleDateFormat()
+
 		// java/security/*
 		Load_Security_SecureRandom()
 
@@ -156,6 +159,7 @@ func MTableLoadGFunctions(MTable *classloader.MT) {
 		Load_Util_Base64()
 		Load_Util_Concurrent_Atomic_AtomicInteger()
 		Load_Util_Concurrent_Atomic_Atomic_Long()
+		Load_Util_Date()
 		Load_Util_Hash_Map()
 		Load_Util_Hash_Set()
 		Load_Util_HexFormat()
@@ -165,6 +169,7 @@ func MTableLoadGFunctions(MTable *classloader.MT) {
 		Load_Util_Objects()
 		Load_Util_Optional()
 		Load_Util_Random()
+		Load_Util_TimeZone()
 		Load_Util_Zip_Adler32()
 		Load_Util_Zip_Crc32_Crc32c()
 

--- a/src/gfunction/javaIoFileInputStream.go
+++ b/src/gfunction/javaIoFileInputStream.go
@@ -65,6 +65,12 @@ func Load_Io_FileInputStream() {
 			GFunction:  fisReadByteArrayOffset,
 		}
 
+	MethodSignatures["java/io/FileInputStream.readNBytes([BII)I"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  fisReadByteArrayOffset,
+		}
+
 	MethodSignatures["java/io/FileInputStream.skip(J)J"] =
 		GMeth{
 			ParamSlots: 1,

--- a/src/gfunction/javaLangString.go
+++ b/src/gfunction/javaLangString.go
@@ -1332,7 +1332,17 @@ func substringStartEnd(params []interface{}) interface{} {
 	// params[0] = base string
 	// params[1] = start offset
 	// params[2] = end offset
-	str := object.GoStringFromStringObject(params[0].(*object.Object))
+
+	obj, ok := params[0].(*object.Object)
+	if !ok {
+		if object.IsNull(params[0]) {
+			errMsg := "substringStartEnd: params[0] is null"
+			return getGErrBlk(excNames.NullPointerException, errMsg)
+		}
+		errMsg := "substringStartEnd: params[0] is not an object"
+		return getGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	str := object.GoStringFromStringObject(obj)
 
 	// Get substring start and end offset
 	ssStart := params[1].(int64)
@@ -1350,7 +1360,7 @@ func substringStartEnd(params []interface{}) interface{} {
 	str = str[ssStart:ssEnd]
 
 	// Return new string in an object.
-	obj := object.StringObjectFromGoString(str)
+	obj = object.StringObjectFromGoString(str)
 	return obj
 }
 

--- a/src/gfunction/javaMathBigDecimalSqrt_test.go
+++ b/src/gfunction/javaMathBigDecimalSqrt_test.go
@@ -1,0 +1,96 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2025 by  the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package gfunction
+
+import (
+	"math"
+	"testing"
+
+	"jacobin/src/excNames"
+	"jacobin/src/object"
+)
+
+/**
+ * This test verifies BigDecimal.sqrt(MathContext) minimal behavior implemented in
+ * bigdecimalSqrtContext. Our implementation requires a non-null MathContext,
+ * throws ArithmeticException for negative values, and otherwise computes the
+ * result using double math with sqrt, returning a BigDecimal via valueOf(double).
+ *
+ * We DO NOT attempt a huge Gauss–Legendre (Brent–Salamin) computation here; that
+ * comment is illustrative only. Instead, we validate correctness and errors.
+ */
+func TestBigDecimalSqrt(t *testing.T) {
+	bdutInit() // initialize globals/statics used by BigDecimal
+
+	// Helper to make a MathContext with given precision using <init>(int)
+	newMC := func(prec int64) *object.Object {
+		className := "java/math/MathContext"
+		mc := object.MakeEmptyObjectWithClassName(&className)
+		if res := mconInitInt([]interface{}{mc, prec}); res != nil {
+			t.Fatalf("mconInitInt returned error: %v", res)
+		}
+		return mc
+	}
+
+	t.Run("Null_MathContext_Yields_NPE", func(t *testing.T) {
+		// sqrt with null MathContext -> NullPointerException
+		// Make operand 4
+		self := object.MakeEmptyObjectWithClassName(&classNameBigDecimal)
+		if res := bigdecimalInitString([]interface{}{self, object.StringObjectFromGoString("4")}); res != nil {
+			t.Fatalf("init BigDecimal(4) failed: %v", res)
+		}
+		ret := bigdecimalSqrtContext([]interface{}{self, object.Null})
+		if blk, ok := ret.(*GErrBlk); !ok || blk.ExceptionType != excNames.NullPointerException {
+			t.Fatalf("expected NullPointerException, got %T (%v)", ret, ret)
+		}
+	})
+
+	t.Run("Negative_Value_Yields_ArithmeticException", func(t *testing.T) {
+		self := object.MakeEmptyObjectWithClassName(&classNameBigDecimal)
+		if res := bigdecimalInitString([]interface{}{self, object.StringObjectFromGoString("-1")}); res != nil {
+			t.Fatalf("init BigDecimal(-1) failed: %v", res)
+		}
+		mc := newMC(10)
+		ret := bigdecimalSqrtContext([]interface{}{self, mc})
+		if blk, ok := ret.(*GErrBlk); !ok || blk.ExceptionType != excNames.ArithmeticException {
+			t.Fatalf("expected ArithmeticException for sqrt(-1), got %T (%v)", ret, ret)
+		}
+	})
+
+	t.Run("Sqrt_Positive_Basic_Values", func(t *testing.T) {
+		cases := []struct{
+			in   string
+			want float64
+		}{
+			{"0", 0},
+			{"1", 1},
+			{"4", 2},
+			{"2", math.Sqrt(2)},
+			{"123.456", math.Sqrt(123.456)},
+		}
+		for _, c := range cases {
+			self := object.MakeEmptyObjectWithClassName(&classNameBigDecimal)
+			if res := bigdecimalInitString([]interface{}{self, object.StringObjectFromGoString(c.in)}); res != nil {
+				t.Fatalf("init BigDecimal(%s) failed: %v", c.in, res)
+			}
+			mc := newMC(16)
+			out := bigdecimalSqrtContext([]interface{}{self, mc})
+			if blk, ok := out.(*GErrBlk); ok {
+				t.Fatalf("unexpected error for sqrt(%s): %d %s", c.in, blk.ExceptionType, blk.ErrMsg)
+			}
+			bd := out.(*object.Object)
+			got := bigdecimalDoubleValue([]interface{}{bd}).(float64)
+			if math.IsNaN(got) || math.IsInf(got, 0) {
+				t.Fatalf("sqrt(%s) produced invalid double: %v", c.in, got)
+			}
+			// Allow small tolerance due to double conversion and toBigDecimal from double
+			if math.Abs(got-c.want) > 1e-12 {
+				t.Fatalf("sqrt(%s) mismatch: got %.15g want %.15g", c.in, got, c.want)
+			}
+		}
+	})
+}

--- a/src/gfunction/javaMathBigDecimal_50digits_test.go
+++ b/src/gfunction/javaMathBigDecimal_50digits_test.go
@@ -1,0 +1,248 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2025 by  the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package gfunction
+
+import (
+	"jacobin/src/object"
+	"math/big"
+	"testing"
+)
+
+// Helpers local to this file
+func bdFromStr50(t *testing.T, s string) *object.Object {
+	t.Helper()
+	bd := object.MakeEmptyObjectWithClassName(&classNameBigDecimal)
+	if res := bigdecimalInitString([]interface{}{bd, object.StringObjectFromGoString(s)}); res != nil {
+		t.Fatalf("bdFromStr50 calling bigdecimalInitString failed for %s: %v", s, res)
+	}
+	return bd
+}
+
+func bdToString(t *testing.T, bd *object.Object) string {
+	t.Helper()
+	params := []interface{}{bd}
+	return object.GoStringFromStringObject(bigdecimalToString(params).(*object.Object))
+}
+
+func Test_BigDecimal_Add_50Digits(t *testing.T) {
+	bdutInit()
+	// Two 50-digit numbers with decimals: a has 3 decimal places, b has 5 decimal places
+	aStr := "12345678901234567890123456789012345678901234567.123" // 47 digits before dot + 3 after = 50
+	bStr := "987654321098765432109876543210987654321098765.43210" // 45 digits before dot + 5 after = 50
+	A := bdFromStr50(t, aStr)
+	B := bdFromStr50(t, bStr)
+	C := bigdecimalAdd([]interface{}{A, B}).(*object.Object)
+	// Expected: align scales to max(sA,sB)=5
+	aU, aS := extractBigDecimalComponents(t, A)
+	bU, bS := extractBigDecimalComponents(t, B)
+	s := aS
+	if bS > s {
+		s = bS
+	}
+	adjA := new(big.Int).Set(aU)
+	if s > aS {
+		mul := new(big.Int).Exp(big.NewInt(10), big.NewInt(s-aS), nil)
+		adjA.Mul(adjA, mul)
+	}
+	adjB := new(big.Int).Set(bU)
+	if s > bS {
+		mul := new(big.Int).Exp(big.NewInt(10), big.NewInt(s-bS), nil)
+		adjB.Mul(adjB, mul)
+	}
+	expected := new(big.Int).Add(adjA, adjB)
+	u, gotS := extractBigDecimalComponents(t, C)
+	if gotS != s {
+		t.Fatalf("add scale expected %d, got %d", s, gotS)
+	}
+	if u.Cmp(expected) != 0 {
+		t.Fatalf("add unscaled mismatch: got %s want %s", u.String(), expected.String())
+	}
+}
+
+func Test_BigDecimal_Subtract_50Digits(t *testing.T) {
+	bdutInit()
+	// Two 50-digit numbers with decimals; verify subtraction. a has 3 dp, b has 5 dp
+	aStr := "98765432109876543210987654321098765432109876543.210" // 47+3
+	bStr := "123456789012345678901234567890123456789012345.67890" // 45+5
+	A := bdFromStr50(t, aStr)
+	B := bdFromStr50(t, bStr)
+	res := bigdecimalSubtract([]interface{}{A, B}).(*object.Object)
+	// Expected with aligned scales
+	aU, aS := extractBigDecimalComponents(t, A)
+	bU, bS := extractBigDecimalComponents(t, B)
+	s := aS
+	if bS > s {
+		s = bS
+	}
+	adjA := new(big.Int).Set(aU)
+	if s > aS {
+		mul := new(big.Int).Exp(big.NewInt(10), big.NewInt(s-aS), nil)
+		adjA.Mul(adjA, mul)
+	}
+	adjB := new(big.Int).Set(bU)
+	if s > bS {
+		mul := new(big.Int).Exp(big.NewInt(10), big.NewInt(s-bS), nil)
+		adjB.Mul(adjB, mul)
+	}
+	expected := new(big.Int).Sub(adjA, adjB)
+	u, gotS := extractBigDecimalComponents(t, res)
+	if gotS != s {
+		t.Fatalf("subtract scale expected %d, got %d", s, gotS)
+	}
+	if u.Cmp(expected) != 0 {
+		t.Fatalf("subtract unscaled mismatch: got %s want %s", u.String(), expected.String())
+	}
+}
+
+func Test_BigDecimal_Multiply_50Digits(t *testing.T) {
+	bdutInit()
+	// Two 50-digit numbers with decimals; product scale should be sum of scales (3+5=8)
+	aStr := "12345678901234567890123456789012345678901234567.890" // 47+3
+	bStr := "987654321098765432109876543210987654321098765.43210" // 45+5
+	A := bdFromStr50(t, aStr)
+	B := bdFromStr50(t, bStr)
+	res := bigdecimalMultiply([]interface{}{A, B}).(*object.Object)
+	// Expected via unscaled multiplication; scale = sA + sB
+	aU, aS := extractBigDecimalComponents(t, A)
+	bU, bS := extractBigDecimalComponents(t, B)
+	expected := new(big.Int).Mul(new(big.Int).Set(aU), new(big.Int).Set(bU))
+	u, s := extractBigDecimalComponents(t, res)
+	if s != aS+bS {
+		t.Fatalf("multiply scale expected %d, got %d", aS+bS, s)
+	}
+	if u.Cmp(expected) != 0 {
+		t.Fatalf("multiply unscaled mismatch: got %s want %s", u.String(), expected.String())
+	}
+}
+
+func Test_BigDecimal_Divide_50Digits_ExactMatch(t *testing.T) {
+	bdutInit()
+
+	// dividend
+	aStr := "963963963963963963963963963963963963963963963963963963963.963" // 57+3
+	Div := bdFromStr50(t, aStr)
+
+	// divisor
+	bStr := "2.87654876548765487654876548765487654876548765487654"
+	Dsr := bdFromStr50(t, bStr)
+
+	// Perform division with specified scale and rounding (3 dp, HALF_UP)
+	rm := rmodeValueOfString([]interface{}{object.StringObjectFromGoString("HALF_UP")})
+	if blk, ok := rm.(*GErrBlk); ok {
+		t.Fatalf("failed to get RoundingMode.HALF_UP: %v", blk)
+	}
+	Quotient := bigdecimalDivideScaleRoundingMode([]interface{}{Div, Dsr, int64(3), rm.(*object.Object)})
+
+	// Expected 3-decimal HALF_UP rounding of approximately a/3
+	expected := "335111288753189383117212577810800663414238150377653296938.250"
+
+	// Check quotient or other result.
+	switch Quotient.(type) {
+	case *object.Object:
+		observed := bdToString(t, Quotient.(*object.Object))
+		if observed != expected {
+			t.Fatalf("BigDecimal divide result mismatch: got %s want %s", observed, expected)
+		}
+		t.Logf("BigDecimal divide result: %s", observed)
+	case *GErrBlk:
+		t.Fatalf("unexpected G function error block, got %s", Quotient.(*GErrBlk).ErrMsg)
+	default:
+		t.Fatalf("unexpected G function return, got %T", Quotient)
+	}
+}
+
+func Test_BigDecimal_DivideAndRemainder_IssueCase(t *testing.T) {
+	bdutInit()
+	A := bdFromStr50(t, "963963963963963963963963963963963963963963963963963963963.963")
+	B := bdFromStr50(t, "2.87654876548765487654876548765487654876548765487654")
+	arr := bigdecimalDivideAndRemainder([]interface{}{A, B})
+	if blk, ok := arr.(*GErrBlk); ok {
+		t.Fatalf("divideAndRemainder returned error: %v", blk)
+	}
+	arrObj := arr.(*object.Object)
+	vals, _ := arrObj.FieldTable["value"].Fvalue.([]*object.Object)
+	if len(vals) != 2 {
+		t.Fatalf("expected array of length 2, got %d", len(vals))
+	}
+	qStr := bdToString(t, vals[0])
+	rStr := bdToString(t, vals[1])
+	expectedQ := "335111288753189383117212577810800663414238150377653296938"
+	expectedR := "0.71804475666634227855232831541824534553677564996548"
+	if qStr != expectedQ {
+		t.Fatalf("divideAndRemainder quotient mismatch: got %s want %s", qStr, expectedQ)
+	}
+	if rStr != expectedR {
+		t.Fatalf("divideAndRemainder remainder mismatch: got %s want %s", rStr, expectedR)
+	}
+}
+
+func Test_BigDecimal_Pow_5_Scaled_String_IssueCase(t *testing.T) {
+	bdutInit()
+	B := bdFromStr50(t, "2.87654876548765487654876548765487654876548765487654")
+	res := bigdecimalPow([]interface{}{B, int64(5)})
+	if blk, ok := res.(*GErrBlk); ok {
+		t.Fatalf("pow returned error: %v", blk)
+	}
+	C := res.(*object.Object)
+	observed := bdToString(t, C)
+	expected := "196.9512332632041425648903952282597858571550912228881576467059003975279194556093059395958737271613605818429385286431679948696259759708157256485445979026081037557688179566936520311094050547107546448817694942476182957384867462249103941371639497016916093024"
+	if observed != expected {
+		t.Fatalf("BigDecimal pow(5) mismatch: got %s want %s", observed, expected)
+	}
+}
+
+func Test_BigDecimal_LongValue_ScaledOverflow_IssueCase(t *testing.T) {
+	bdutInit()
+	// A from the issue description
+	A := bdFromStr50(t, "963963963963963963963963963963963963963963963963963963963.963")
+	res := bigdecimalLongValue([]interface{}{A})
+	got, ok := res.(int64)
+	if !ok {
+		t.Fatalf("expected int64 from longValue, got %T", res)
+	}
+	var expected int64 = -5163478405204313541
+	if got != expected {
+		t.Fatalf("A.longValue() mismatch: got %d want %d", got, expected)
+	}
+}
+
+func Test_BigDecimal_Divide_50Digits_ArithmeticException(t *testing.T) {
+	bdutInit()
+	// These specific operands do not divide to a terminating decimal; expect ArithmeticException
+	// dividend
+	aStr := "987654321098765432109876543210987654321098765.43210" // 45+5
+	Div := bdFromStr50(t, aStr)
+	// divisor
+	bStr := "12345678901234567890123456789012345678901234567.890" // 47+3
+	Dsr := bdFromStr50(t, bStr)
+	// expected quotient
+	cStr := "3.0"
+	expected := bdFromStr50(t, cStr)
+	t.Logf("expected quotient: %T", expected)
+
+	res := bigdecimalDivide([]interface{}{Div, Dsr})
+	blk, isGErrBlk := res.(*GErrBlk)
+	if !isGErrBlk {
+		t.Fatalf("expected ArithmeticException for non-terminating division, got %T", blk)
+	}
+}
+
+// Added test for toBigInteger issue case
+func Test_BigDecimal_ToBigInteger_IssueCase(t *testing.T) {
+	bdutInit()
+	A := bdFromStr50(t, "963963963963963963963963963963963963963963963963963963963.963")
+	res := bigdecimalToBigInteger([]interface{}{A})
+	bi, ok := res.(*object.Object)
+	if !ok || bi == nil {
+		t.Fatalf("toBigInteger did not return a BigInteger object: %T", res)
+	}
+	got := bi.FieldTable["value"].Fvalue.(*big.Int).String()
+	expected := "963963963963963963963963963963963963963963963963963963963"
+	if got != expected {
+		t.Fatalf("BigDecimal.toBigInteger mismatch: got %s want %s", got, expected)
+	}
+}

--- a/src/gfunction/javaTextSimpleDateFormat.go
+++ b/src/gfunction/javaTextSimpleDateFormat.go
@@ -1,0 +1,185 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2025 by the Jacobin Authors. All rights reserved.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)  Consult jacobin.org.
+ */
+
+package gfunction
+
+import (
+	"jacobin/src/object"
+	"jacobin/src/types"
+)
+
+func Load_Math_SimpleDateFormat() {
+
+	MethodSignatures["java/text/SimpleDateFormat.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  clinitGeneric,
+		}
+
+	MethodSignatures["java/text/SimpleDateFormat.<init>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  sdfInit,
+		}
+
+	MethodSignatures["java/text/SimpleDateFormat.<init>(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  sdfInitString,
+		}
+
+	MethodSignatures["java/text/SimpleDateFormat.<init>(Ljava/lang/String;Ljava/text/DateFormatSymbols;)V"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/text/SimpleDateFormat.applyLocalizedPattern(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  sdfApplyPattern,
+		}
+
+	MethodSignatures["java/text/SimpleDateFormat.applyPattern(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  sdfApplyPattern,
+		}
+
+	MethodSignatures["java/text/SimpleDateFormat.clone()Ljava/lang/Object;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  sdfClone,
+		}
+
+	MethodSignatures["java/text/SimpleDateFormat.format(Ljava/util/Date;)Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/text/SimpleDateFormat.format(Ljava/util/Date;Ljava/lang/StringBuffer;Ljava/text/FieldPosition;)Ljava/lang/StringBuffer;"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/text/SimpleDateFormat.parse(Ljava/lang/String;)Ljava/util/Date;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/text/SimpleDateFormat.parse(Ljava/lang/String;Ljava/text/ParsePosition;)Ljava/util/Date;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/text/SimpleDateFormat.toLocalizedPattern()Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  sdfToPattern,
+		}
+
+	MethodSignatures["java/text/SimpleDateFormat.toPattern()Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  sdfToPattern,
+		}
+}
+
+// === SimpleDateFormat minimal implementations ===
+
+// sdfInit initializes a new SimpleDateFormat instance with no pattern.
+// Per project constructor convention, returns nil (void).
+func sdfInit(params []interface{}) interface{} {
+	if len(params) < 1 {
+		return nil
+	}
+	obj, ok := params[0].(*object.Object)
+	if !ok || obj == nil {
+		return nil
+	}
+	// Initialize empty field table.
+	obj.FieldTable = make(map[string]object.Field)
+	return nil
+}
+
+// sdfInitString initializes a new SimpleDateFormat with a pattern String.
+// Stores the provided pattern object in a "pattern" field for potential later use.
+func sdfInitString(params []interface{}) interface{} {
+	if len(params) < 2 {
+		return sdfInit(params)
+	}
+	obj, ok := params[0].(*object.Object)
+	if !ok || obj == nil {
+		return nil
+	}
+	obj.FieldTable = make(map[string]object.Field)
+	// Accept either a Java String object or null; store as-is.
+	s, _ := params[1].(*object.Object)
+	obj.FieldTable["pattern"] = object.Field{Ftype: types.StringClassRef, Fvalue: s}
+	return nil
+}
+
+// sdfClone returns a shallow clone; minimal implementation returns the same object reference.
+// Many call sites only require an Object to be returned; deeper cloning is out of scope here.
+func sdfClone(params []interface{}) interface{} {
+	if len(params) < 1 {
+		return object.Null
+	}
+	obj, _ := params[0].(*object.Object)
+	if obj == nil {
+		return object.Null
+	}
+	return obj
+}
+
+// sdfToPattern returns the stored pattern String if present.
+// Behavior:
+// - If a "pattern" field exists and is a non-nil String object, return it.
+// - If the field exists but is null, return Java null.
+// - If no pattern field exists (e.g., default ctor), return an empty String.
+func sdfToPattern(params []interface{}) interface{} {
+	if len(params) < 1 {
+		return object.Null
+	}
+	obj, _ := params[0].(*object.Object)
+	if obj == nil {
+		return object.Null
+	}
+	if fld, ok := obj.FieldTable["pattern"]; ok {
+		so, _ := fld.Fvalue.(*object.Object)
+		if so == nil {
+			return object.Null
+		}
+		return so
+	}
+	// No pattern stored; return empty string as minimal placeholder.
+	return object.StringObjectFromGoString("")
+}
+
+// sdfApplyPattern sets or replaces the stored pattern String.
+// Behavior:
+// - Stores the provided String object (or null) into the "pattern" field.
+// - Initializes FieldTable if needed.
+// - Returns nil (void).
+func sdfApplyPattern(params []interface{}) interface{} {
+	if len(params) < 2 {
+		return nil
+	}
+	obj, _ := params[0].(*object.Object)
+	if obj == nil {
+		return nil
+	}
+	if obj.FieldTable == nil {
+		obj.FieldTable = make(map[string]object.Field)
+	}
+	s, _ := params[1].(*object.Object)
+	obj.FieldTable["pattern"] = object.Field{Ftype: types.StringClassRef, Fvalue: s}
+	return nil
+}

--- a/src/gfunction/javaTextSimpleDateFormat_test.go
+++ b/src/gfunction/javaTextSimpleDateFormat_test.go
@@ -1,0 +1,209 @@
+package gfunction
+
+import (
+	"jacobin/src/globals"
+	"jacobin/src/object"
+	"jacobin/src/types"
+	"testing"
+)
+
+// Helpers
+func newSDFObj() *object.Object {
+	className := "java/text/SimpleDateFormat"
+	return object.MakeEmptyObjectWithClassName(&className)
+}
+
+func sdfStr(s string) *object.Object { return object.StringObjectFromGoString(s) }
+
+func TestSimpleDateFormat_MethodRegistration(t *testing.T) {
+	// Ensure the string pool is initialized for class names and strings.
+	globals.InitStringPool()
+
+	// Clear and load just the SDF methods to MethodSignatures map for this test context.
+	MethodSignatures = make(map[string]GMeth)
+	Load_Math_SimpleDateFormat()
+
+	// Verify a few critical registrations and their ParamSlots.
+	tests := []struct {
+		key   string
+		slots int
+	}{
+		{"java/text/SimpleDateFormat.<init>()V", 0},
+		{"java/text/SimpleDateFormat.<init>(Ljava/lang/String;)V", 1},
+		{"java/text/SimpleDateFormat.clone()Ljava/lang/Object;", 0},
+		{"java/text/SimpleDateFormat.toPattern()Ljava/lang/String;", 0},
+		{"java/text/SimpleDateFormat.applyPattern(Ljava/lang/String;)V", 1},
+		{"java/text/SimpleDateFormat.applyLocalizedPattern(Ljava/lang/String;)V", 1},
+	}
+
+	for _, tc := range tests {
+		gm, ok := MethodSignatures[tc.key]
+		if !ok {
+			t.Fatalf("Method signature not registered: %s", tc.key)
+		}
+		if gm.ParamSlots != tc.slots {
+			t.Fatalf("ParamSlots mismatch for %s: want %d, got %d", tc.key, tc.slots, gm.ParamSlots)
+		}
+		if gm.GFunction == nil {
+			t.Fatalf("GFunction pointer is nil for %s", tc.key)
+		}
+	}
+}
+
+func TestSimpleDateFormat_Init_NoPattern(t *testing.T) {
+	globals.InitStringPool()
+
+	obj := newSDFObj()
+	// Pre-populate a dummy field to ensure constructor clears/initializes FieldTable anew.
+	obj.FieldTable["dummy"] = object.Field{Ftype: types.Int, Fvalue: int64(1)}
+
+	ret := sdfInit([]interface{}{obj})
+	if ret != nil {
+		t.Fatalf("sdfInit returned non-nil: %v", ret)
+	}
+	if obj.FieldTable == nil {
+		t.Fatalf("FieldTable is nil after sdfInit")
+	}
+	if _, exists := obj.FieldTable["dummy"]; exists {
+		t.Fatalf("FieldTable was not reinitialized; unexpected 'dummy' key remains")
+	}
+}
+
+func TestSimpleDateFormat_Init_WithPattern(t *testing.T) {
+	globals.InitStringPool()
+
+	obj := newSDFObj()
+ pat := sdfStr("yyyy-MM-dd")
+
+	ret := sdfInitString([]interface{}{obj, pat})
+	if ret != nil {
+		t.Fatalf("sdfInitString returned non-nil: %v", ret)
+	}
+	fld, ok := obj.FieldTable["pattern"]
+	if !ok {
+		t.Fatalf("pattern field not set by sdfInitString")
+	}
+	if fld.Ftype != types.StringClassRef {
+		t.Fatalf("pattern field Ftype mismatch: want %s, got %s", types.StringClassRef, fld.Ftype)
+	}
+	if fld.Fvalue != pat {
+		t.Fatalf("pattern field Fvalue should be the same String object reference")
+	}
+}
+
+func TestSimpleDateFormat_Init_WithNullPattern(t *testing.T) {
+	globals.InitStringPool()
+
+	obj := newSDFObj()
+	// Pass a nil *object.Object as Java null for the pattern.
+	var nullStr *object.Object = nil
+
+	ret := sdfInitString([]interface{}{obj, nullStr})
+	if ret != nil {
+		t.Fatalf("sdfInitString(null) returned non-nil: %v", ret)
+	}
+	fld, ok := obj.FieldTable["pattern"]
+	if !ok {
+		t.Fatalf("pattern field not set by sdfInitString with null pattern")
+	}
+	if fld.Ftype != types.StringClassRef {
+		t.Fatalf("pattern field Ftype mismatch with null: want %s, got %s", types.StringClassRef, fld.Ftype)
+	}
+ if !object.IsNull(fld.Fvalue) {
+		t.Fatalf("pattern field Fvalue should be Java null for null pattern; got %T", fld.Fvalue)
+	}
+}
+
+func TestSimpleDateFormat_Clone_Minimal(t *testing.T) {
+	globals.InitStringPool()
+
+	obj := newSDFObj()
+	_ = sdfInit([]interface{}{obj})
+
+	cl := sdfClone([]interface{}{obj})
+	clObj, ok := cl.(*object.Object)
+	if !ok || clObj == nil {
+						t.Fatalf("sdfClone should return a non-nil *object.Object, got %T", cl)
+	}
+	if clObj != obj {
+		t.Fatalf("sdfClone minimal behavior should return same object reference")
+	}
+}
+
+func TestSimpleDateFormat_ToPattern_Behavior(t *testing.T) {
+	globals.InitStringPool()
+
+	// 1) With explicit pattern
+	obj1 := newSDFObj()
+	pat1 := sdfStr("yyyy-MM-dd")
+	_ = sdfInitString([]interface{}{obj1, pat1})
+	out1 := sdfToPattern([]interface{}{obj1})
+	if out1 == nil {
+		t.Fatalf("toPattern returned nil for explicit pattern")
+	}
+	so1, ok := out1.(*object.Object)
+	if !ok || so1 == nil {
+		t.Fatalf("toPattern did not return a String object: %T", out1)
+	}
+	if gs := object.GoStringFromStringObject(so1); gs != "yyyy-MM-dd" {
+		t.Fatalf("toPattern mismatch: got %q want %q", gs, "yyyy-MM-dd")
+	}
+
+	// 2) With null pattern -> expect Java null
+	obj2 := newSDFObj()
+	var nullStr *object.Object = nil
+	_ = sdfInitString([]interface{}{obj2, nullStr})
+	out2 := sdfToPattern([]interface{}{obj2})
+	if !object.IsNull(out2) {
+		t.Fatalf("toPattern with null pattern should return null; got %T", out2)
+	}
+
+	// 3) No pattern (default constructor) -> expect empty string
+	obj3 := newSDFObj()
+	_ = sdfInit([]interface{}{obj3})
+	out3 := sdfToPattern([]interface{}{obj3})
+	so3, ok := out3.(*object.Object)
+	if !ok || so3 == nil {
+		t.Fatalf("toPattern with no pattern should return a String object: %T", out3)
+	}
+	if gs := object.GoStringFromStringObject(so3); gs != "" {
+		t.Fatalf("toPattern with no pattern: got %q want empty string", gs)
+	}
+}
+
+
+func TestSimpleDateFormat_ApplyPattern_Behavior(t *testing.T) {
+	globals.InitStringPool()
+
+	// 1) Start with default ctor, then applyPattern("MM/dd/yyyy")
+	obj := newSDFObj()
+	_ = sdfInit([]interface{}{obj})
+	_ = sdfApplyPattern([]interface{}{obj, sdfStr("MM/dd/yyyy")})
+	out := sdfToPattern([]interface{}{obj})
+	so, ok := out.(*object.Object)
+	if !ok || so == nil {
+		t.Fatalf("toPattern after applyPattern should return a String object: %T", out)
+	}
+	if gs := object.GoStringFromStringObject(so); gs != "MM/dd/yyyy" {
+		t.Fatalf("applyPattern did not set pattern: got %q want %q", gs, "MM/dd/yyyy")
+	}
+
+	// 2) applyPattern(null) should set pattern to null
+	_ = sdfApplyPattern([]interface{}{obj, (*object.Object)(nil)})
+	out2 := sdfToPattern([]interface{}{obj})
+	if !object.IsNull(out2) {
+		t.Fatalf("applyPattern(null) should result in toPattern==null; got %T", out2)
+	}
+
+	// 3) applyLocalizedPattern minimal impl behaves the same (loader maps to same Go func)
+	_ = sdfApplyPattern([]interface{}{obj, sdfStr("yyyyMMdd")}) // set to some value first
+	_ = sdfApplyPattern([]interface{}{obj, sdfStr("yyyy-MM")})
+	out3 := sdfToPattern([]interface{}{obj})
+	so3, ok := out3.(*object.Object)
+	if !ok || so3 == nil {
+		t.Fatalf("toPattern after applyLocalizedPattern should return a String object: %T", out3)
+	}
+	if gs := object.GoStringFromStringObject(so3); gs != "yyyy-MM" {
+		t.Fatalf("applyLocalizedPattern behavior mismatch: got %q want %q", gs, "yyyy-MM")
+	}
+}

--- a/src/gfunction/javaUtilDate.go
+++ b/src/gfunction/javaUtilDate.go
@@ -1,0 +1,361 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2025 by  the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package gfunction
+
+import (
+	"fmt"
+	"jacobin/src/excNames"
+	"jacobin/src/object"
+	"jacobin/src/types"
+	"time"
+)
+
+func Load_Util_Date() {
+
+	MethodSignatures["java/util/Date.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  clinitGeneric,
+		}
+
+	MethodSignatures["java/util/Date.<init>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  udateInit,
+		}
+
+	MethodSignatures["java/util/Date.<init>(III)V"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  udateInit3Ints,
+		}
+
+	MethodSignatures["java/util/Date.<init>(IIIII)V"] =
+		GMeth{
+			ParamSlots: 5,
+			GFunction:  udateInit5Ints,
+		}
+
+	MethodSignatures["java/util/Date.<init>(IIIIII)V"] =
+		GMeth{
+			ParamSlots: 6,
+			GFunction:  udateInit6Ints,
+		}
+
+	MethodSignatures["java/util/Date.<init>(J)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  udateInitLong,
+		}
+
+	MethodSignatures["java/util/Date.<init>(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  udateInitString,
+		}
+
+	MethodSignatures["java/util/Date.after(Ljava/util/Date;)Z"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  udateAfter,
+		}
+
+	MethodSignatures["java/util/Date.before(Ljava/util/Date;)Z"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  udateBefore,
+		}
+
+	MethodSignatures["java/util/Date.clone()Ljava/lang/Object;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  udateClone,
+		}
+
+	MethodSignatures["java/util/Date.equals(Ljava/lang/Object;)Z"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  udateEquals,
+		}
+
+	MethodSignatures["java/util/Date.hashCode()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  udateHashCode,
+		}
+
+	// --- Deprecated getters ---
+	MethodSignatures["java/util/Date.getDate()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
+		}
+	MethodSignatures["java/util/Date.getDay()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
+		}
+	MethodSignatures["java/util/Date.getHours()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
+		}
+	MethodSignatures["java/util/Date.getMinutes()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
+		}
+	MethodSignatures["java/util/Date.getMonth()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
+		}
+	MethodSignatures["java/util/Date.getSeconds()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures["java/util/Date.getTime()J"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  udateGetTime,
+		}
+
+	// --- Deprecated setters ---
+	MethodSignatures["java/util/Date.setDate(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapDeprecated,
+		}
+	MethodSignatures["java/util/Date.setHours(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapDeprecated,
+		}
+	MethodSignatures["java/util/Date.setMinutes(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapDeprecated,
+		}
+	MethodSignatures["java/util/Date.setMonth(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapDeprecated,
+		}
+	MethodSignatures["java/util/Date.setSeconds(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapDeprecated,
+		}
+
+	MethodSignatures["java/util/Date.setTime(J)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  udateSetTime,
+		}
+
+	MethodSignatures["java/util/Date.toString()Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  udateToString,
+		}
+}
+
+// === java/util/Date minimal implementation ===
+
+const dateValueField = "value" // store milliseconds since epoch (UTC) as types.Long
+
+// udateInit: no-arg constructor -> initialize to current time in milliseconds.
+func udateInit(params []interface{}) interface{} {
+	if len(params) < 1 {
+		return nil
+	}
+	obj, ok := params[0].(*object.Object)
+	if !ok || obj == nil {
+		return getGErrBlk(excNames.IllegalArgumentException, "udateInit: self is not an object")
+	}
+	object.ClearFieldTable(obj)
+	millis := time.Now().UnixMilli()
+	obj.FieldTable[dateValueField] = object.Field{Ftype: types.Long, Fvalue: millis}
+	return nil
+}
+
+// Deprecated ctors: return a trap indicating deprecation (unsupported).
+func udateInit3Ints(params []interface{}) interface{}  { return trapDeprecated(params) }
+func udateInit5Ints(params []interface{}) interface{}  { return trapDeprecated(params) }
+func udateInit6Ints(params []interface{}) interface{}  { return trapDeprecated(params) }
+func udateInitString(params []interface{}) interface{} { return trapDeprecated(params) }
+
+// Construct from long milliseconds.
+func udateInitLong(params []interface{}) interface{} {
+	if len(params) < 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "udateInitLong: missing millis parameter")
+	}
+	obj, ok := params[0].(*object.Object)
+	if !ok || obj == nil {
+		return getGErrBlk(excNames.IllegalArgumentException, "udateInitLong: self is not an object")
+	}
+	millis, ok := params[1].(int64)
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "udateInitLong: millis parameter is not a long")
+	}
+	object.ClearFieldTable(obj)
+	obj.FieldTable[dateValueField] = object.Field{Ftype: types.Long, Fvalue: millis}
+	return nil
+}
+
+// Helper to get millis and maybe error.
+func dateGetMillis(obj *object.Object) (int64, interface{}) {
+	if obj == nil {
+		return 0, getGErrBlk(excNames.NullPointerException, "Date object is null")
+	}
+	fld, ok := obj.FieldTable[dateValueField]
+	if !ok {
+		return 0, getGErrBlk(excNames.IllegalStateException, "Date value field missing")
+	}
+	millis, ok := fld.Fvalue.(int64)
+	if !ok {
+		return 0, getGErrBlk(excNames.IllegalStateException, "Date value field not a long")
+	}
+	return millis, nil
+}
+
+func udateAfter(params []interface{}) interface{} {
+	if len(params) < 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "udateAfter: requires this and other Date")
+	}
+	this, _ := params[0].(*object.Object)
+	other, _ := params[1].(*object.Object)
+	m1, err := dateGetMillis(this)
+	if err != nil {
+		return err
+	}
+	m2, err2 := dateGetMillis(other)
+	if err2 != nil {
+		return err2
+	}
+	if m1 > m2 {
+		return types.JavaBoolTrue
+	}
+	return types.JavaBoolFalse
+}
+
+func udateBefore(params []interface{}) interface{} {
+	if len(params) < 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "udateBefore: requires this and other Date")
+	}
+	this, _ := params[0].(*object.Object)
+	other, _ := params[1].(*object.Object)
+	m1, err := dateGetMillis(this)
+	if err != nil {
+		return err
+	}
+	m2, err2 := dateGetMillis(other)
+	if err2 != nil {
+		return err2
+	}
+	if m1 < m2 {
+		return types.JavaBoolTrue
+	}
+	return types.JavaBoolFalse
+}
+
+func udateClone(params []interface{}) interface{} {
+	if len(params) < 1 {
+		return object.Null
+	}
+	obj, _ := params[0].(*object.Object)
+	if obj == nil {
+		return object.Null
+	}
+	return object.CloneObject(obj)
+}
+
+func udateEquals(params []interface{}) interface{} {
+	if len(params) < 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "udateEquals: requires this and other Object")
+	}
+	this, _ := params[0].(*object.Object)
+	other, _ := params[1].(*object.Object)
+	// If other is null, return false
+	if object.IsNull(other) {
+		return types.JavaBoolFalse
+	}
+	m1, err := dateGetMillis(this)
+	if err != nil {
+		return err
+	}
+	m2, err2 := dateGetMillis(other)
+	if err2 != nil {
+		return err2
+	}
+	if m1 == m2 {
+		return types.JavaBoolTrue
+	}
+	return types.JavaBoolFalse
+}
+
+func udateHashCode(params []interface{}) interface{} {
+	if len(params) < 1 {
+		return getGErrBlk(excNames.IllegalArgumentException, "udateHashCode: requires this")
+	}
+	this, _ := params[0].(*object.Object)
+	m, err := dateGetMillis(this)
+	if err != nil {
+		return err
+	}
+	// Java Date.hashCode: (int)(value ^ (value >>> 32))
+	h := int32(m ^ (m >> 32))
+	return int64(h)
+}
+
+func udateGetTime(params []interface{}) interface{} {
+	if len(params) < 1 {
+		return getGErrBlk(excNames.IllegalArgumentException, "udateGetTime: requires this")
+	}
+	this, _ := params[0].(*object.Object)
+	m, err := dateGetMillis(this)
+	if err != nil {
+		return err
+	}
+	return m
+}
+
+func udateSetTime(params []interface{}) interface{} {
+	if len(params) < 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "udateSetTime: requires this and millis")
+	}
+	this, _ := params[0].(*object.Object)
+	if this == nil {
+		return getGErrBlk(excNames.NullPointerException, "udateSetTime: this is null")
+	}
+	m, ok := params[1].(int64)
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "udateSetTime: millis is not a long")
+	}
+	fld := object.Field{Ftype: types.Long, Fvalue: m}
+	this.FieldTable[dateValueField] = fld
+	return nil
+}
+
+func udateToString(params []interface{}) interface{} {
+	if len(params) < 1 {
+		return object.StringObjectFromGoString("null")
+	}
+	this, _ := params[0].(*object.Object)
+	m, err := dateGetMillis(this)
+	if err != nil {
+		// On error, return an informative string
+		msg := fmt.Sprintf("Date[error:%T]", err)
+		return object.StringObjectFromGoString(msg)
+	}
+	// Minimal readable format: RFC3339-like in local time for friendliness.
+	t := time.UnixMilli(m).Local()
+	// Use Go's default formatting; Java's exact format is not replicated.
+	return object.StringObjectFromGoString(t.String())
+}

--- a/src/gfunction/javaUtilDate_test.go
+++ b/src/gfunction/javaUtilDate_test.go
@@ -1,0 +1,201 @@
+package gfunction
+
+import (
+	"jacobin/src/excNames"
+	"jacobin/src/globals"
+	"jacobin/src/object"
+	"jacobin/src/types"
+	"testing"
+	"time"
+)
+
+// Helpers
+func newDateObj(t *testing.T) *object.Object {
+	// Create an empty Date object with correct class name
+	className := "java/util/Date"
+	obj := object.MakeEmptyObjectWithClassName(&className)
+	if obj == nil {
+		t.Fatalf("failed to allocate Date object")
+	}
+	return obj
+}
+
+func assertJavaBoolDate(t *testing.T, got interface{}, want int64, msg string) {
+	t.Helper()
+	b, ok := got.(int64)
+	if !ok {
+		if geb, ok := got.(*GErrBlk); ok {
+			t.Fatalf("%s: expected Java boolean, got GErrBlk %d (%s)", msg, geb.ExceptionType, geb.ErrMsg)
+		}
+		t.Fatalf("%s: expected Java boolean (int64), got %T", msg, got)
+	}
+	if b != want {
+		t.Fatalf("%s: expected %d, got %d", msg, want, b)
+	}
+}
+
+func TestJavaUtilDate_MethodRegistration(t *testing.T) {
+	globals.InitStringPool()
+	MethodSignatures = make(map[string]GMeth)
+	Load_Util_Date()
+
+	cases := []struct{
+		key   string
+		slots int
+	}{
+		{"java/util/Date.<init>()V", 0},
+		{"java/util/Date.<init>(J)V", 1},
+		{"java/util/Date.after(Ljava/util/Date;)Z", 1},
+		{"java/util/Date.before(Ljava/util/Date;)Z", 1},
+		{"java/util/Date.equals(Ljava/lang/Object;)Z", 1},
+		{"java/util/Date.getTime()J", 0},
+		{"java/util/Date.setTime(J)V", 1},
+		{"java/util/Date.hashCode()I", 0},
+		{"java/util/Date.clone()Ljava/lang/Object;", 0},
+		{"java/util/Date.toString()Ljava/lang/String;", 0},
+	}
+	for _, c := range cases {
+		gm, ok := MethodSignatures[c.key]
+		if !ok {
+			t.Fatalf("method not registered: %s", c.key)
+		}
+		if gm.ParamSlots != c.slots {
+			t.Fatalf("ParamSlots mismatch for %s: want %d got %d", c.key, c.slots, gm.ParamSlots)
+		}
+		if gm.GFunction == nil {
+			t.Fatalf("GFunction is nil for %s", c.key)
+		}
+	}
+}
+
+func TestJavaUtilDate_Init_CurrentTime(t *testing.T) {
+	globals.InitStringPool()
+
+	obj := newDateObj(t)
+	now := time.Now().UnixMilli()
+	if ret := udateInit([]interface{}{obj}); ret != nil {
+		if geb, ok := ret.(*GErrBlk); ok {
+			t.Fatalf("udateInit returned error: %d %s", geb.ExceptionType, geb.ErrMsg)
+		}
+		t.Fatalf("udateInit returned non-nil: %v", ret)
+	}
+	// getTime should be within a reasonable window around now
+	gt := udateGetTime([]interface{}{obj})
+	millis, ok := gt.(int64)
+	if !ok {
+		t.Fatalf("getTime type: expected int64, got %T", gt)
+	}
+	// allow for a 10-second skew (generous for CI)
+	if millis < now-10_000 || millis > now+10_000 {
+		t.Fatalf("constructed time %d not within 10s of now %d", millis, now)
+	}
+}
+
+func TestJavaUtilDate_InitLong_And_GetSetTime(t *testing.T) {
+	globals.InitStringPool()
+
+	obj := newDateObj(t)
+	const base int64 = 1_700_000_000_000 // a stable fixed millis value
+	if ret := udateInitLong([]interface{}{obj, base}); ret != nil {
+		t.Fatalf("udateInitLong returned error: %v", ret)
+	}
+	if got := udateGetTime([]interface{}{obj}).(int64); got != base {
+		t.Fatalf("getTime after initLong: got %d want %d", got, base)
+	}
+	// setTime then verify
+	const newer int64 = base + 12345
+	if ret := udateSetTime([]interface{}{obj, newer}); ret != nil {
+		t.Fatalf("setTime returned error: %v", ret)
+	}
+	if got := udateGetTime([]interface{}{obj}).(int64); got != newer {
+		t.Fatalf("getTime after setTime: got %d want %d", got, newer)
+	}
+}
+
+func TestJavaUtilDate_Deprecated_Constructors_Trap(t *testing.T) {
+	globals.InitStringPool()
+	obj := newDateObj(t)
+	cases := []interface{}{
+		udateInit3Ints([]interface{}{obj, int64(1), int64(2), int64(3)}),
+		udateInit5Ints([]interface{}{obj, int64(1), int64(2), int64(3), int64(4), int64(5)}),
+		udateInit6Ints([]interface{}{obj, int64(1), int64(2), int64(3), int64(4), int64(5), int64(6)}),
+		udateInitString([]interface{}{obj, object.StringObjectFromGoString("2020-01-01")}),
+	}
+	for i, ret := range cases {
+		geb, ok := ret.(*GErrBlk)
+		if !ok {
+			t.Fatalf("case %d: expected GErrBlk for deprecated ctor, got %T", i, ret)
+		}
+		if geb.ExceptionType != excNames.UnsupportedOperationException {
+			t.Fatalf("case %d: expected UnsupportedOperationException, got %d", i, geb.ExceptionType)
+		}
+	}
+}
+
+func TestJavaUtilDate_After_Before_Equals(t *testing.T) {
+	globals.InitStringPool()
+	// d1 < d2
+	d1 := newDateObj(t)
+	d2 := newDateObj(t)
+	_ = udateInitLong([]interface{}{d1, int64(1000)})
+	_ = udateInitLong([]interface{}{d2, int64(2000)})
+
+ assertJavaBoolDate(t, udateBefore([]interface{}{d1, d2}), types.JavaBoolTrue, "1000 before 2000")
+ assertJavaBoolDate(t, udateAfter([]interface{}{d1, d2}), types.JavaBoolFalse, "1000 after 2000 should be false")
+ assertJavaBoolDate(t, udateAfter([]interface{}{d2, d1}), types.JavaBoolTrue, "2000 after 1000")
+ assertJavaBoolDate(t, udateBefore([]interface{}{d2, d1}), types.JavaBoolFalse, "2000 before 1000 should be false")
+
+	// equals
+ assertJavaBoolDate(t, udateEquals([]interface{}{d1, d1}), types.JavaBoolTrue, "equals self true")
+ assertJavaBoolDate(t, udateEquals([]interface{}{d1, d2}), types.JavaBoolFalse, "equals different false")
+	var nullObj *object.Object = nil
+ assertJavaBoolDate(t, udateEquals([]interface{}{d1, nullObj}), types.JavaBoolFalse, "equals null false")
+}
+
+func TestJavaUtilDate_Clone_And_HashCode(t *testing.T) {
+	globals.InitStringPool()
+	obj := newDateObj(t)
+	// Use a deterministic millis to compute expected hash
+	const v int64 = 0x0123456789ABCDEF
+	_ = udateInitLong([]interface{}{obj, v})
+	cl := udateClone([]interface{}{obj})
+	clObj, ok := cl.(*object.Object)
+	if !ok || clObj == nil {
+		t.Fatalf("clone returned invalid object: %T", cl)
+	}
+	if clObj == obj {
+		t.Fatalf("clone should return a distinct object pointer")
+	}
+	// Millis should be equal
+	mv := udateGetTime([]interface{}{clObj}).(int64)
+	if mv != v {
+		t.Fatalf("clone millis mismatch: got %d want %d", mv, v)
+	}
+	// HashCode per Java: (int)(v ^ (v >>> 32)) as int64 in our impl
+	upper := int64(uint64(v) >> 32)
+	x := v ^ upper
+	expectedHash := int64(int32(x))
+	gotHash := udateHashCode([]interface{}{obj}).(int64)
+	if gotHash != expectedHash {
+		t.Fatalf("hashCode mismatch: got %d want %d", gotHash, expectedHash)
+	}
+}
+
+func TestJavaUtilDate_ToString_Sane(t *testing.T) {
+	globals.InitStringPool()
+	obj := newDateObj(t)
+	_ = udateInitLong([]interface{}{obj, int64(1_700_000_000_000)})
+	strObj := udateToString([]interface{}{obj})
+	so, ok := strObj.(*object.Object)
+	if !ok || so == nil {
+		t.Fatalf("toString did not return a String object: %T", strObj)
+	}
+	gs := object.GoStringFromStringObject(so)
+	if gs == "" {
+		t.Fatalf("toString returned empty string")
+	}
+	// It should not be our explicit error marker prefix
+	if len(gs) >= 5 && gs[:5] == "Date[" {
+		t.Fatalf("toString returned an error marker: %q", gs)
+	}
+}

--- a/src/gfunction/javaUtilTimeZone.go
+++ b/src/gfunction/javaUtilTimeZone.go
@@ -1,0 +1,421 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2025 by  the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package gfunction
+
+import (
+	"jacobin/src/excNames"
+	"jacobin/src/object"
+	"jacobin/src/types"
+	"time"
+)
+
+const (
+	fieldTZID        = "id"
+	fieldRawOffset   = "rawOffset"   // milliseconds
+	fieldDSTSavings  = "dstSavings"  // milliseconds
+)
+
+func Load_Util_TimeZone() {
+	MethodSignatures["java/util/TimeZone.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  clinitGeneric,
+		}
+
+	MethodSignatures["java/util/TimeZone.<init>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  tzInit,
+		}
+
+	MethodSignatures["java/util/TimeZone.clone()Ljava/lang/Object;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  txClone,
+		}
+
+	MethodSignatures["java/util/TimeZone.getAvailableIDs()[Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  tzGetAvailableIDs,
+		}
+
+	MethodSignatures["java/util/TimeZone.getAvailableIDs(I)[Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  tzGetAvailableIDsInt,
+		}
+
+	MethodSignatures["java/util/TimeZone.getDefault()Ljava/util/TimeZone;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/TimeZone.getDisplayName()Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  tzGetDisplayName,
+		}
+
+	MethodSignatures["java/util/TimeZone.getDisplayName(ZI)Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 2,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/TimeZone.getDisplayName(ZILjava/util/Locale;)Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/TimeZone.getDisplayName(Ljava/util/Locale;)Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/TimeZone.getDSTSavings()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  ttzGetDSTSavings,
+		}
+
+	MethodSignatures["java/util/TimeZone.getID()Ljava/lang/String;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  tzGetID,
+		}
+
+	MethodSignatures["java/util/TimeZone.getOffset(IIIII)I"] =
+		GMeth{
+			ParamSlots: 6,
+			GFunction:  tzGetOffset,
+		}
+
+	MethodSignatures["java/util/TimeZone.getOffset(J)I"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  tzGetOffsetLong,
+		}
+
+	MethodSignatures["java/util/TimeZone.getRawOffset()I"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  tzGetRawOffset,
+		}
+
+	MethodSignatures["java/util/TimeZone.getTimeZone(Ljava/lang/String;)Ljava/util/TimeZone;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  tzGetTimeZoneString,
+		}
+
+	MethodSignatures["java/util/TimeZone.getTimeZone(Ljava/time/ZoneId;)Ljava/util/TimeZone;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/util/TimeZone.hasSameRules(Ljava/util/TimeZone;)Z"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  tzHasSameRules,
+		}
+
+	MethodSignatures["java/util/TimeZone.inDaylightTime(Ljava/util/Date;)Z"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  tzInDaylightTime,
+		}
+
+	MethodSignatures["java/util/TimeZone.observesDaylightTime()Z"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  tzObservesDaylightTime,
+		}
+
+	MethodSignatures["java/util/TimeZone.setDefault(Ljava/util/TimeZone;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  tzSetDefault,
+		}
+
+	MethodSignatures["java/util/TimeZone.setID(Ljava/lang/String;)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  tzSetID,
+		}
+
+	MethodSignatures["java/util/TimeZone.setRawOffset(I)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  tzSetRawOffset,
+		}
+
+ MethodSignatures["java/util/TimeZone.toZoneId()Ljava/time/ZoneId;"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+}
+
+// --- Helpers ---
+func tzGetStringID(obj *object.Object) (string, interface{}) {
+	if obj == nil {
+		return "", getGErrBlk(excNames.NullPointerException, "TimeZone object is null")
+	}
+	fld, ok := obj.FieldTable[fieldTZID]
+	if !ok {
+		return "", getGErrBlk(excNames.IllegalStateException, "TimeZone id field missing")
+	}
+	so, _ := fld.Fvalue.(*object.Object)
+	if so == nil {
+		return "", nil // treat null as empty
+	}
+	return object.GoStringFromStringObject(so), nil
+}
+
+func tzComputeOffsetsForID(id string) (rawMS int64, dstMS int64) {
+	if id == "" || id == "UTC" || id == "GMT" {
+		return 0, 0
+	}
+	loc, err := time.LoadLocation(id)
+	if err != nil {
+		return 0, 0
+	}
+	now := time.Now()
+	y := now.Year()
+	w1 := time.Date(y, 1, 1, 0, 0, 0, 0, loc)
+	w2 := time.Date(y, 7, 1, 0, 0, 0, 0, loc)
+	_, off1 := w1.Zone()
+	_, off2 := w2.Zone()
+	std := off1
+	if off2 < std { std = off2 }
+	// dst savings estimated as absolute difference
+	diff := off1 - off2
+	if diff < 0 { diff = -diff }
+	return int64(std) * 1000, int64(diff) * 1000
+}
+
+func tzCurrentOffsetAt(id string, millis int64) int64 {
+	if id == "" || id == "UTC" || id == "GMT" {
+		return 0
+	}
+	loc, err := time.LoadLocation(id)
+	if err != nil {
+		// fallback to raw offset computed from ID
+		raw, _ := tzComputeOffsetsForID(id)
+		return raw
+	}
+	t := time.UnixMilli(millis).In(loc)
+	_, off := t.Zone()
+	return int64(off) * 1000
+}
+
+func tzEnsureFields(obj *object.Object) {
+	if obj.FieldTable == nil {
+		obj.FieldTable = make(map[string]object.Field)
+	}
+	if _, ok := obj.FieldTable[fieldTZID]; !ok {
+		obj.FieldTable[fieldTZID] = object.Field{Ftype: types.StringClassRef, Fvalue: object.StringObjectFromGoString("UTC")}
+	}
+	if _, ok := obj.FieldTable[fieldRawOffset]; !ok {
+		obj.FieldTable[fieldRawOffset] = object.Field{Ftype: types.Int, Fvalue: int64(0)}
+	}
+	if _, ok := obj.FieldTable[fieldDSTSavings]; !ok {
+		obj.FieldTable[fieldDSTSavings] = object.Field{Ftype: types.Int, Fvalue: int64(0)}
+	}
+}
+
+// --- Implementations ---
+
+func tzInit(params []interface{}) interface{} {
+	obj, _ := params[0].(*object.Object)
+	if obj == nil { return getGErrBlk(excNames.IllegalArgumentException, "tzInit: self not object") }
+	object.ClearFieldTable(obj)
+	obj.FieldTable[fieldTZID] = object.Field{Ftype: types.StringClassRef, Fvalue: object.StringObjectFromGoString("UTC")}
+	obj.FieldTable[fieldRawOffset] = object.Field{Ftype: types.Int, Fvalue: int64(0)}
+	obj.FieldTable[fieldDSTSavings] = object.Field{Ftype: types.Int, Fvalue: int64(0)}
+	return nil
+}
+
+// Note: loader references txClone; provide that symbol
+func txClone(params []interface{}) interface{} {
+	if len(params) < 1 { return object.Null }
+	obj, _ := params[0].(*object.Object)
+	if obj == nil { return object.Null }
+	return object.CloneObject(obj)
+}
+
+func tzGetAvailableIDs(params []interface{}) interface{} {
+	// Minimal list
+	ids := []string{"UTC", "GMT"}
+	arr := make([]*object.Object, 0, len(ids))
+	for _, id := range ids {
+		arr = append(arr, object.StringObjectFromGoString(id))
+	}
+	return object.MakeArrayFromRawArray(arr)
+}
+
+func tzGetAvailableIDsInt(params []interface{}) interface{} {
+	if len(params) < 2 { return getGErrBlk(excNames.IllegalArgumentException, "tzGetAvailableIDsInt: need rawOffset") }
+	off, _ := params[1].(int64)
+	if off == 0 {
+		return tzGetAvailableIDs(nil)
+	}
+	// No other known IDs in minimal implementation
+	return object.MakeArrayFromRawArray([]*object.Object{})
+}
+
+func tzGetDisplayName(params []interface{}) interface{} {
+	obj, _ := params[0].(*object.Object)
+	if obj == nil { return getGErrBlk(excNames.IllegalArgumentException, "tzGetDisplayName: self not object") }
+	id, err := tzGetStringID(obj)
+	if err != nil { return err }
+	return object.StringObjectFromGoString(id)
+}
+
+func ttzGetDSTSavings(params []interface{}) interface{} {
+	obj, _ := params[0].(*object.Object)
+	if obj == nil { return int64(0) }
+	fld := obj.FieldTable[fieldDSTSavings]
+	val, ok := fld.Fvalue.(int64)
+	if !ok { return int64(0) }
+	return val
+}
+
+func tzGetID(params []interface{}) interface{} {
+	obj, _ := params[0].(*object.Object)
+	if obj == nil { return getGErrBlk(excNames.IllegalArgumentException, "tzGetID: self not object") }
+	id, err := tzGetStringID(obj)
+	if err != nil { return err }
+	return object.StringObjectFromGoString(id)
+}
+
+func tzGetOffset(params []interface{}) interface{} {
+	// Minimal: return raw offset only
+	obj, _ := params[0].(*object.Object)
+	if obj == nil { return getGErrBlk(excNames.IllegalArgumentException, "tzGetOffset: self not object") }
+	fld := obj.FieldTable[fieldRawOffset]
+	val, ok := fld.Fvalue.(int64)
+	if !ok { return int64(0) }
+	return val
+}
+
+func tzGetOffsetLong(params []interface{}) interface{} {
+	if len(params) < 2 { return getGErrBlk(excNames.IllegalArgumentException, "tzGetOffsetLong: need millis") }
+	obj, _ := params[0].(*object.Object)
+	millis, _ := params[1].(int64)
+	if obj == nil { return int64(0) }
+	id, err := tzGetStringID(obj)
+	if err != nil { return err }
+	if id == "" { // fallback to raw
+		fld := obj.FieldTable[fieldRawOffset]
+		if v, ok := fld.Fvalue.(int64); ok { return v }
+		return int64(0)
+	}
+	return tzCurrentOffsetAt(id, millis)
+}
+
+func tzGetRawOffset(params []interface{}) interface{} {
+	obj, _ := params[0].(*object.Object)
+	if obj == nil { return getGErrBlk(excNames.IllegalArgumentException, "tzGetRawOffset: self not object") }
+	fld := obj.FieldTable[fieldRawOffset]
+	if v, ok := fld.Fvalue.(int64); ok { return v }
+	return int64(0)
+}
+
+func tzGetTimeZoneString(params []interface{}) interface{} {
+	if len(params) < 1 { return object.Null }
+	// First param is this? For static method, receiver is absent; in our calling convention, params[0] is the ID String
+	idObj, _ := params[0].(*object.Object)
+	if idObj == nil { return object.Null }
+	id := object.GoStringFromStringObject(idObj)
+	className := "java/util/TimeZone"
+	obj := object.MakeEmptyObjectWithClassName(&className)
+	object.ClearFieldTable(obj)
+	raw, dst := tzComputeOffsetsForID(id)
+	obj.FieldTable[fieldTZID] = object.Field{Ftype: types.StringClassRef, Fvalue: object.StringObjectFromGoString(id)}
+	obj.FieldTable[fieldRawOffset] = object.Field{Ftype: types.Int, Fvalue: raw}
+	obj.FieldTable[fieldDSTSavings] = object.Field{Ftype: types.Int, Fvalue: dst}
+	return obj
+}
+
+func tzHasSameRules(params []interface{}) interface{} {
+	obj, _ := params[0].(*object.Object)
+	other, _ := params[1].(*object.Object)
+	if obj == nil || other == nil { return types.JavaBoolFalse }
+	r1, ok1 := obj.FieldTable[fieldRawOffset].Fvalue.(int64)
+	r2, ok2 := other.FieldTable[fieldRawOffset].Fvalue.(int64)
+	d1, ok3 := obj.FieldTable[fieldDSTSavings].Fvalue.(int64)
+	d2, ok4 := other.FieldTable[fieldDSTSavings].Fvalue.(int64)
+	if ok1 && ok2 && ok3 && ok4 && r1 == r2 && d1 == d2 {
+		return types.JavaBoolTrue
+	}
+	return types.JavaBoolFalse
+}
+
+func tzInDaylightTime(params []interface{}) interface{} {
+	obj, _ := params[0].(*object.Object)
+	dateObj, _ := params[1].(*object.Object)
+	if obj == nil || dateObj == nil { return types.JavaBoolFalse }
+	millisVal := udateGetTime([]interface{}{dateObj})
+	millis, ok := millisVal.(int64)
+	if !ok { return types.JavaBoolFalse }
+	id, err := tzGetStringID(obj)
+	if err != nil { return types.JavaBoolFalse }
+	offsetAt := tzCurrentOffsetAt(id, millis)
+	raw := tzGetRawOffset([]interface{}{obj}).(int64)
+	if offsetAt != raw { return types.JavaBoolTrue }
+	return types.JavaBoolFalse
+}
+
+func tzObservesDaylightTime(params []interface{}) interface{} {
+	obj, _ := params[0].(*object.Object)
+	if obj == nil { return types.JavaBoolFalse }
+	dst := ttzGetDSTSavings([]interface{}{obj}).(int64)
+	if dst != 0 { return types.JavaBoolTrue }
+	return types.JavaBoolFalse
+}
+
+var defaultTZ *object.Object = nil
+
+func tzSetDefault(params []interface{}) interface{} {
+	// Set static default; ignore invalid
+	if len(params) < 1 { return nil }
+	tz, _ := params[0].(*object.Object)
+	defaultTZ = tz
+	return nil
+}
+
+func tzSetID(params []interface{}) interface{} {
+	obj, _ := params[0].(*object.Object)
+	idObj, _ := params[1].(*object.Object)
+	if obj == nil { return getGErrBlk(excNames.IllegalArgumentException, "tzSetID: self not object") }
+	if idObj == nil { // set to empty
+		obj.FieldTable[fieldTZID] = object.Field{Ftype: types.StringClassRef, Fvalue: nil}
+		obj.FieldTable[fieldRawOffset] = object.Field{Ftype: types.Int, Fvalue: int64(0)}
+		obj.FieldTable[fieldDSTSavings] = object.Field{Ftype: types.Int, Fvalue: int64(0)}
+		return nil
+	}
+	id := object.GoStringFromStringObject(idObj)
+	raw, dst := tzComputeOffsetsForID(id)
+	obj.FieldTable[fieldTZID] = object.Field{Ftype: types.StringClassRef, Fvalue: object.StringObjectFromGoString(id)}
+	obj.FieldTable[fieldRawOffset] = object.Field{Ftype: types.Int, Fvalue: raw}
+	obj.FieldTable[fieldDSTSavings] = object.Field{Ftype: types.Int, Fvalue: dst}
+	return nil
+}
+
+func tzSetRawOffset(params []interface{}) interface{} {
+	obj, _ := params[0].(*object.Object)
+	if obj == nil { return getGErrBlk(excNames.IllegalArgumentException, "tzSetRawOffset: self not object") }
+	val, _ := params[1].(int64)
+	obj.FieldTable[fieldRawOffset] = object.Field{Ftype: types.Int, Fvalue: val}
+	return nil
+}

--- a/src/gfunction/javaUtilTimeZone_test.go
+++ b/src/gfunction/javaUtilTimeZone_test.go
@@ -1,0 +1,199 @@
+package gfunction
+
+import (
+	"jacobin/src/globals"
+	"jacobin/src/object"
+	"jacobin/src/types"
+	"testing"
+)
+
+// Helpers
+func newTZObj(t *testing.T) *object.Object {
+	t.Helper()
+	className := "java/util/TimeZone"
+	obj := object.MakeEmptyObjectWithClassName(&className)
+	if obj == nil {
+		t.Fatalf("failed to allocate TimeZone object")
+	}
+	return obj
+}
+
+func str(s string) *object.Object { return object.StringObjectFromGoString(s) }
+
+func assertJavaBoolTZ(t *testing.T, got interface{}, want int64, msg string) {
+	t.Helper()
+	b, ok := got.(int64)
+	if !ok {
+		if geb, ok := got.(*GErrBlk); ok {
+			t.Fatalf("%s: expected Java boolean, got GErrBlk %d (%s)", msg, geb.ExceptionType, geb.ErrMsg)
+		}
+		t.Fatalf("%s: expected Java boolean (int64), got %T", msg, got)
+	}
+	if b != want {
+		t.Fatalf("%s: expected %d, got %d", msg, want, b)
+	}
+}
+
+func TestTimeZone_MethodRegistration(t *testing.T) {
+	globals.InitStringPool()
+	MethodSignatures = make(map[string]GMeth)
+	Load_Util_TimeZone()
+
+	cases := []struct {
+		key   string
+		slots int
+	}{
+		{"java/util/TimeZone.<init>()V", 0},
+		{"java/util/TimeZone.clone()Ljava/lang/Object;", 0},
+		{"java/util/TimeZone.getAvailableIDs()[Ljava/lang/String;", 0},
+		{"java/util/TimeZone.getAvailableIDs(I)[Ljava/lang/String;", 1},
+		{"java/util/TimeZone.getDisplayName()Ljava/lang/String;", 0},
+		{"java/util/TimeZone.getDSTSavings()I", 0},
+		{"java/util/TimeZone.getID()Ljava/lang/String;", 0},
+		{"java/util/TimeZone.getOffset(IIIII)I", 6},
+		{"java/util/TimeZone.getOffset(J)I", 1},
+		{"java/util/TimeZone.getRawOffset()I", 0},
+		{"java/util/TimeZone.getTimeZone(Ljava/lang/String;)Ljava/util/TimeZone;", 1},
+		{"java/util/TimeZone.hasSameRules(Ljava/util/TimeZone;)Z", 1},
+		{"java/util/TimeZone.inDaylightTime(Ljava/util/Date;)Z", 1},
+		{"java/util/TimeZone.observesDaylightTime()Z", 0},
+		{"java/util/TimeZone.setDefault(Ljava/util/TimeZone;)V", 1},
+		{"java/util/TimeZone.setID(Ljava/lang/String;)V", 1},
+		{"java/util/TimeZone.setRawOffset(I)V", 1},
+	}
+	for _, c := range cases {
+		gm, ok := MethodSignatures[c.key]
+		if !ok {
+			t.Fatalf("method not registered: %s", c.key)
+		}
+		if gm.ParamSlots != c.slots {
+			t.Fatalf("ParamSlots mismatch for %s: want %d got %d", c.key, c.slots, gm.ParamSlots)
+		}
+		if gm.GFunction == nil {
+			t.Fatalf("GFunction is nil for %s", c.key)
+		}
+	}
+}
+
+func TestTimeZone_Init_DefaultFields(t *testing.T) {
+	globals.InitStringPool()
+	obj := newTZObj(t)
+	if ret := tzInit([]interface{}{obj}); ret != nil {
+		t.Fatalf("tzInit returned error: %v", ret)
+	}
+	// id should be "UTC"
+	id := tzGetID([]interface{}{obj}).(*object.Object)
+	if object.GoStringFromStringObject(id) != "UTC" {
+		t.Fatalf("getID expected UTC, got %q", object.GoStringFromStringObject(id))
+	}
+	// displayName should match id
+	dn := tzGetDisplayName([]interface{}{obj}).(*object.Object)
+	if object.GoStringFromStringObject(dn) != "UTC" {
+		t.Fatalf("getDisplayName expected UTC, got %q", object.GoStringFromStringObject(dn))
+	}
+	// raw/dst should be 0
+	if got := tzGetRawOffset([]interface{}{obj}).(int64); got != 0 {
+		t.Fatalf("rawOffset expected 0, got %d", got)
+	}
+	if got := ttzGetDSTSavings([]interface{}{obj}).(int64); got != 0 {
+		t.Fatalf("dstSavings expected 0, got %d", got)
+	}
+}
+
+func TestTimeZone_Setters_And_Offsets(t *testing.T) {
+	globals.InitStringPool()
+	obj := newTZObj(t)
+	_ = tzInit([]interface{}{obj})
+
+	// Change raw offset and verify getRawOffset and getOffset reflect it
+	_ = tzSetRawOffset([]interface{}{obj, int64(3600 * 1000)}) // +1 hour
+	if got := tzGetRawOffset([]interface{}{obj}).(int64); got != 3600*1000 {
+		t.Fatalf("getRawOffset got %d want %d", got, 3600*1000)
+	}
+	if got := tzGetOffset([]interface{}{obj}).(int64); got != 3600*1000 {
+		t.Fatalf("getOffset(IIIII) minimal impl should return raw, got %d", got)
+	}
+	// getOffset(long) for UTC id remains 0; for non-empty id we rely on tz logic
+	_ = tzSetID([]interface{}{obj, str("UTC")})
+	if got := tzGetOffsetLong([]interface{}{obj, int64(1_700_000_000_000)}).(int64); got != 0 {
+		t.Fatalf("getOffset(long) for UTC expected 0, got %d", got)
+	}
+}
+
+func TestTimeZone_GetTimeZone_Factory_And_Rules(t *testing.T) {
+	globals.InitStringPool()
+	// Static factory: pass String id as single param
+	utcObj := tzGetTimeZoneString([]interface{}{str("UTC")} )
+	if utcObj == nil {
+		t.Fatalf("getTimeZone(UTC) returned nil")
+	}
+	utc := utcObj.(*object.Object)
+	id := tzGetID([]interface{}{utc}).(*object.Object)
+	if object.GoStringFromStringObject(id) != "UTC" {
+		t.Fatalf("factory getID expected UTC, got %q", object.GoStringFromStringObject(id))
+	}
+	// Same rules with another UTC instance
+	utc2 := tzGetTimeZoneString([]interface{}{str("UTC")} ).(*object.Object)
+	assertJavaBoolTZ(t, tzHasSameRules([]interface{}{utc, utc2}), types.JavaBoolTrue, "same rules for two UTCs")
+	// Different rules after rawOffset change
+	_ = tzSetRawOffset([]interface{}{utc2, int64(1234)})
+	assertJavaBoolTZ(t, tzHasSameRules([]interface{}{utc, utc2}), types.JavaBoolFalse, "different rules after raw change")
+}
+
+func TestTimeZone_AvailableIDs_And_InDaylight(t *testing.T) {
+	globals.InitStringPool()
+	arr := tzGetAvailableIDs(nil).(*object.Object)
+	// Expect at least 2 entries (UTC,GMT)
+	if arr == nil {
+		t.Fatalf("getAvailableIDs returned nil")
+	}
+	// Object array is stored as [](*object.Object) in String[]; we can convert via object utilities
+	// However, we only ensure it is a non-null array by relying on not panicking while reading value.
+	// For a stronger check, we create strings and compare by scanning the Go string conversion of each element.
+	// Build simple presence flags.
+	vals, _ := arr.FieldTable["value"].Fvalue.([]*object.Object)
+	foundUTC, foundGMT := false, false
+	for _, e := range vals {
+		if e == nil { continue }
+		v := object.GoStringFromStringObject(e)
+		if v == "UTC" { foundUTC = true }
+		if v == "GMT" { foundGMT = true }
+	}
+	if !foundUTC || !foundGMT {
+		t.Fatalf("available IDs should contain UTC and GMT; got UTC=%v GMT=%v", foundUTC, foundGMT)
+	}
+	// Filter by raw offset: 0 should return non-empty; non-zero returns empty in minimal impl
+	empty := tzGetAvailableIDsInt([]interface{}{nil, int64(123)}).(*object.Object)
+	vals2, _ := empty.FieldTable["value"].Fvalue.([]*object.Object)
+	if len(vals2) != 0 {
+		t.Fatalf("getAvailableIDs(123) expected empty, got %d entries", len(vals2))
+	}
+
+	// inDaylightTime should be false for UTC regardless of date
+	obj := newTZObj(t)
+	_ = tzInit([]interface{}{obj})
+	_ = tzSetID([]interface{}{obj, str("UTC")} )
+	// Construct a Date for some millis
+	d := object.MakeEmptyObjectWithClassName(&[]string{"java/util/Date"}[0])
+	_ = udateInitLong([]interface{}{d, int64(1_700_000_000_000)})
+	assertJavaBoolTZ(t, tzInDaylightTime([]interface{}{obj, d}), types.JavaBoolFalse, "UTC not in DST")
+}
+
+func TestTimeZone_Clone_Minimal(t *testing.T) {
+	globals.InitStringPool()
+	obj := newTZObj(t)
+	_ = tzInit([]interface{}{obj})
+	_ = tzSetRawOffset([]interface{}{obj, int64(999)})
+	cl := txClone([]interface{}{obj})
+	clObj, ok := cl.(*object.Object)
+	if !ok || clObj == nil {
+		t.Fatalf("clone should return *object.Object, got %T", cl)
+	}
+	if clObj == obj {
+		t.Fatalf("clone should return a distinct object pointer")
+	}
+	// Fields copied
+	if got := tzGetRawOffset([]interface{}{clObj}).(int64); got != 999 {
+		t.Fatalf("cloned rawOffset got %d want %d", got, 999)
+	}
+}

--- a/src/object/string.go
+++ b/src/object/string.go
@@ -107,7 +107,8 @@ func GoStringFromStringObject(obj *Object) string {
 		return bytes.(string)
 	}
 
-	return ""
+	return "*** GoStringFromStringObject: unexpected object class: " +
+		fmt.Sprint(GoStringFromStringPoolIndex(obj.KlassName))
 }
 
 // StringObjectArrayFromGoStringArray: convenience method to create a Golang string array from a Java String object array

--- a/src/object/string_test.go
+++ b/src/object/string_test.go
@@ -84,7 +84,7 @@ func TestGoStringFromInvalidObject(t *testing.T) {
 	obj := MakeEmptyObject()
 	obj.FieldTable["value"] = Field{Ftype: types.Int, Fvalue: 42}
 	str := GoStringFromStringObject(obj)
-	if str != "" {
+	if !strings.HasPrefix(str, "*** GoStringFromStringObject") {
 		t.Errorf("expected empty string, observed: '%s'", str)
 	}
 }

--- a/src/wholeClassTests/ArrayLength_test.go
+++ b/src/wholeClassTests/ArrayLength_test.go
@@ -83,7 +83,9 @@ func TestRunArrlen(t *testing.T) {
 	initErr := initVarsArrlen()
 	if initErr != nil {
 		t.Fatalf("Test failure due to: %s", initErr.Error())
+		//t.Skipf("Skipping TestRunArrlen: %s", initErr.Error()) // Created by Junie
 	}
+	t.Logf("initVarsArrlen() ok on class: %s", _TESTCLASS)
 
 	var cmd *exec.Cmd
 	// run the various combinations of args. This is necessary b/c the empty string is viewed as


### PR DESCRIPTION
Miscellaneous updates:
- object/string.go :: instead of returning `""` when encountering an invalid object, report which class of object was the input. Could be enhanced further if desired.
- object/string_test.go :: make unit test look for new error message prefix.
- wholeClassTests/ArrayLength_test.go :: Junie made a strange choice so I fixed it.
- gfunction/javaIoFileInputStream.go :: "java/io/FileInputStream.readNBytes([BII)I" is a new method function reference to an existing method function (they do the same thing). I must have made 2 commits on the same file before pushing.
- gfunction/javaLangString.go :: give a clearer reason why an input object is invalid. Again, I must have made 2 commits on the same file before pushing.
- gfunction/javaMathBigDecimalFuncAtoM.go :: fixed functions
- gfunction/javaMathBigDecimalFuncNtoZ.go :: fixed functions

The new stuff:
- gfunction/javaTextSimpleDateFormat.go :: new class.
- gfunction/javaTextSimpleDateFormat_test.go :: new unit tests.
- gfunction/javaUtilDate.go :: new class.
- gfunction/javaUtilDate_test.go :: new unit tests.
- gfunction/javaUtilTimeZone.go :: new class.
- gfunction/javaUtilTimeZone_test.go :: new unit tests.
- gfunction/gfunction.go :: load the MethodSignatures for the new classes.
- gfunction/javaMathBigDecimalSqrt_test.go :: new unit tests.
- gfunction/javaMathBigDecimal_50digits_test.go :: new unit tests.

