### PR TITLE
JACOBIN-894 and -895

### DIFF
--- a/src/gfunction/javaMath/javaMathBigInteger.go
+++ b/src/gfunction/javaMath/javaMathBigInteger.go
@@ -900,32 +900,33 @@ func bigIntegerHashCode(params []interface{}) interface{} {
 	// big.Int.Bytes() returns big-endian bytes.
 	bytes := bi.Bytes()
 
-	// Convert bytes to int32 array (mag array in Java)
-	var mag []int32
+	// Convert bytes to uint32 array (mag array in Java)
+	var mag []uint32
 	// If the byte array length is not a multiple of 4, we need to handle the first few bytes.
 	firstIntLen := len(bytes) % 4
 	if firstIntLen > 0 {
-		var firstInt int32
+		var firstInt uint32
 		for i := 0; i < firstIntLen; i++ {
-			firstInt = (firstInt << 8) | int32(bytes[i])
+			firstInt = (firstInt << 8) | uint32(bytes[i])
 		}
 		mag = append(mag, firstInt)
 	}
 
 	for i := firstIntLen; i < len(bytes); i += 4 {
-		var val int32
+		var val uint32
 		for j := 0; j < 4; j++ {
-			val = (val << 8) | int32(bytes[i+j])
+			val = (val << 8) | uint32(bytes[i+j])
 		}
 		mag = append(mag, val)
 	}
 
-	var hashCode int32 = 0
+	var hashCode uint32 = 0
 	for _, val := range mag {
 		hashCode = 31*hashCode + val
 	}
 
-	return int64(hashCode * int32(bi.Sign()))
+	res := int32(hashCode) * int32(bi.Sign())
+	return int64(res)
 }
 
 // "java/math/BigInteger.intValue()I"

--- a/src/gfunction/javaSecurity/javaSecuritySignature.go
+++ b/src/gfunction/javaSecurity/javaSecuritySignature.go
@@ -867,8 +867,17 @@ func signDSA(privateKey *dsa.PrivateKey, data []byte, algo string) ([]byte, erro
 		return nil, err
 	}
 
-	// Concatenate r and s
-	signature := append(r.Bytes(), s.Bytes()...)
+	// DSA signature in Java is typically ASN.1 DER encoded (r, s)
+	// though some libraries use fixed-length concatenation (P1363).
+	// Go's dsa package provides r and s, but doesn't have a built-in ASN.1 encoder.
+	// We'll use fixed-length concatenation (P1363 format) as it's common in some contexts,
+	// but we MUST ensure they are padded to the correct length (size of Q).
+
+	qLen := (privateKey.Q.BitLen() + 7) / 8
+	signature := make([]byte, 2*qLen)
+	r.FillBytes(signature[:qLen])
+	s.FillBytes(signature[qLen:])
+
 	return signature, nil
 }
 
@@ -876,10 +885,13 @@ func verifyDSA(publicKey *dsa.PublicKey, data []byte, signature []byte, algo str
 	hashType := getSigHashForAlgorithm(algo)
 	hashed := hashData(data, hashType)
 
-	// Split signature into r and s
-	sigLen := len(signature) / 2
-	r := new(big.Int).SetBytes(signature[:sigLen])
-	s := new(big.Int).SetBytes(signature[sigLen:])
+	qLen := (publicKey.Q.BitLen() + 7) / 8
+	if len(signature) != 2*qLen {
+		return false
+	}
+
+	r := new(big.Int).SetBytes(signature[:qLen])
+	s := new(big.Int).SetBytes(signature[qLen:])
 
 	return dsa.Verify(publicKey, hashed, r, s)
 }

--- a/src/types/constants.go
+++ b/src/types/constants.go
@@ -84,6 +84,7 @@ var ClassNameRSAPublicKey = "java/security/interfaces/RSAPublicKey"
 var ClassNameSecurityProvider = "java/security/Provider"
 var ClassNameSecurityProviderService = "java/security/Provider$Service"
 var ClassNameSignature = "java/security/Signature"
+var ClassNameSecretKey = "javax/crypto/SecretKey"
 var ClassNameSecureRandom = "java/security/SecureRandom"
 
 // File system


### PR DESCRIPTION
See https://jacobin.myjetbrains.com/youtrack/issue/JACOBIN-894/DSA-Signature-Verification-occasionally-failed

`gfunction/javaSecurity/javaSecuritySignature.go`

and https://jacobin.myjetbrains.com/youtrack/issue/JACOBIN-895/BigInteger-hashCode-should-use-uint32-not-int32

`gfunction/javaMath/javaMathBigInteger.go`