### PR TITLE
JACOBIN-811 don't look at stderr unless a subprocess returns an error in cmd.Wait

### DIFF
--- a/src/jvm/TestHexHello2Class_test.go
+++ b/src/jvm/TestHexHello2Class_test.go
@@ -101,7 +101,6 @@ func TestHexHello2ValidClass(t *testing.T) {
 	// Initialise global, logging, classloader
 	globals.InitGlobals("test")
 	trace.Init()
-	globals.TraceInst = true
 	statics.LoadProgramStatics()
 	t.Logf("globals.InitGlobals and trace.Init ok\n")
 	// globals.TraceCloadi = true

--- a/src/jvm/TestHexHello2Class_test.go
+++ b/src/jvm/TestHexHello2Class_test.go
@@ -101,6 +101,7 @@ func TestHexHello2ValidClass(t *testing.T) {
 	// Initialise global, logging, classloader
 	globals.InitGlobals("test")
 	trace.Init()
+	globals.TraceInst = true
 	statics.LoadProgramStatics()
 	t.Logf("globals.InitGlobals and trace.Init ok\n")
 	// globals.TraceCloadi = true
@@ -170,9 +171,9 @@ func TestHexHello2ValidClass(t *testing.T) {
 				string(msgStdout), string(msgStderr))
 		}
 
-		if string(msgStderr) != "" {
-			t.Errorf("Error in output: expected stderr to be empty, but saw:\n%s\n", string(msgStderr))
-		}
+		//if string(msgStderr) != "" {
+		//	t.Errorf("Error in output: expected stderr to be empty, but saw:\n%s\n", string(msgStderr))
+		//}
 	}
 }
 

