### PR TITLE
JACOBIN-784 unit tests for INSTANCEOF and CHECKCAST; fixed INSTANCEOF; JACOBIN-778 more G functions and related unit tests

### DIFF
--- a/src/gfunction/javaUtilArrays.go
+++ b/src/gfunction/javaUtilArrays.go
@@ -7,35 +7,300 @@
 package gfunction
 
 import (
+	"fmt"
 	"jacobin/src/excNames"
 	"jacobin/src/object"
+	"jacobin/src/types"
+	"strings"
 )
 
 // A partial implementation of the java/util/Arrays class.
 
 func Load_Util_Arrays() {
+
+	MethodSignatures["java/util/Arrays.<clinit>()V"] =
+		GMeth{ParamSlots: 0, GFunction: clinitGeneric}
+
+	// asList
+	MethodSignatures["java/util/Arrays.asList([Ljava/lang/Object;)Ljava/util/List;"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
+	// binarySearch
+	MethodSignatures["java/util/Arrays.binarySearch([B)I"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([B[B)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([B[BI)I"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([BII)I"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([C)I"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([C[C)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([C[CI)I"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([CI)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([D)I"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([D[D)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([D[DI)I"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([DI)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([F)I"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([F[F)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([F[FI)I"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([FI)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([I)I"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([I[I)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([I[II)I"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([II)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([J)I"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([J[J)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([J[JI)I"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([JI)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([S)I"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([S[S)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([S[SI)I"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([SI)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([Z)I"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([Z[Z)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([Z[ZI)I"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.binarySearch([ZI)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+
+	// copyOf
 	MethodSignatures["java/util/Arrays.copyOf([Ljava/lang/Object;I)[Ljava/lang/Object;"] =
 		GMeth{
 			ParamSlots: 2,
-			GFunction:  copyOfObjectPointers,
+			GFunction:  utilArraysCopyOf,
 		}
+	MethodSignatures["java/util/Arrays.copyOf([Ljava/lang/Object;ILjava/lang/Class;)[Ljava/lang/Object;"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
 
-	MethodSignatures["java/util/Arrays.copyOf([Ljava/lang/Object;ILjava/lang/Class;)[Ljava/lang/Object;"] =
-		GMeth{
-			ParamSlots: 3,
-			GFunction:  trapFunction,
+	// equals
+	MethodSignatures["java/util/Arrays.equals([B[B)Z"] = GMeth{ParamSlots: 2, GFunction: utilArraysEquals}
+	MethodSignatures["java/util/Arrays.equals([C[C)Z"] = GMeth{ParamSlots: 2, GFunction: utilArraysEquals}
+	MethodSignatures["java/util/Arrays.equals([D[D)Z"] = GMeth{ParamSlots: 2, GFunction: utilArraysEquals}
+	MethodSignatures["java/util/Arrays.equals([F[F)Z"] = GMeth{ParamSlots: 2, GFunction: utilArraysEquals}
+	MethodSignatures["java/util/Arrays.equals([I[I)Z"] = GMeth{ParamSlots: 2, GFunction: utilArraysEquals}
+	MethodSignatures["java/util/Arrays.equals([J[J)Z"] = GMeth{ParamSlots: 2, GFunction: utilArraysEquals}
+	MethodSignatures["java/util/Arrays.equals([S[S)Z"] = GMeth{ParamSlots: 2, GFunction: utilArraysEquals}
+	MethodSignatures["java/util/Arrays.equals([Z[Z)Z"] = GMeth{ParamSlots: 2, GFunction: utilArraysEquals}
+
+	// fill
+	MethodSignatures["java/util/Arrays.fill([BB)V"] = GMeth{
+		ParamSlots: 2,
+		GFunction:  utilArraysFillBytes,
+	}
+	MethodSignatures["java/util/Arrays.fill([BBII)V"] = GMeth{ParamSlots: 4, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.fill([CC)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.fill([DD)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.fill([FF)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.fill([II)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.fill([JJ)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.fill([SS)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.fill([ZZ)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.fill([Ljava/lang/Object;Ljava/lang/Object;)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.fill([Ljava/lang/Object;IILjava/lang/Object;)V"] = GMeth{ParamSlots: 4, GFunction: trapFunction}
+
+	// hashCode
+	MethodSignatures["java/util/Arrays.hashCode([B)I"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.hashCode([C)I"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.hashCode([D)I"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.hashCode([F)I"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.hashCode([I)I"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.hashCode([J)I"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.hashCode([Ljava/lang/Object;)I"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.hashCode([S)I"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.hashCode([Z)I"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+
+	// mismatch
+	MethodSignatures["java/util/Arrays.mismatch([B[B)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.mismatch([C[C)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.mismatch([D[D)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.mismatch([F[F)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.mismatch([I[I)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.mismatch([J[J)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.mismatch([S[S)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.mismatch([Z[Z)I"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+
+	// parallelPrefix
+	MethodSignatures["java/util/Arrays.parallelPrefix([DLjava/util/function/DoubleBinaryOperator;)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelPrefix([DIILjava/util/function/DoubleBinaryOperator;)V"] = GMeth{ParamSlots: 4, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelPrefix([FLjava/util/function/FloatBinaryOperator;)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelPrefix([FIILjava/util/function/FloatBinaryOperator;)V"] = GMeth{ParamSlots: 4, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelPrefix([ILjava/util/function/IntBinaryOperator;)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelPrefix([IIILjava/util/function/IntBinaryOperator;)V"] = GMeth{ParamSlots: 4, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelPrefix([JLjava/util/function/LongBinaryOperator;)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelPrefix([JIILjava/util/function/LongBinaryOperator;)V"] = GMeth{ParamSlots: 4, GFunction: trapFunction}
+
+	// parallelSetAll
+	MethodSignatures["java/util/Arrays.parallelSetAll([DLjava/util/function/IntToDoubleFunction;)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelSetAll([FLjava/util/function/IntToFloatFunction;)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelSetAll([ILjava/util/function/IntUnaryOperator;)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelSetAll([JLjava/util/function/IntToLongFunction;)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelSetAll([Ljava/lang/Object;Ljava/util/function/IntFunction;)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+
+	// parallelSort
+	MethodSignatures["java/util/Arrays.parallelSort([D)V"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelSort([DII)V"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelSort([F)V"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelSort([FII)V"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelSort([I)V"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelSort([III)V"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelSort([J)V"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelSort([JII)V"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelSort([Ljava/lang/Object;)V"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelSort([Ljava/lang/Object;II)V"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.parallelSort([Ljava/lang/Object;IILjava/util/Comparator;)V"] = GMeth{ParamSlots: 4, GFunction: trapFunction}
+
+	// setAll
+	MethodSignatures["java/util/Arrays.setAll([DLjava/util/function/IntToDoubleFunction;)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.setAll([FLjava/util/function/IntToFloatFunction;)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.setAll([ILjava/util/function/IntUnaryOperator;)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.setAll([JLjava/util/function/IntToLongFunction;)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.setAll([Ljava/lang/Object;Ljava/util/function/IntFunction;)V"] = GMeth{ParamSlots: 2, GFunction: trapFunction}
+
+	// sort
+	MethodSignatures["java/util/Arrays.sort([D)V"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.sort([DII)V"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.sort([F)V"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.sort([FII)V"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.sort([I)V"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.sort([III)V"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.sort([J)V"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.sort([JII)V"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.sort([Ljava/lang/Object;)V"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.sort([Ljava/lang/Object;II)V"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.sort([Ljava/lang/Object;IILjava/util/Comparator;)V"] = GMeth{ParamSlots: 4, GFunction: trapFunction}
+
+	// spliterator
+	MethodSignatures["java/util/Arrays.spliterator([D)Ljava/util/Spliterator$OfDouble;"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.spliterator([F)Ljava/util/Spliterator$OfFloat;"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.spliterator([I)Ljava/util/Spliterator$OfInt;"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.spliterator([J)Ljava/util/Spliterator$OfLong;"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.spliterator([Ljava/lang/Object;)Ljava/util/Spliterator;"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+
+	// stream
+	MethodSignatures["java/util/Arrays.stream([D)Ljava/util/DoubleStream;"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.stream([DII)Ljava/util/DoubleStream;"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.stream([F)Ljava/util/FloatStream;"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.stream([FII)Ljava/util/FloatStream;"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.stream([I)Ljava/util/IntStream;"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.stream([III)Ljava/util/IntStream;"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.stream([J)Ljava/util/LongStream;"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.stream([JII)Ljava/util/LongStream;"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.stream([Ljava/lang/Object;)Ljava/util/Stream;"] = GMeth{ParamSlots: 1, GFunction: trapFunction}
+	MethodSignatures["java/util/Arrays.stream([Ljava/lang/Object;II)Ljava/util/Stream;"] = GMeth{ParamSlots: 3, GFunction: trapFunction}
+
+	// toString
+	MethodSignatures["java/util/Arrays.toString([B)Ljava/lang/String;"] = GMeth{ParamSlots: 1, GFunction: utilArraysToString}
+	MethodSignatures["java/util/Arrays.toString([C)Ljava/lang/String;"] = GMeth{ParamSlots: 1, GFunction: utilArraysToString}
+	MethodSignatures["java/util/Arrays.toString([D)Ljava/lang/String;"] = GMeth{ParamSlots: 1, GFunction: utilArraysToString}
+	MethodSignatures["java/util/Arrays.toString([F)Ljava/lang/String;"] = GMeth{ParamSlots: 1, GFunction: utilArraysToString}
+	MethodSignatures["java/util/Arrays.toString([I)Ljava/lang/String;"] = GMeth{ParamSlots: 1, GFunction: utilArraysToString}
+	MethodSignatures["java/util/Arrays.toString([J)Ljava/lang/String;"] = GMeth{ParamSlots: 1, GFunction: utilArraysToString}
+	MethodSignatures["java/util/Arrays.toString([Ljava/lang/Object;)Ljava/lang/String;"] = GMeth{ParamSlots: 1, GFunction: utilArraysToString}
+	MethodSignatures["java/util/Arrays.toString([S)Ljava/lang/String;"] = GMeth{ParamSlots: 1, GFunction: utilArraysToString}
+	MethodSignatures["java/util/Arrays.toString([Z)Ljava/lang/String;"] = GMeth{ParamSlots: 1, GFunction: utilArraysToString}
+
+}
+
+// Arrays.equals(Object[] a, Object[] b) -> boolean
+// Minimal implementation that compares reference arrays element-wise by reference equality.
+func utilArraysEquals(params []interface{}) interface{} {
+	if len(params) < 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "utilArraysEquals: too few arguments")
+	}
+
+	// Handle nulls per Java semantics
+	if params[0] == nil && params[1] == nil {
+		return types.JavaBoolTrue
+	}
+	if params[0] == nil || params[1] == nil {
+		return types.JavaBoolFalse
+	}
+
+	objA, okA := params[0].(*object.Object)
+	objB, okB := params[1].(*object.Object)
+	if !okA || !okB {
+		return types.JavaBoolFalse
+	}
+
+	fieldA, ok := objA.FieldTable["value"]
+	if !ok {
+		return types.JavaBoolFalse
+	}
+	fieldB, ok := objB.FieldTable["value"]
+	if !ok {
+		return types.JavaBoolFalse
+	}
+
+	switch a := fieldA.Fvalue.(type) {
+	case []*object.Object:
+		b, ok := fieldB.Fvalue.([]*object.Object)
+		if !ok {
+			return types.JavaBoolFalse
 		}
+		if len(a) != len(b) {
+			return types.JavaBoolFalse
+		}
+		for i := 0; i < len(a); i++ {
+			if a[i] != b[i] { // reference equality (nil handled by !=)
+				return types.JavaBoolFalse
+			}
+		}
+		return types.JavaBoolTrue
+	case []types.JavaByte:
+		b, ok := fieldB.Fvalue.([]types.JavaByte)
+		if !ok {
+			return types.JavaBoolFalse
+		}
+		if len(a) != len(b) {
+			return types.JavaBoolFalse
+		}
+		for i := 0; i < len(a); i++ {
+			if a[i] != b[i] {
+				return types.JavaBoolFalse
+			}
+		}
+		return types.JavaBoolTrue
+	case []int64:
+		b, ok := fieldB.Fvalue.([]int64)
+		if !ok {
+			return types.JavaBoolFalse
+		}
+		if len(a) != len(b) {
+			return types.JavaBoolFalse
+		}
+		for i := 0; i < len(a); i++ {
+			if a[i] != b[i] {
+				return types.JavaBoolFalse
+			}
+		}
+		return types.JavaBoolTrue
+	case []float64:
+		b, ok := fieldB.Fvalue.([]float64)
+		if !ok {
+			return types.JavaBoolFalse
+		}
+		if len(a) != len(b) {
+			return types.JavaBoolFalse
+		}
+		for i := 0; i < len(a); i++ {
+			if a[i] != b[i] { // minimal; does not handle NaN bitwise cases
+				return types.JavaBoolFalse
+			}
+		}
+		return types.JavaBoolTrue
+	default:
+		// Unsupported array backing type
+		return types.JavaBoolFalse
+	}
 }
 
 // Copy the specified array of pointers, truncating or padding with nulls so the copy has the specified length.
-func copyOfObjectPointers(params []interface{}) interface{} {
+func utilArraysCopyOf(params []interface{}) interface{} {
 	if len(params) < 2 {
-		return getGErrBlk(excNames.IllegalArgumentException, "copyOfObjectPointers: too few arguments")
+		return getGErrBlk(excNames.IllegalArgumentException, "utilArraysCopyOf: too few arguments")
 	}
 
 	// Check for a null array.
 	if params[0] == nil {
-		return getGErrBlk(excNames.NullPointerException, "copyOfObjectPointers: null array argument")
+		return getGErrBlk(excNames.NullPointerException, "utilArraysCopyOf: null array argument")
 	}
 
 	// Extract the array and the new length.
@@ -44,7 +309,7 @@ func copyOfObjectPointers(params []interface{}) interface{} {
 
 	// Check for a negative length.
 	if newLen < 0 {
-		return getGErrBlk(excNames.NegativeArraySizeException, "copyOfObjectPointers: negative array length")
+		return getGErrBlk(excNames.NegativeArraySizeException, "utilArraysCopyOf: negative array length")
 	}
 
 	// Get the array length.
@@ -69,4 +334,105 @@ func copyOfObjectPointers(params []interface{}) interface{} {
 	}
 
 	return newArrayObj
+}
+
+// Arrays.fill(byte[] a, byte val) -> void (also used for boolean[])
+func utilArraysFillBytes(params []interface{}) interface{} {
+	if len(params) < 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "utilArraysFillBytes: too few arguments")
+	}
+	if params[0] == nil {
+		return getGErrBlk(excNames.NullPointerException, "utilArraysFillBytes: null array argument")
+	}
+	arrObj, ok := params[0].(*object.Object)
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "utilArraysFillBytes: first arg not an array object")
+	}
+	field, ok := arrObj.FieldTable["value"]
+	if !ok {
+		return getGErrBlk(excNames.IllegalArgumentException, "utilArraysFillBytes: missing array value field")
+	}
+	// Java byte value is passed as int64
+	val := types.JavaByte(params[1].(int64))
+	switch a := field.Fvalue.(type) {
+	case []types.JavaByte:
+		for i := range a {
+			a[i] = val
+		}
+		// write back (not strictly necessary as slice is by reference)
+		arrObj.FieldTable["value"] = field
+		return nil
+	default:
+		return getGErrBlk(excNames.IllegalArgumentException, "utilArraysFillBytes: unsupported array type")
+	}
+}
+
+// Arrays.toString for primitive and reference arrays
+func utilArraysToString(params []interface{}) interface{} {
+	if len(params) < 1 {
+		return getGErrBlk(excNames.IllegalArgumentException, "utilArraysToString: too few arguments")
+	}
+	if params[0] == nil {
+		return object.StringObjectFromGoString("null")
+	}
+	arrObj, ok := params[0].(*object.Object)
+	if !ok {
+		return object.StringObjectFromGoString("null")
+	}
+	field, ok := arrObj.FieldTable["value"]
+	if !ok {
+		return object.StringObjectFromGoString("null")
+	}
+
+	var b strings.Builder
+	b.WriteByte('[')
+
+	appendComma := func(idx, l int) {
+		if idx+1 < l {
+			b.WriteString(", ")
+		}
+	}
+
+	switch v := field.Fvalue.(type) {
+	case []types.JavaByte:
+		for i, e := range v {
+			b.WriteString(fmt.Sprintf("%d", int8(e)))
+			appendComma(i, len(v))
+		}
+	case []int64:
+		// Special-case char arrays by type
+		if field.Ftype == types.CharArray {
+			for i, e := range v {
+				b.WriteString(string(rune(e)))
+				appendComma(i, len(v))
+			}
+		} else {
+			for i, e := range v {
+				b.WriteString(fmt.Sprintf("%d", e))
+				appendComma(i, len(v))
+			}
+		}
+	case []float64:
+		for i, e := range v {
+			b.WriteString(fmt.Sprintf("%v", e))
+			appendComma(i, len(v))
+		}
+	case []*object.Object:
+		for i, e := range v {
+			if e == nil || object.IsNull(e) {
+				b.WriteString("null")
+			} else if object.IsStringObject(e) {
+				b.WriteString(object.GoStringFromStringObject(e))
+			} else {
+				// Fallback to class name
+				b.WriteString(object.GoStringFromStringPoolIndex(e.KlassName))
+			}
+			appendComma(i, len(v))
+		}
+	default:
+		// Unknown backing; return []
+	}
+
+	b.WriteByte(']')
+	return object.StringObjectFromGoString(b.String())
 }

--- a/src/gfunction/javaUtilArrays_test.go
+++ b/src/gfunction/javaUtilArrays_test.go
@@ -15,23 +15,23 @@ import (
 )
 
 func TestCopyOfObjectPointers_TooFewArguments(t *testing.T) {
-	result := *(copyOfObjectPointers([]interface{}{}).(*GErrBlk))
-	if result.ExceptionType != excNames.IllegalArgumentException || result.ErrMsg != "copyOfObjectPointers: too few arguments" {
+	result := *(utilArraysCopyOf([]interface{}{}).(*GErrBlk))
+	if result.ExceptionType != excNames.IllegalArgumentException || result.ErrMsg != "utilArraysCopyOf: too few arguments" {
 		t.Errorf("Expected IllegalArgumentException for too few arguments")
 	}
 }
 
 func TestCopyOfObjectPointers_NullArray(t *testing.T) {
-	result := *(copyOfObjectPointers([]interface{}{nil, int64(5)}).(*GErrBlk))
-	if result.ExceptionType != excNames.NullPointerException || result.ErrMsg != "copyOfObjectPointers: null array argument" {
+	result := *(utilArraysCopyOf([]interface{}{nil, int64(5)}).(*GErrBlk))
+	if result.ExceptionType != excNames.NullPointerException || result.ErrMsg != "utilArraysCopyOf: null array argument" {
 		t.Errorf("Expected NullPointerException for null array argument")
 	}
 }
 
 func TestCopyOfObjectPointers_NegativeLength(t *testing.T) {
 	obj := &object.Object{}
-	result := *(copyOfObjectPointers([]interface{}{obj, int64(-1)}).(*GErrBlk))
-	if result.ExceptionType != excNames.NegativeArraySizeException || result.ErrMsg != "copyOfObjectPointers: negative array length" {
+	result := *(utilArraysCopyOf([]interface{}{obj, int64(-1)}).(*GErrBlk))
+	if result.ExceptionType != excNames.NegativeArraySizeException || result.ErrMsg != "utilArraysCopyOf: negative array length" {
 		// if result != getGErrBlk(excNames.NegativeArraySizeException, "copyOf: negative array length") {
 		t.Errorf("Expected NegativeArraySizeException for negative array length")
 	}
@@ -48,7 +48,7 @@ func TestCopyOfObjectPointers_CopyArray(t *testing.T) {
 	rawOldArray[1] = object.StringObjectFromGoString("bar")
 
 	// Test copying to a larger array
-	result := copyOfObjectPointers([]interface{}{oldArray, int64(4)})
+	result := utilArraysCopyOf([]interface{}{oldArray, int64(4)})
 	newArray := result.(*object.Object).FieldTable["value"].Fvalue.([]*object.Object)
 	if len(newArray) != 4 {
 		t.Errorf("Expected new array length of 4, got %d", len(newArray))

--- a/src/gfunction/javaUtilObjects.go
+++ b/src/gfunction/javaUtilObjects.go
@@ -68,7 +68,7 @@ func Load_Util_Objects() {
 	MethodSignatures["java/util/Objects.equals(Ljava/lang/Object;Ljava/lang/Object;)Z"] =
 		GMeth{
 			ParamSlots: 2,
-			GFunction:  trapFunction,
+			GFunction:  objectsEquals,
 		}
 
 	MethodSignatures["java/util/Objects.hash([Ljava/lang/Object;)I"] =
@@ -152,6 +152,36 @@ func objectsCheckIndex(params []interface{}) interface{} {
 		return getGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
 	}
 	return index
+}
+
+// java/util/Objects.equals(Object a, Object b) -> boolean
+// Minimal implementation:
+// - returns true if both are null
+// - returns false if exactly one is null
+// - returns true if both are the same reference
+// - otherwise returns false (does not invoke a.equals(b))
+func objectsEquals(params []interface{}) interface{} {
+	if len(params) < 2 {
+		return getGErrBlk(excNames.IllegalArgumentException, "objectsEquals: too few arguments")
+	}
+
+	if params[0] == nil && params[1] == nil {
+		return types.JavaBoolTrue
+	}
+	if params[0] == nil || params[1] == nil {
+		return types.JavaBoolFalse
+	}
+
+	a, okA := params[0].(*object.Object)
+	b, okB := params[1].(*object.Object)
+	if !okA || !okB {
+		return types.JavaBoolFalse
+	}
+
+	if a == b {
+		return types.JavaBoolTrue
+	}
+	return types.JavaBoolFalse
 }
 
 func objectsIsNull(params []interface{}) interface{} {

--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -3020,10 +3020,16 @@ func doAthrow(fr *frames.Frame, _ int64) int {
 
 // 0xC0 CHECKCAST
 func doCheckcast(fr *frames.Frame, _ int64) int {
-	// same as INSTANCEOF but does nothing on null;
-	// doesn't change the stack if the cast is legal.
-	// Because this uses the same logic as INSTANCEOF,
-	// any change here should be made to INSTANCEOF
+	//
+	// CHECKCAST and INSTANCEOF are nearly the same. Differences:
+	//
+	// * CHECKCAST: Peeks at the objectRef on the stack. It returns immediately if objectRef is null (not an error).
+	// * INSTANCEOF: Pops the objectRef and pushes a result of types.JavaBoolTrue (if an instance of) or types.JavaBoolFalse (if not).
+	// * Both return 3 (2 for CPslot + 1 for next byte) or some sort of error.
+	//
+	// Because doCheckcast uses the same middle logic as doInstanceof,
+	// any change here should probably be made to doInstanceof
+	// and vice versa!
 
 	ref := peek(fr) // peek b/c the objectRef is *not* removed from the op stack
 	if ref == nil { // if ref is nil, just carry on
@@ -3056,6 +3062,12 @@ func doCheckcast(fr *frames.Frame, _ int64) int {
 	CP := fr.CP.(*classloader.CPool)
 	// CPentry := CP.CpIndex[CPslot]
 	classNamePtr := classloader.FetchCPentry(CP, CPslot)
+	targetClassName := *(classNamePtr.StringVal)
+
+	if globals.TraceVerbose {
+		trace.Trace(fmt.Sprintf("CHECKCAST: object=%s, target=%s",
+			objName, targetClassName))
+	}
 
 	var objClassType = types.Error
 	if strings.HasPrefix(objName, "[") {
@@ -3076,11 +3088,11 @@ func doCheckcast(fr *frames.Frame, _ int64) int {
 	var checkcastStatus bool
 	switch objClassType {
 	case types.NonArrayObject:
-		checkcastStatus = checkcastNonArrayObject(obj, *(classNamePtr.StringVal))
+		checkcastStatus = checkcastNonArrayObject(obj, targetClassName)
 	case types.Array:
-		checkcastStatus = checkcastArray(obj, *(classNamePtr.StringVal))
+		checkcastStatus = checkcastArray(obj, targetClassName)
 	case types.Interface:
-		checkcastStatus = checkcastInterface(obj, *(classNamePtr.StringVal))
+		checkcastStatus = checkcastInterface(obj, targetClassName)
 	default:
 		errMsg := fmt.Sprintf("CHECKCAST: expected to verify class or interface, but got none")
 		status := exceptions.ThrowEx(excNames.InvalidTypeException, errMsg, fr)
@@ -3093,77 +3105,117 @@ func doCheckcast(fr *frames.Frame, _ int64) int {
 	if checkcastStatus == false {
 		globals.GetGlobalRef().ErrorGoStack = string(debug.Stack())
 		errMsg := fmt.Sprintf("CHECKCAST: %s is not castable with respect to %s",
-			*(stringPool.GetStringPointer(obj.KlassName)), *(classNamePtr.StringVal))
+			*(stringPool.GetStringPointer(obj.KlassName)), targetClassName)
 		status := exceptions.ThrowEx(excNames.ClassCastException, errMsg, fr)
 		if status != exceptions.Caught {
 			return exceptions.ERROR_OCCURRED // applies only if in test
 		}
 		return exceptions.RESUME_HERE // caught
 	}
+
 	return 3 // 2 for CPslot + 1 for next byte
 }
 
-//	 0xC1 INSTANCEOF validate the type of object (if not nil or null)
-//		Because this uses similar logic to CHECKCAST, any change here
-//		should likely be made to CHECKCAST as well
+// 0xC1 INSTANCEOF validate the type of object (if not nil or null)
 func doInstanceof(fr *frames.Frame, _ int64) int {
+	//
+	// See detail design documentation in doCheckcast.
+	//
+	// Because doInstanceof uses the same middle logic as doCheckcast,
+	// any change here should probably be made to doCheckcast
+	// and vice versa!
+	//
 	ref := pop(fr)
-	if ref == nil || ref == object.Null {
-		push(fr, int64(0))
-		return 3 // 2 to move past index bytes to comp object + 1 for next bytecode
+	if ref == nil || object.IsNull(ref) {
+		if globals.TraceVerbose {
+			trace.Trace("INSTANCEOF: null reference -> false")
+		}
+		push(fr, types.JavaBoolFalse)
+		return 3 // 2 bytes for CP index + 1 for next bytecode
 	}
 
+	var obj *object.Object
+	var objName string
 	switch ref.(type) {
 	case *object.Object:
-		if ref == object.Null {
-			push(fr, int64(0))
-			return 3 // 2 move past index bytes + 1 for next bytecode
+		if object.IsNull(ref) { // if ref is null, just carry on
+			return 3
 		} else {
-			obj := *ref.(*object.Object)
-			CPslot := (int(fr.Meth[fr.PC+1]) * 256) + int(fr.Meth[fr.PC+2])
-			CP := fr.CP.(*classloader.CPool)
-			CPentry := CP.CpIndex[CPslot]
-			if CPentry.Type == classloader.ClassRef { // slot of ClassRef points to
-				// a CP entry for a stringPool entry for name of class
-				var className string
-				classNamePtr := classloader.FetchCPentry(CP, CPslot)
-				if classNamePtr.RetType != classloader.IS_STRING_ADDR {
-					globals.GetGlobalRef().ErrorGoStack = string(debug.Stack())
-					errMsg := "INSTANCEOF: Invalid classRef found"
-					status := exceptions.ThrowEx(excNames.InvalidTypeException, errMsg, fr)
-					if status != exceptions.Caught {
-						return exceptions.ERROR_OCCURRED // applies only if in test
-					}
-					return exceptions.RESUME_HERE // caught
-				} else {
-					className = *(classNamePtr.StringVal)
-					if globals.TraceVerbose {
-						traceInfo := fmt.Sprintf("INSTANCEOF: className = %s", className)
-						trace.Trace(traceInfo)
-					}
-				}
-				classPtr := classloader.MethAreaFetch(className)
-				if classPtr == nil { // class wasn't loaded, so load it now
-					if classloader.LoadClassFromNameOnly(className) != nil {
-						globals.GetGlobalRef().ErrorGoStack = string(debug.Stack())
-						errMsg := "INSTANCEOF: Could not load class: " + className
-						status := exceptions.ThrowEx(excNames.ClassNotLoadedException, errMsg, fr)
-						if status != exceptions.Caught {
-							return exceptions.ERROR_OCCURRED // applies only if in test
-						}
-						return exceptions.RESUME_HERE // caught
-					}
-					classPtr = classloader.MethAreaFetch(className)
-				}
-				if classPtr == classloader.MethAreaFetch(*(stringPool.GetStringPointer(obj.KlassName))) {
-					push(fr, types.JavaBoolTrue)
-				} else {
-					push(fr, types.JavaBoolFalse)
-				}
-			}
+			obj = (ref).(*object.Object)
+			objName = *(stringPool.GetStringPointer(obj.KlassName))
+		}
+	default: // objectRef must be a reference to an object
+		globals.GetGlobalRef().ErrorGoStack = string(debug.Stack())
+		errMsg := fmt.Sprintf("CHECKCAST: Invalid class reference, type=%T", ref)
+		status := exceptions.ThrowEx(excNames.ClassCastException, errMsg, fr)
+		if status != exceptions.Caught {
+			return exceptions.ERROR_OCCURRED // applies only if in test
+		}
+		return exceptions.RESUME_HERE // caught
+	}
+
+	// at this point, we know we have a non-nil/non-null pointer to an object;
+	// now, get the class we're casting the object to.
+	CPslot := (int(fr.Meth[fr.PC+1]) * 256) + int(fr.Meth[fr.PC+2])
+	CP := fr.CP.(*classloader.CPool)
+	// CPentry := CP.CpIndex[CPslot]
+	classNamePtr := classloader.FetchCPentry(CP, CPslot)
+	targetClassName := *(classNamePtr.StringVal)
+
+	if globals.TraceVerbose {
+		trace.Trace(fmt.Sprintf("INSTANCEOF: object=%s, target=%s",
+			objName, targetClassName))
+	}
+
+	var objClassType = types.Error
+	if strings.HasPrefix(objName, "[") {
+		objClassType = types.Array
+	} else {
+		objData := classloader.MethAreaFetch(objName)
+		if objData == nil || objData.Data == nil {
+			_ = classloader.LoadClassFromNameOnly(objName)
+			objData = classloader.MethAreaFetch(objName)
+		}
+		if objData.Data.Access.ClassIsInterface {
+			objClassType = types.Interface
+		} else {
+			objClassType = types.NonArrayObject
 		}
 	}
-	return 3 // 2 for CP slot + 1 for next bytecode
+
+	// Perform assignability check using same helpers as CHECKCAST
+	var isInstance bool
+	switch objClassType {
+	case types.NonArrayObject:
+		isInstance = checkcastNonArrayObject(obj, targetClassName)
+	case types.Array:
+		isInstance = checkcastArray(obj, targetClassName)
+	case types.Interface:
+		isInstance = checkcastInterface(obj, targetClassName)
+	default:
+		globals.GetGlobalRef().ErrorGoStack = string(debug.Stack())
+		errMsg := "INSTANCEOF: expected to verify class or interface, but got none"
+		status := exceptions.ThrowEx(excNames.InvalidTypeException, errMsg, fr)
+		if status != exceptions.Caught {
+			return exceptions.ERROR_OCCURRED
+		}
+		return exceptions.RESUME_HERE
+	}
+
+	// Push result onto operand stack
+	if isInstance {
+		if globals.TraceVerbose {
+			trace.Trace("INSTANCEOF: result = true")
+		}
+		push(fr, types.JavaBoolTrue)
+	} else {
+		if globals.TraceVerbose {
+			trace.Trace("INSTANCEOF: result = false")
+		}
+		push(fr, types.JavaBoolFalse)
+	}
+
+	return 3 // 2 bytes for CP slot + 1 for next byte
 }
 
 // 0xC4 WIDE use wide versions of bytecode arguments

--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -3156,9 +3156,9 @@ func doInstanceof(fr *frames.Frame, _ int64) int {
 					classPtr = classloader.MethAreaFetch(className)
 				}
 				if classPtr == classloader.MethAreaFetch(*(stringPool.GetStringPointer(obj.KlassName))) {
-					push(fr, int64(1))
+					push(fr, types.JavaBoolTrue)
 				} else {
-					push(fr, int64(0))
+					push(fr, types.JavaBoolFalse)
 				}
 			}
 		}

--- a/src/jvm/interpreter_checkcast_test.go
+++ b/src/jvm/interpreter_checkcast_test.go
@@ -1,0 +1,143 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2025 by Jacobin authors. All rights reserved.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)
+ */
+
+package jvm
+
+import (
+	"jacobin/src/classloader"
+	"jacobin/src/frames"
+	"jacobin/src/globals"
+	"jacobin/src/object"
+	"jacobin/src/opcodes"
+	"jacobin/src/stringPool"
+	"jacobin/src/types"
+	"testing"
+)
+
+// helper to set CP slot 1 to a ClassRef for the given class name
+func setCPClassRefFor(f *frames.Frame, className string) {
+	// Place two bytes after opcode to reference CP slot 1
+	f.Meth = append(f.Meth, 0)
+	f.Meth = append(f.Meth, 1)
+	// Build a minimal constant pool with [1] as ClassRef -> string pool index of className
+	CP := classloader.CPool{}
+	CP.CpIndex = make([]classloader.CpEntry, 2)
+	CP.CpIndex[0] = classloader.CpEntry{Type: 0, Slot: 0}
+	CP.CpIndex[1] = classloader.CpEntry{Type: classloader.ClassRef, Slot: 0}
+	idx := stringPool.GetStringIndex(&className)
+	CP.ClassRefs = append(CP.ClassRefs, idx)
+	f.CP = &CP
+}
+
+// helper to insert a class record in the Method Area if not present
+func ensureClassInMethArea(name string) {
+	if classloader.MethAreaFetch(name) == nil {
+		classloader.MethAreaInsert(name, &classloader.Klass{Status: 'X', Loader: "bootstrap", Data: &classloader.ClData{}})
+	}
+}
+
+// helper to insert a class with a given superclass linkage into the Method Area
+func ensureClassWithSuper(name string, super string) {
+	if classloader.MethAreaFetch(name) != nil {
+		return
+	}
+	var superIdx uint32
+	if super == "" {
+		superIdx = types.InvalidStringIndex
+	} else if super == "java/lang/Object" {
+		superIdx = types.ObjectPoolStringIndex
+	} else {
+		superIdx = stringPool.GetStringIndex(&super)
+	}
+	classloader.MethAreaInsert(name, &classloader.Klass{Status: 'X', Loader: "bootstrap", Data: &classloader.ClData{SuperclassIndex: superIdx}})
+}
+
+// runCheckcast runs doCheckcast on obj against targetName and returns whether the cast succeeded (no exception)
+// and the object that remains on the stack (should be unchanged on success).
+func runCheckcast(t *testing.T, obj interface{}, targetName string) (ok bool, top interface{}, pc int) {
+	fr := newFrame(opcodes.CHECKCAST)
+	setCPClassRefFor(&fr, targetName)
+	push(&fr, obj)
+	fs := frames.CreateFrameStack()
+	fs.PushFront(&fr)
+	interpret(fs)
+	pc = fr.PC
+	// If no exception occurred, CHECKCAST leaves the object on the stack unchanged.
+	if fr.TOS >= 0 {
+		top = peek(&fr)
+		ok = true
+	} else {
+		ok = false
+	}
+	return
+}
+
+func TestCheckcastMisc(t *testing.T) {
+	// Initialize runtime and minimal classes
+	globals.InitGlobals("test")
+	_ = classloader.Init()
+
+	// Prepare classes in the method area used as targets
+	ensureClassWithSuper("java/lang/Object", "")
+	ensureClassWithSuper("java/lang/String", "java/lang/Object")
+	ensureClassInMethArea("[Ljava/lang/String")
+	ensureClassInMethArea("[Ljava/lang/Object")
+	ensureClassWithSuper("MyClass", "java/lang/Object")
+	ensureClassInMethArea("[LMyClass")
+
+	// Build objects per the Java program
+	strSimple := object.StringObjectFromGoString("ABC")
+	strArray := object.Make1DimRefArray("java/lang/String", 1)
+	arrVals := strArray.FieldTable["value"].Fvalue.([]*object.Object)
+	arrVals[0] = strSimple
+
+	strMyClass := "MyClass"
+	objSimple := object.MakeEmptyObjectWithClassName(&strMyClass)
+	objArray := object.Make1DimRefArray("MyClass", 1)
+	objArrVals := objArray.FieldTable["value"].Fvalue.([]*object.Object)
+	objArrVals[0] = objSimple
+
+	// Success cases: CHECKCAST should allow upcasts and leave object unchanged on stack
+	ok, top, pc := runCheckcast(t, strSimple, "java/lang/String")
+	if !ok || top != strSimple || pc != 3 {
+		t.Fatalf("CHECKCAST strSimple->String failed: ok=%v top==obj? %v pc=%d", ok, top == strSimple, pc)
+	}
+
+	ok, top, pc = runCheckcast(t, strSimple, "java/lang/Object")
+	if !ok || top != strSimple || pc != 3 {
+		t.Fatalf("CHECKCAST strSimple->Object should succeed: ok=%v top==obj? %v pc=%d", ok, top == strSimple, pc)
+	}
+
+	ok, top, pc = runCheckcast(t, strArray, "[Ljava/lang/String")
+	if !ok || top != strArray || pc != 3 {
+		t.Fatalf("CHECKCAST strArray->String[] failed: ok=%v top==obj? %v pc=%d", ok, top == strArray, pc)
+	}
+
+	ok, top, pc = runCheckcast(t, strArray, "[Ljava/lang/Object")
+	if !ok || top != strArray || pc != 3 {
+		t.Fatalf("CHECKCAST strArray->Object[] should succeed: ok=%v top==obj? %v pc=%d", ok, top == strArray, pc)
+	}
+
+	ok, top, pc = runCheckcast(t, objSimple, strMyClass)
+	if !ok || top != objSimple || pc != 3 {
+		t.Fatalf("CHECKCAST objSimple->MyClass failed: ok=%v top==obj? %v pc=%d", ok, top == objSimple, pc)
+	}
+
+	ok, top, pc = runCheckcast(t, objSimple, "java/lang/Object")
+	if !ok || top != objSimple || pc != 3 {
+		t.Fatalf("CHECKCAST objSimple->Object should succeed: ok=%v top==obj? %v pc=%d", ok, top == objSimple, pc)
+	}
+
+	ok, top, pc = runCheckcast(t, objArray, "[L"+strMyClass)
+	if !ok || top != objArray || pc != 3 {
+		t.Fatalf("CHECKCAST objArray->MyClass[] failed: ok=%v top==obj? %v pc=%d", ok, top == objArray, pc)
+	}
+
+	ok, top, pc = runCheckcast(t, objArray, "[Ljava/lang/Object")
+	if !ok || top != objArray || pc != 3 {
+		t.Fatalf("CHECKCAST objArray->Object[] should succeed: ok=%v top==obj? %v pc=%d", ok, top == objArray, pc)
+	}
+}

--- a/src/jvm/interpreter_instanceof_test.go
+++ b/src/jvm/interpreter_instanceof_test.go
@@ -4,6 +4,7 @@
  * Licensed under Mozilla Public License 2.0 (MPL 2.0)
  */
 
+// 2025-09-10
 // According to Java semantics, several of these should be true (1) for Object and Object[]
 // But the current doInstanceof implementation only matches exact class equality.
 // These assertions therefore reflect CURRENT BEHAVIOR.

--- a/src/jvm/interpreter_instanceof_test.go
+++ b/src/jvm/interpreter_instanceof_test.go
@@ -4,12 +4,6 @@
  * Licensed under Mozilla Public License 2.0 (MPL 2.0)
  */
 
-// 2025-09-10
-// According to Java semantics, several of these should be true (1) for Object and Object[]
-// But the current doInstanceof implementation only matches exact class equality.
-// These assertions therefore reflect CURRENT BEHAVIOR.
-// TODO: fix doInstanceof and these assertions to match Java semantics.
-
 package jvm
 
 import (
@@ -63,28 +57,28 @@ func TestInstanceofMisc(t *testing.T) {
 	if got := runInstanceof(t, strSimple, "java/lang/String"); got != types.JavaBoolTrue {
 		t.Fatalf("strSimple instanceof String: want 1 got %d", got)
 	}
-	if got := runInstanceof(t, strSimple, "java/lang/Object"); got != types.JavaBoolFalse {
+	if got := runInstanceof(t, strSimple, "java/lang/Object"); got != types.JavaBoolTrue {
 		t.Fatalf("strSimple instanceof Object: CURRENT want 0 got %d", got)
 	}
 
 	if got := runInstanceof(t, strArray, "[Ljava/lang/String"); got != types.JavaBoolTrue {
 		t.Fatalf("strArray instanceof String[]: want 1 got %d", got)
 	}
-	if got := runInstanceof(t, strArray, "[Ljava/lang/Object"); got != types.JavaBoolFalse {
+	if got := runInstanceof(t, strArray, "[Ljava/lang/Object"); got != types.JavaBoolTrue {
 		t.Fatalf("strArray instanceof Object[]: CURRENT want 0 got %d", got)
 	}
 
 	if got := runInstanceof(t, objSimple, strMyClass); got != types.JavaBoolTrue {
 		t.Fatalf("objSimple instanceof MyClass: want 1 got %d", got)
 	}
-	if got := runInstanceof(t, objSimple, "java/lang/Object"); got != types.JavaBoolFalse {
+	if got := runInstanceof(t, objSimple, "java/lang/Object"); got != types.JavaBoolTrue {
 		t.Fatalf("objSimple instanceof Object: CURRENT want 0 got %d", got)
 	}
 
 	if got := runInstanceof(t, objArray, "[L"+strMyClass); got != types.JavaBoolTrue {
 		t.Fatalf("objArray instanceof MyClass[]: want 1 got %d", got)
 	}
-	if got := runInstanceof(t, objArray, "[Ljava/lang/Object"); got != types.JavaBoolFalse {
+	if got := runInstanceof(t, objArray, "[Ljava/lang/Object"); got != types.JavaBoolTrue {
 		t.Fatalf("objArray instanceof Object[]: CURRENT want 0 got %d", got)
 	}
 }

--- a/src/jvm/interpreter_instanceof_test.go
+++ b/src/jvm/interpreter_instanceof_test.go
@@ -1,0 +1,89 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2025 by Jacobin authors. All rights reserved.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0)
+ */
+
+// According to Java semantics, several of these should be true (1) for Object and Object[]
+// But the current doInstanceof implementation only matches exact class equality.
+// These assertions therefore reflect CURRENT BEHAVIOR.
+// TODO: fix doInstanceof and these assertions to match Java semantics.
+
+package jvm
+
+import (
+	"jacobin/src/classloader"
+	"jacobin/src/frames"
+	"jacobin/src/globals"
+	"jacobin/src/object"
+	"jacobin/src/opcodes"
+	"jacobin/src/types"
+	"testing"
+)
+
+// runInstanceof runs doInstanceof on obj against targetName and returns a result pushed on the stack.
+func runInstanceof(t *testing.T, obj interface{}, targetName string) int64 {
+	fr := newFrame(opcodes.INSTANCEOF)
+	setCPClassRefFor(&fr, targetName)
+	push(&fr, obj)
+	fs := frames.CreateFrameStack()
+	fs.PushFront(&fr)
+	interpret(fs)
+	val, _ := pop(&fr).(int64)
+	return val
+}
+
+func TestInstanceofMisc(t *testing.T) {
+	// Initialize runtime and minimal classes
+	globals.InitGlobals("test")
+	_ = classloader.Init()
+
+	// Prepare classes in the method area used as targets
+	ensureClassWithSuper("java/lang/Object", "")
+	ensureClassWithSuper("java/lang/String", "java/lang/Object")
+	ensureClassInMethArea("[Ljava/lang/String")
+	ensureClassInMethArea("[Ljava/lang/Object")
+	ensureClassWithSuper("MyClass", "java/lang/Object")
+	ensureClassInMethArea("[LMyClass")
+
+	// Build objects per the Java program
+	strSimple := object.StringObjectFromGoString("ABC")
+	strArray := object.Make1DimRefArray("java/lang/String", 1)
+	// place element (not strictly needed for instanceof of array itself)
+	arrVals := strArray.FieldTable["value"].Fvalue.([]*object.Object)
+	arrVals[0] = strSimple
+
+	strMyClass := "MyClass"
+	objSimple := object.MakeEmptyObjectWithClassName(&strMyClass)
+	objArray := object.Make1DimRefArray("MyClass", 1)
+	objArrVals := objArray.FieldTable["value"].Fvalue.([]*object.Object)
+	objArrVals[0] = objSimple
+
+	if got := runInstanceof(t, strSimple, "java/lang/String"); got != types.JavaBoolTrue {
+		t.Fatalf("strSimple instanceof String: want 1 got %d", got)
+	}
+	if got := runInstanceof(t, strSimple, "java/lang/Object"); got != types.JavaBoolFalse {
+		t.Fatalf("strSimple instanceof Object: CURRENT want 0 got %d", got)
+	}
+
+	if got := runInstanceof(t, strArray, "[Ljava/lang/String"); got != types.JavaBoolTrue {
+		t.Fatalf("strArray instanceof String[]: want 1 got %d", got)
+	}
+	if got := runInstanceof(t, strArray, "[Ljava/lang/Object"); got != types.JavaBoolFalse {
+		t.Fatalf("strArray instanceof Object[]: CURRENT want 0 got %d", got)
+	}
+
+	if got := runInstanceof(t, objSimple, strMyClass); got != types.JavaBoolTrue {
+		t.Fatalf("objSimple instanceof MyClass: want 1 got %d", got)
+	}
+	if got := runInstanceof(t, objSimple, "java/lang/Object"); got != types.JavaBoolFalse {
+		t.Fatalf("objSimple instanceof Object: CURRENT want 0 got %d", got)
+	}
+
+	if got := runInstanceof(t, objArray, "[L"+strMyClass); got != types.JavaBoolTrue {
+		t.Fatalf("objArray instanceof MyClass[]: want 1 got %d", got)
+	}
+	if got := runInstanceof(t, objArray, "[Ljava/lang/Object"); got != types.JavaBoolFalse {
+		t.Fatalf("objArray instanceof Object[]: CURRENT want 0 got %d", got)
+	}
+}


### PR DESCRIPTION
new file:   jvm/interpreter_checkcast_test.go - additional unit tests.
new file:   jvm/interpreter_instanceof_test.go - additional unit tests.
modified:   jvm/interpreter.go - minor change to use `types.JavaBoolTrue` and `types.JavaBoolFalse inestead` of 1 and 0.
modified:   jvm/interpreter.go - major overhaul of `doInstanceof` to look more like the successful `doCheckcast`.
modified:   jvm/interpreter_instanceof_test.go - removed TODO; all unit tests function as they are supposed to.

_2025-09-13_
modified: gfunction/javaUtilObjects.go - added "java/util/Objects.equals(Ljava/lang/Object;Ljava/lang/Object;)Z".
modified: gfunction/javaUtilArrays.go - filled out java/util/Arrays with additional functional code and traps.


