### PR TITLE
JACOBIN-778 & JACOBIN-779 miscellaneous small updates

### DIFF
--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -12,6 +12,12 @@ import (
 
 func Load_Traps() {
 
+	MethodSignatures["java/awt/image/BufferedImage.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapClass,
+		}
+
 	MethodSignatures["java/rmi/RMISecurityManager.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,

--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -36,6 +36,18 @@ func Load_Traps() {
 			GFunction:  trapFunction,
 		}
 
+	MethodSignatures["java/awt/Image.<clinit>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapClass,
+		}
+
+	MethodSignatures["java/awt/Image.<init>()V"] =
+		GMeth{
+			ParamSlots: 0,
+			GFunction:  trapFunction,
+		}
+
 	MethodSignatures["java/awt/ImageCapabilities.<init>(Z)V"] =
 		GMeth{
 			ParamSlots: 1,

--- a/src/gfunction/Traps.go
+++ b/src/gfunction/Traps.go
@@ -18,6 +18,30 @@ func Load_Traps() {
 			GFunction:  trapClass,
 		}
 
+	MethodSignatures["java/awt/image/BufferedImage.<init>(III)Ljava/awt/image/BufferedImage;"] =
+		GMeth{
+			ParamSlots: 3,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/awt/image/BufferedImage.<init>(IIILjava/awt/image/IndexColorModel;)Ljava/awt/image/BufferedImage;"] =
+		GMeth{
+			ParamSlots: 4,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/awt/image/BufferedImage.<init>(Ljava/awt/image/ColorModel;Ljava/awt/image/WritableRaster;ZLjava/util/Hashtable;)Ljava/awt/image/BufferedImage;"] =
+		GMeth{
+			ParamSlots: 4,
+			GFunction:  trapFunction,
+		}
+
+	MethodSignatures["java/awt/ImageCapabilities.<init>(Z)V"] =
+		GMeth{
+			ParamSlots: 1,
+			GFunction:  trapFunction,
+		}
+
 	MethodSignatures["java/rmi/RMISecurityManager.<clinit>()V"] =
 		GMeth{
 			ParamSlots: 0,

--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -2957,12 +2957,13 @@ func doAthrow(fr *frames.Frame, _ int64) int {
 				switch value.(type) {
 				case []byte:
 					errMsg += fmt.Sprintf(": %s", string(obj.FieldTable["value"].Fvalue.([]byte)))
+				case []types.JavaByte:
+					errMsg += fmt.Sprintf(": %s", object.GoStringFromJavaByteArray(obj.FieldTable["value"].Fvalue.([]types.JavaByte)))
 				case uint32:
 					str := stringPool.GetStringPointer(value.(uint32))
 					errMsg += fmt.Sprintf(": %s", *str)
 				default:
-					str := fmt.Sprintf(": %v", value)
-					errMsg += fmt.Sprintf(": %s", str)
+					errMsg += fmt.Sprintf(": <default value> %v", value)
 				}
 			default:
 				errMsg += ": objectRef.FieldTable[\"detailMessage\"] is object.Null"


### PR DESCRIPTION
* jvm/interpreter.go : Fixed ATHROW display for String and default valued `detailMessage`.
* gfunction/Traps.go : 
   - Added `java/awt/image/BufferedImage.<clinit>()V`.
   - Added `<init>` construction traps for BufferedImage and `java/awt/Image` to Traps.go"
* gfunction/javaLangThrowable.go : Added `<init>` functions for nil argument and String argument.
* gfunction/javaLangThrowable_test.go : Added unit tests for add unit tests for `throwableInitNull` and `throwableInitString`.