--- a/src/jvm/gfunctionExec_test.go
+++ b/src/jvm/gfunctionExec_test.go
@@ -135,6 +135,7 @@ func TestGfuncINVOKEVIRTUALwith1stringArgtemplate(t *testing.T) {
 
 	globals.InitGlobals("test")
 	trace.Init()
+	globals.TraceInst = true
 	normalStderr := os.Stderr
 	rerr, werr, _ := os.Pipe()
 	os.Stderr = werr
@@ -198,20 +199,12 @@ func TestGfuncINVOKEVIRTUALwith1stringArgtemplate(t *testing.T) {
 	// get contents written by stderr and stdout, then
 	// restore stderr and stdout to what they were before the test
 	_ = werr.Close()
-	rawStderrMsg, _ := io.ReadAll(rerr)
+	_, _ = io.ReadAll(rerr)
 	os.Stderr = normalStderr
 
 	_ = wout.Close()
 	rawStdoutMsg, _ := io.ReadAll(rout)
 	os.Stdout = normalStdout
-
-	// convert the contents written to stderr and stdout into strings
-	// and run tests on those strings
-
-	errMsg := string(rawStderrMsg[:])
-	if len(errMsg) != 0 {
-		t.Errorf("gfunctionExec: Got unexpected error message: %s", errMsg)
-	}
 
 	outMsg := string(rawStdoutMsg[:])
 	if !strings.Contains(outMsg, stringParam) {

--- a/src/wholeClassTests/BitShifts_test.go
+++ b/src/wholeClassTests/BitShifts_test.go
@@ -45,7 +45,7 @@ func initVarsTestBitShifts() error {
 	}
 
 	_JACOBIN = os.Getenv("JACOBIN_EXE") // returns "" if JACOBIN_EXE has not been specified.
-	_JVM_ARGS = ""
+	_JVM_ARGS = "-trace:inst"
 	_TESTCLASS = "testBitShifts.class" // the class to test
 	_APP_ARGS = ""
 
@@ -111,17 +111,21 @@ func TestRunBitShifts(t *testing.T) {
 	}
 
 	// Here begin the actual tests on the output to stderr and stdout
-	slurp, _ := io.ReadAll(stderr)
-	slurpErr := string(slurp)
-	if len(slurp) != 0 {
-		t.Errorf("Got unexpected output to stderr: %s", slurpErr)
+	bStderr, _ := io.ReadAll(stderr)
+	bStdout, _ := io.ReadAll(stdout)
+	strStderr := string(bStderr)
+	strStdout := string(bStdout)
+
+	// Wait for completion
+	err = cmd.Wait()
+
+	// Success?
+	if err != nil {
+		t.Errorf("Got unexpected output to stderr: %s", strStderr)
 	}
 
-	slurp, _ = io.ReadAll(stdout)
-	slurpOut := string(slurp)
-
-	if !strings.Contains(slurpOut, "-100 >> 2: -25") &&
-		!strings.Contains(string(slurp), "+100 << 3: 800") {
-		t.Errorf("Did not get expected output to stdout. Got: %s", slurpOut)
+	if !strings.Contains(strStdout, "-100 >> 2: -25") &&
+		!strings.Contains(strStdout, "+100 << 3: 800") {
+		t.Errorf("Did not get expected output to stdout. Got: %s", strStdout)
 	}
 }

--- a/src/wholeClassTests/Hello1_test.go
+++ b/src/wholeClassTests/Hello1_test.go
@@ -65,7 +65,7 @@ func initVarsHello() error {
 	}
 
 	_JACOBIN = os.Getenv("JACOBIN_EXE") // returns "" if JACOBIN_EXE has not been specified.
-	_JVM_ARGS = ""
+	_JVM_ARGS = "-trace:inst"
 	_TESTCLASS = "Hello.class" // the class to test
 	_APP_ARGS = ""
 
@@ -126,15 +126,21 @@ func TestRunHello(t *testing.T) {
 	}
 
 	// Here begin the actual tests on the output to stderr and stdout
-	slurp, _ := io.ReadAll(stderr)
-	if len(slurp) != 0 {
-		t.Errorf("Got unexpected output to stderr: %s", string(slurp))
+	bStderr, _ := io.ReadAll(stderr)
+	bStdout, _ := io.ReadAll(stdout)
+	strStderr := string(bStderr)
+	strStdout := string(bStdout)
+
+	// Wait for completion
+	err = cmd.Wait()
+
+	// Success?
+	if err != nil {
+		t.Errorf("Got unexpected output to stderr: %s", strStderr)
 	}
 
-	slurp, _ = io.ReadAll(stdout)
-
-	if !strings.Contains(string(slurp), helloMsg) {
-		t.Errorf("Did not get expected output to stdout. Got: %s", string(slurp))
+	if !strings.Contains(strStdout, helloMsg) {
+		t.Errorf("Did not get expected output to stdout. Got: %s", strStdout)
 	}
 }
 

--- a/src/wholeClassTests/Hello2_test.go
+++ b/src/wholeClassTests/Hello2_test.go
@@ -132,6 +132,7 @@ func TestRunHello2(t *testing.T) {
 	// Here begin the actual tests on the output to stderr and stdout
 	bStderr, _ := io.ReadAll(stderr)
 	bStdout, _ := io.ReadAll(stdout)
+	strStderr := string(bStderr)
 	strStdout := string(bStdout)
 
 	// Wait for completion
@@ -139,7 +140,7 @@ func TestRunHello2(t *testing.T) {
 
 	// Success?
 	if err != nil {
-		t.Errorf("Got unexpected output to stderr: %s", string(bStderr))
+		t.Errorf("Got unexpected output to stderr: %s", strStderr)
 	}
 
 	if !strings.Contains(strStdout, "-1") && !strings.Contains(strStdout, "17") {

--- a/src/wholeClassTests/Hello3_test.go
+++ b/src/wholeClassTests/Hello3_test.go
@@ -49,7 +49,7 @@ func initVarsHello3() error {
 	}
 
 	_JACOBIN = os.Getenv("JACOBIN_EXE") // returns "" if JACOBIN_EXE has not been specified.
-	_JVM_ARGS = ""
+	_JVM_ARGS = "-trace:inst"
 	_TESTCLASS = "Hello3.class" // the class to test
 	_APP_ARGS = ""
 
@@ -119,16 +119,20 @@ func TestRunHello3(t *testing.T) {
 	}
 
 	// Here begin the actual tests on the output to stderr and stdout
-	slurp, _ := io.ReadAll(stderr)
-	slurpErr := string(slurp)
-	if len(slurp) != 0 {
-		t.Errorf("Got unexpected output to stderr: %s", slurpErr)
+	bStderr, _ := io.ReadAll(stderr)
+	bStdout, _ := io.ReadAll(stdout)
+	strStderr := string(bStderr)
+	strStdout := string(bStdout)
+
+	// Wait for completion
+	err = cmd.Wait()
+
+	// Success?
+	if err != nil {
+		t.Errorf("Got unexpected output to stderr: %s", strStderr)
 	}
 
-	slurp, _ = io.ReadAll(stdout)
-	slurpOut := string(slurp)
-
-	if !strings.Contains(slurpOut, "57") && !strings.Contains(string(slurp), "73") {
-		t.Errorf("Did not get expected output to stdout. Got: %s", slurpOut)
+	if !strings.Contains(strStdout, "57") && !strings.Contains(strStdout, "73") {
+		t.Errorf("Did not get expected output to stdout. Got: %s", strStdout)
 	}
 }

--- a/src/wholeClassTests/Nanoprint_test.go
+++ b/src/wholeClassTests/Nanoprint_test.go
@@ -48,7 +48,7 @@ func initVarsNanoPrint() error {
 	}
 
 	_JACOBIN = os.Getenv("JACOBIN_EXE") // returns "" if JACOBIN_EXE has not been specified.
-	_JVM_ARGS = ""
+	_JVM_ARGS = "-trace:inst"
 	_TESTCLASS = "NanoPrint.class" // the class to test
 	_APP_ARGS = ""
 
@@ -110,16 +110,20 @@ func TestRunNanoprint(t *testing.T) {
 	}
 
 	// Here begin the actual tests on the output to stderr and stdout
-	slurp, _ := io.ReadAll(stderr)
-	slurpErr := string(slurp)
-	if len(slurp) != 0 {
-		t.Errorf("Got unexpected output to stderr: %s", slurpErr)
+	bStderr, _ := io.ReadAll(stderr)
+	bStdout, _ := io.ReadAll(stdout)
+	strStderr := string(bStderr)
+	strStdout := string(bStdout)
+
+	// Wait for completion
+	err = cmd.Wait()
+
+	// Success?
+	if err != nil {
+		t.Errorf("Got unexpected output from cmd.Wait: %s", strStderr)
 	}
 
-	slurp, _ = io.ReadAll(stdout)
-	slurpOut := string(slurp)
-
-	outStrings := strings.Split(strings.ReplaceAll(slurpOut, "\r\n", "\n"), "\n")
+	outStrings := strings.Split(strings.ReplaceAll(strStdout, "\r\n", "\n"), "\n")
 	time1, err1 := strconv.Atoi(outStrings[0])
 	time2, err2 := strconv.Atoi(outStrings[1])
 

--- a/src/wholeClassTests/WIDE_test.go
+++ b/src/wholeClassTests/WIDE_test.go
@@ -31,7 +31,7 @@ func initVarsWIDE() error {
 	}
 
 	_JACOBIN = os.Getenv("JACOBIN_EXE") // returns "" if JACOBIN_EXE has not been specified.
-	_JVM_ARGS = ""
+	_JVM_ARGS = "-trace:inst"
 	_TESTCLASS = "testWIDE.class" // the class to test
 	_APP_ARGS = ""
 
@@ -92,14 +92,20 @@ func TestRunWIDE(t *testing.T) {
 	}
 
 	// Here begin the actual tests on the output to stderr and stdout
-	slurp, _ := io.ReadAll(stderr)
-	if len(slurp) != 0 {
-		t.Errorf("Got unexpected output to stderr: %s", string(slurp))
+	bStderr, _ := io.ReadAll(stderr)
+	bStdout, _ := io.ReadAll(stdout)
+	strStderr := string(bStderr)
+	strStdout := string(bStdout)
+
+	// Wait for completion
+	err = cmd.Wait()
+
+	// Success?
+	if err != nil {
+		t.Errorf("Got unexpected output from cmd.Wait: %s", strStderr)
 	}
 
-	slurp, _ = io.ReadAll(stdout)
-
-	if !strings.Contains(string(slurp), "total should be 3, is 3") {
-		t.Errorf("Did not get expected output to stdout. Got: %s", string(slurp))
+	if !strings.Contains(strStdout, "total should be 3, is 3") {
+		t.Errorf("Did not get expected output to stdout. Got: %s", strStdout)
 	}
 }

--- a/src/wholeClassTests/clientVersion_test.go
+++ b/src/wholeClassTests/clientVersion_test.go
@@ -85,7 +85,7 @@ func TestRunClientVersion(t *testing.T) {
 	// Here begin the actual tests on the output to stderr and stdout
 
 	slurp, _ := io.ReadAll(stderr)
-	if !strings.HasPrefix(string(slurp), "Jacobin VM") {
+	if !strings.Contains(string(slurp), "Jacobin VM") {
 		t.Errorf("Stderr did not begin with Jacobin name, instead: %s", string(slurp))
 	}
 

--- a/src/wholeClassTests/primitiveArrays_test.go
+++ b/src/wholeClassTests/primitiveArrays_test.go
@@ -62,7 +62,7 @@ func initVarsPrimitiveArrays() error {
 	}
 
 	_JACOBIN = os.Getenv("JACOBIN_EXE") // returns "" if JACOBIN_EXE has not been specified.
-	_JVM_ARGS = ""
+	_JVM_ARGS = "-trace:inst"
 	_TESTCLASS = "testArrays.class" // the class to test
 	_APP_ARGS = ""
 
@@ -127,35 +127,43 @@ func TestRunPrimitiveArrays(t *testing.T) {
 	}
 
 	// Here begin the actual tests on the output to stderr and stdout
-	slurp, _ := io.ReadAll(stderr)
-	if len(slurp) != 0 {
-		t.Errorf("Got unexpected output to stderr:\n%s", string(slurp))
+	bStderr, _ := io.ReadAll(stderr)
+	bStdout, _ := io.ReadAll(stdout)
+	strStderr := string(bStderr)
+	strStdout := string(bStdout)
+	//if len(slurp) != 0 {
+	//	t.Errorf("Got unexpected output to stderr:\n%s", string(slurp))
+	//}
+
+	// Wait for completion
+	err = cmd.Wait()
+
+	// Success?
+	if err != nil {
+		t.Errorf("Got unexpected output from cmd.Wait: %s", strStderr)
 	}
 
-	slurp, _ = io.ReadAll(stdout)
-	str := string(slurp)
-
-	if !strings.Contains(str, "intArray: 600") {
-		t.Errorf("Did not get expected output for intArray. Got:\n%s", string(slurp))
+	if !strings.Contains(strStdout, "intArray: 600") {
+		t.Errorf("Did not get expected output for intArray. Got:\n%s", strStdout)
 	}
 
-	if !strings.Contains(str, "floatArray: 400") {
-		t.Errorf("Did not get expected output for floatArray. Got:\n%s", string(slurp))
+	if !strings.Contains(strStdout, "floatArray: 400") {
+		t.Errorf("Did not get expected output for floatArray. Got:\n%s", strStdout)
 	}
 
-	if !strings.Contains(str, "longArray: 5000") {
-		t.Errorf("Did not get expected output for longArray. Got:\n%s", string(slurp))
+	if !strings.Contains(strStdout, "longArray: 5000") {
+		t.Errorf("Did not get expected output for longArray. Got:\n%s", strStdout)
 	}
 
-	if !strings.Contains(str, "doubleArray: 1.000003") {
-		t.Errorf("Did not get expected output for doubleArray. Got:\n%s", string(slurp))
+	if !strings.Contains(strStdout, "doubleArray: 1.000003") {
+		t.Errorf("Did not get expected output for doubleArray. Got:\n%s", strStdout)
 	}
 
-	if !strings.Contains(str, "booleanArray: 3") {
-		t.Errorf("Did not get expected output for booleanArray. Got:\n%s", string(slurp))
+	if !strings.Contains(strStdout, "booleanArray: 3") {
+		t.Errorf("Did not get expected output for booleanArray. Got:\n%s", strStdout)
 	}
 
-	if !strings.Contains(str, "byteArray: 9") {
-		t.Errorf("Did not get expected output for byteArray. Got:\n%s", string(slurp))
+	if !strings.Contains(strStdout, "byteArray: 9") {
+		t.Errorf("Did not get expected output for byteArray. Got:\n%s", strStdout)
 	}
 }

--- a/src/wholeClassTests/println_void_237_test.go
+++ b/src/wholeClassTests/println_void_237_test.go
@@ -34,7 +34,7 @@ func initVarsPrint_237() error {
 	}
 
 	_JACOBIN = os.Getenv("JACOBIN_EXE") // returns "" if JACOBIN_EXE has not been specified.
-	_JVM_ARGS = ""
+	_JVM_ARGS = "-trace:inst"
 	_TESTCLASS = "println_void_JACOBIN_237.class" // the class to test
 	_APP_ARGS = ""
 
@@ -96,17 +96,20 @@ func TestRun237(t *testing.T) {
 	}
 
 	// Here begin the actual tests on the output to stderr and stdout
-	slurp, _ := io.ReadAll(stderr)
-	slurpErr := string(slurp)
-	if len(slurp) != 0 {
-		t.Errorf("Got unexpected output to stderr: %s", slurpErr)
+	bStderr, _ := io.ReadAll(stderr)
+	bStdout, _ := io.ReadAll(stdout)
+	strStderr := string(bStderr)
+	strStdout := string(bStdout)
+
+	// Wait for completion
+	err = cmd.Wait()
+	// Success?
+	if err != nil {
+		t.Errorf("Got unexpected output from cmd.Wait: %s", strStderr)
 	}
 
-	slurp, _ = io.ReadAll(stdout)
-	slurpOut := string(slurp)
-
-	poss1 := strings.Count(slurpOut, "\n\n")
-	poss2 := strings.Count(slurpOut, "\r\r")
+	poss1 := strings.Count(strStdout, "\n\n")
+	poss2 := strings.Count(strStdout, "\r\r")
 
 	// due to running on multiple platforms, the output could be
 	// two /n or two /r, so both are checked.

--- a/src/wholeClassTests/showVersion_test.go
+++ b/src/wholeClassTests/showVersion_test.go
@@ -98,7 +98,7 @@ func TestRunShowVersion(t *testing.T) {
 	}
 
 	serr, _ := io.ReadAll(stderr)
-	if !strings.HasPrefix(string(serr), "Jacobin VM") {
+	if !strings.Contains(string(serr), "Jacobin VM") {
 		t.Errorf("Output did not begin with Jacobin name, instead: %s", string(serr))
 	}
 

--- a/src/wholeClassTests/systemExit0_235_test.go
+++ b/src/wholeClassTests/systemExit0_235_test.go
@@ -32,7 +32,7 @@ func initVarsPrint_235() error {
 	}
 
 	_JACOBIN = os.Getenv("JACOBIN_EXE") // returns "" if JACOBIN_EXE has not been specified.
-	_JVM_ARGS = ""
+	_JVM_ARGS = "-trace:inst"
 	_TESTCLASS = "SystemExit0_JACOBIN235.class" // the class to test
 	_APP_ARGS = ""
 
@@ -83,27 +83,26 @@ func TestRun235(t *testing.T) {
 
 	// get the stdout and stderr contents from the file execution
 	stderr, err := cmd.StderrPipe()
-	stdout, err := cmd.StdoutPipe()
+	//stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// run the command
 	if err = cmd.Start(); err != nil {
-		t.Errorf("Got error running Jacobin: %s", err.Error())
+		t.Errorf("Got error starting Jacobin: %s", err.Error())
 	}
 
 	// Here begin the actual tests on the output to stderr and stdout
-	slurp, _ := io.ReadAll(stderr)
-	slurpErr := string(slurp)
-	if len(slurp) != 0 {
-		t.Errorf("Got unexpected output to stderr: %s", slurpErr)
-	}
+	bStderr, _ := io.ReadAll(stderr)
+	//bStdout, _ := io.ReadAll(stdout)
+	strStderr := string(bStderr)
+	//strStdout := string(bStdout)
 
-	slurp, _ = io.ReadAll(stdout)
-	slurpOut := string(slurp)
-
-	if len(slurpOut) != 0 {
-		t.Errorf("Got unexpected output to stdout: %s", slurpErr)
+	// Wait for completion
+	err = cmd.Wait()
+	// Success?
+	if err != nil {
+		t.Errorf("Got unexpected output from cmd.Wait: %s", strStderr)
 	}
 }

--- a/src/wholeClassTests/version_test.go
+++ b/src/wholeClassTests/version_test.go
@@ -99,7 +99,7 @@ func TestRunVersion(t *testing.T) {
 	// Here begin the actual tests on the output to stderr and stdout
 
 	slurp, _ := io.ReadAll(stderr)
-	if !strings.HasPrefix(string(slurp), "Jacobin VM") {
+	if !strings.Contains(string(slurp), "Jacobin VM") {
 		t.Errorf("Stderr did not begin with Jacobin name, instead: %s", string(slurp))
 	}
 


### PR DESCRIPTION
	modified:   jvm/TestHexHello2Class_test.go
	modified:   jvm/gfunctionExec_test.go
	modified:   wholeClassTests/BitShifts_test.go
	modified:   wholeClassTests/Hello1_test.go
	modified:   wholeClassTests/Hello2_test.go
	modified:   wholeClassTests/Hello3_test.go
	modified:   wholeClassTests/Nanoprint_test.go
	modified:   wholeClassTests/WIDE_test.go
	modified:   wholeClassTests/clientVersion_test.go
	modified:   wholeClassTests/primitiveArrays_test.go
	modified:   wholeClassTests/println_void_237_test.go
	modified:   wholeClassTests/showVersion_test.go
	modified:   wholeClassTests/systemExit0_235_test.go
	modified:   wholeClassTests/version_test.go
