### PR TITLE
JACOBIN-891 set frame nil when returning (interpreter doReturn, doIreturn)

### DIFF
--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -2141,9 +2141,11 @@ func doIreturn(fr *frames.Frame, _ int64) int {
 		}
 	}
 	valToReturn := pop(fr)
-	f := fr.FrameStack.Front().Next().Value.(*frames.Frame)
-	push(f, valToReturn)
-	fr.FrameStack.Remove(fr.FrameStack.Front())
+	nextFrame := fr.FrameStack.Front().Next().Value.(*frames.Frame)
+	push(nextFrame, valToReturn)
+	fs := fr.FrameStack
+	fs.Remove(fs.Front())
+	fr = nil
 	return 0
 }
 
@@ -2158,7 +2160,9 @@ func doReturn(fr *frames.Frame, _ int64) int {
 			trace.Trace(traceInfo)
 		}
 	}
-	fr.FrameStack.Remove(fr.FrameStack.Front())
+	fs := fr.FrameStack
+	fs.Remove(fs.Front())
+	fr = nil
 	return 0
 }
 


### PR DESCRIPTION
modified:   jvm/interpreter.go

Functions `doReturn` and `doIreturn` (I/L/F/D/A) were modified to set the removed frame to nil.