### PR TITLE
JACOBIN-892 correct ParamSlots value in MethodSignature entries

### DIFF
--- a/src/gfunction/javaLang/javaLangObject.go
+++ b/src/gfunction/javaLang/javaLangObject.go
@@ -42,7 +42,7 @@ func Load_Lang_Object() {
 		ghelpers.GMeth{ParamSlots: 0, GFunction: ObjectGetClass} // TODO: finish implementing objectGetClass
 
 	ghelpers.MethodSignatures["java/lang/Object.getResourceAsStream(Ljava/lang/String;)Ljava/io/InputStream;"] =
-		ghelpers.GMeth{ParamSlots: 0, GFunction: ghelpers.TrapFunction}
+		ghelpers.GMeth{ParamSlots: 1, GFunction: ghelpers.TrapFunction}
 
 	ghelpers.MethodSignatures["java/lang/Object.hashCode()I"] =
 		ghelpers.GMeth{ParamSlots: 0, GFunction: objectHashCode}

--- a/src/gfunction/javaLang/javaLangThread.go
+++ b/src/gfunction/javaLang/javaLangThread.go
@@ -199,7 +199,7 @@ func Load_Lang_Thread() {
 		ghelpers.GMeth{ParamSlots: 0, GFunction: ghelpers.TrapDeprecated}
 
 	ghelpers.MethodSignatures["java/lang/Thread.run()V"] =
-		ghelpers.GMeth{ParamSlots: 1, GFunction: threadRun}
+		ghelpers.GMeth{ParamSlots: 0, GFunction: threadRun}
 
 	ghelpers.MethodSignatures["java/lang/Thread.setContextClassLoader(Ljava/lang/ClassLoader;)V"] =
 		ghelpers.GMeth{ParamSlots: 1, GFunction: ghelpers.TrapFunction}

--- a/src/gfunction/javaSecurity/javaSecurityECFieldAndPoint.go
+++ b/src/gfunction/javaSecurity/javaSecurityECFieldAndPoint.go
@@ -24,7 +24,7 @@ func Load_ECFieldAndPoint() {
 	ghelpers.MethodSignatures["java/security/spec/ECField.<init>(I)V"] =
 		ghelpers.GMeth{ParamSlots: 1, GFunction: ecFieldInit}
 	ghelpers.MethodSignatures["java/security/spec/ECField.getFieldSize()I"] =
-		ghelpers.GMeth{ParamSlots: 1, GFunction: ecFieldGetFieldSize}
+		ghelpers.GMeth{ParamSlots: 0, GFunction: ecFieldGetFieldSize}
 
 	// --------------------------
 	// ECFieldFp
@@ -32,7 +32,7 @@ func Load_ECFieldAndPoint() {
 	ghelpers.MethodSignatures["java/security/spec/ECFieldFp.<init>(Ljava/math/BigInteger;)V"] =
 		ghelpers.GMeth{ParamSlots: 1, GFunction: ecFieldFpInit}
 	ghelpers.MethodSignatures["java/security/spec/ECFieldFp.getP()Ljava/math/BigInteger;"] =
-		ghelpers.GMeth{ParamSlots: 1, GFunction: ecFieldFpGetP}
+		ghelpers.GMeth{ParamSlots: 0, GFunction: ecFieldFpGetP}
 
 	// --------------------------
 	// ECPoint
@@ -40,9 +40,9 @@ func Load_ECFieldAndPoint() {
 	ghelpers.MethodSignatures["java/security/spec/ECPoint.<init>(Ljava/math/BigInteger;Ljava/math/BigInteger;)V"] =
 		ghelpers.GMeth{ParamSlots: 2, GFunction: ecPointInit}
 	ghelpers.MethodSignatures["java/security/spec/ECPoint.getAffineX()Ljava/math/BigInteger;"] =
-		ghelpers.GMeth{ParamSlots: 1, GFunction: ecPointGetAffineX}
+		ghelpers.GMeth{ParamSlots: 0, GFunction: ecPointGetAffineX}
 	ghelpers.MethodSignatures["java/security/spec/ECPoint.getAffineY()Ljava/math/BigInteger;"] =
-		ghelpers.GMeth{ParamSlots: 1, GFunction: ecPointGetAffineY}
+		ghelpers.GMeth{ParamSlots: 0, GFunction: ecPointGetAffineY}
 }
 
 // ---------------------------------------------------------

--- a/src/gfunction/javaSecurity/javaSecurityEllipticCurve.go
+++ b/src/gfunction/javaSecurity/javaSecurityEllipticCurve.go
@@ -28,21 +28,21 @@ func Load_EllipticCurve() {
 	// Getter for field
 	ghelpers.MethodSignatures["java/security/spec/EllipticCurve.getField()Ljava/security/spec/ECField;"] =
 		ghelpers.GMeth{
-			ParamSlots: 1,
+			ParamSlots: 0,
 			GFunction:  ellipticCurveGetField,
 		}
 
 	// Getter for a
 	ghelpers.MethodSignatures["java/security/spec/EllipticCurve.getA()Ljava/math/BigInteger;"] =
 		ghelpers.GMeth{
-			ParamSlots: 1,
+			ParamSlots: 0,
 			GFunction:  ellipticCurveGetA,
 		}
 
 	// Getter for b
 	ghelpers.MethodSignatures["java/security/spec/EllipticCurve.getB()Ljava/math/BigInteger;"] =
 		ghelpers.GMeth{
-			ParamSlots: 1,
+			ParamSlots: 0,
 			GFunction:  ellipticCurveGetB,
 		}
 }

--- a/src/gfunction/javaSecurity/javaSecuritySecureRandom.go
+++ b/src/gfunction/javaSecurity/javaSecuritySecureRandom.go
@@ -140,7 +140,7 @@ func Load_Security_SecureRandom() {
 
 	ghelpers.MethodSignatures["java/security/SecureRandom.nextBoolean()Z"] =
 		ghelpers.GMeth{
-			ParamSlots: 1,
+			ParamSlots: 0,
 			GFunction:  secureRandomNextBoolean,
 		}
 

--- a/src/gfunction/javaUtil/javaUtilProperties.go
+++ b/src/gfunction/javaUtil/javaUtilProperties.go
@@ -95,7 +95,7 @@ func Load_Util_Properties() {
 
 	ghelpers.MethodSignatures["java/util/Properties.propertyNames()Ljava/util/Enumeration;"] =
 		ghelpers.GMeth{
-			ParamSlots: 1,
+			ParamSlots: 0,
 			GFunction:  ghelpers.TrapFunction,
 		}
 

--- a/src/gfunction/javaUtil/javaUtilTimeZone.go
+++ b/src/gfunction/javaUtil/javaUtilTimeZone.go
@@ -95,7 +95,7 @@ func Load_Util_TimeZone() {
 
 	ghelpers.MethodSignatures["java/util/TimeZone.getOffset(IIIII)I"] =
 		ghelpers.GMeth{
-			ParamSlots: 6,
+			ParamSlots: 5,
 			GFunction:  tzGetOffset,
 		}
 

--- a/src/gfunction/javaUtil/javaUtilTimeZone_test.go
+++ b/src/gfunction/javaUtil/javaUtilTimeZone_test.go
@@ -51,7 +51,7 @@ func TestTimeZone_MethodRegistration(t *testing.T) {
 		{"java/util/TimeZone.getDisplayName()Ljava/lang/String;", 0},
 		{"java/util/TimeZone.getDSTSavings()I", 0},
 		{"java/util/TimeZone.getID()Ljava/lang/String;", 0},
-		{"java/util/TimeZone.getOffset(IIIII)I", 6},
+		{"java/util/TimeZone.getOffset(IIIII)I", 5},
 		{"java/util/TimeZone.getOffset(J)I", 1},
 		{"java/util/TimeZone.getRawOffset()I", 0},
 		{"java/util/TimeZone.getTimeZone(Ljava/lang/String;)Ljava/util/TimeZone;", 1},

--- a/src/gfunction/javaxCrypto/javaxCryptoKeyAgreement.go
+++ b/src/gfunction/javaxCrypto/javaxCryptoKeyAgreement.go
@@ -44,7 +44,7 @@ func Load_Crypto_KeyAgreement() {
 
 	ghelpers.MethodSignatures["javax/crypto/KeyAgreement.generateSecret(Ljava/lang/String;)Ljavax/crypto/SecretKey;"] =
 		ghelpers.GMeth{
-			ParamSlots: 2,
+			ParamSlots: 1,
 			GFunction:  ghelpers.TrapFunction,
 		}
 

--- a/src/gfunction/misc/javaxNetSslSslcontext.go
+++ b/src/gfunction/misc/javaxNetSslSslcontext.go
@@ -44,37 +44,37 @@ func Load_Javax_Net_Ssl_SSLContext() {
 
 	ghelpers.MethodSignatures["javax/net/ssl/SSLContext.engineCreateSSLEngine()Ljavax/net/ssl/SSLEngine;"] =
 		ghelpers.GMeth{
-			ParamSlots: 1,
+			ParamSlots: 0,
 			GFunction:  ghelpers.TrapFunction,
 		}
 
 	ghelpers.MethodSignatures["javax/net/ssl/SSLContext.engineCreateSSLEngine(Ljava/lang/String;I)Ljavax/net/ssl/SSLEngine;"] =
 		ghelpers.GMeth{
-			ParamSlots: 3,
+			ParamSlots: 2,
 			GFunction:  ghelpers.TrapFunction,
 		}
 
 	ghelpers.MethodSignatures["javax/net/ssl/SSLContext.engineGetClientSessionContext()Ljavax/net/ssl/SSLSessionContext;"] =
 		ghelpers.GMeth{
-			ParamSlots: 1,
+			ParamSlots: 0,
 			GFunction:  ghelpers.TrapFunction,
 		}
 
 	ghelpers.MethodSignatures["javax/net/ssl/SSLContext.engineGetServerSessionContext()Ljavax/net/ssl/SSLSessionContext;"] =
 		ghelpers.GMeth{
-			ParamSlots: 1,
+			ParamSlots: 0,
 			GFunction:  ghelpers.TrapFunction,
 		}
 
 	ghelpers.MethodSignatures["javax/net/ssl/SSLContext.engineGetSocketFactory()Ljavax/net/ssl/SSLSocketFactory;"] =
 		ghelpers.GMeth{
-			ParamSlots: 1,
+			ParamSlots: 0,
 			GFunction:  ghelpers.TrapFunction,
 		}
 
 	ghelpers.MethodSignatures["javax/net/ssl/SSLContext.engineGetServerSocketFactory()Ljavax/net/ssl/SSLServerSocketFactory;"] =
 		ghelpers.GMeth{
-			ParamSlots: 1,
+			ParamSlots: 0,
 			GFunction:  ghelpers.TrapFunction,
 		}
 	ghelpers.MethodSignatures["javax/net/ssl/SSLContext.getClientSessionContext()Ljavax/net/ssl/SSLSessionContext;"] =


### PR DESCRIPTION
	modified:   gfunction/javaLang/javaLangObject.go
	modified:   gfunction/javaLang/javaLangThread.go
	modified:   gfunction/javaSecurity/javaSecurityECFieldAndPoint.go
	modified:   gfunction/javaSecurity/javaSecurityEllipticCurve.go
	modified:   gfunction/javaSecurity/javaSecuritySecureRandom.go
	modified:   gfunction/javaUtil/javaUtilProperties.go
	modified:   gfunction/javaUtil/javaUtilTimeZone.go
	modified:   gfunction/javaUtil/javaUtilTimeZone_test.go
	modified:   gfunction/javaxCrypto/javaxCryptoKeyAgreement.go
	modified:   gfunction/misc/javaxNetSslSslcontext.go

See JACOBIN-892 for details.