### PR TITLE
JACOBIN-902 throw must quick abort if f.Thread=0

### DIFF
--- a/src/exceptions/throw.go
+++ b/src/exceptions/throw.go
@@ -62,7 +62,7 @@ func ThrowEx(which int, msg string, f *frames.Frame) bool {
 		return NotCaught
 	}
 
-	// Frame pointer provided?
+	// Frame pointer and thread ID provided?
 	if f == nil || f.Thread < 1 {
 		MinimalAbort(which, msg) // this calls exit()
 		return NotCaught         // only occurs in tests

--- a/src/exceptions/throw.go
+++ b/src/exceptions/throw.go
@@ -63,7 +63,7 @@ func ThrowEx(which int, msg string, f *frames.Frame) bool {
 	}
 
 	// Frame pointer provided?
-	if f == nil {
+	if f == nil || f.Thread < 1 {
 		MinimalAbort(which, msg) // this calls exit()
 		return NotCaught         // only occurs in tests
 	}

--- a/src/jvm/jvmStart.go
+++ b/src/jvm/jvmStart.go
@@ -215,8 +215,9 @@ func JVMrun() int {
 	}
 
 	// Instantiate the class so that any static initializers are run.
+	fs := frames.CreateFrameStack()
 	_, instantiateError :=
-		globals.GetGlobalRef().FuncInstantiateClass(clName, frames.CreateFrameStack())
+		globals.GetGlobalRef().FuncInstantiateClass(clName, fs)
 	if instantiateError != nil {
 		errMsg := "RunJavaThread: Error instantiating: " + clName + ".main()"
 		exceptions.ThrowEx(excNames.InstantiationException, errMsg, nil)


### PR DESCRIPTION
modified: exceptions/throw.go
```
	// Frame pointer and thread ID provided?   <--- line 65
	if f == nil || f.Thread < 1 {
		MinimalAbort(which, msg) // this calls exit()
		return NotCaught         // only occurs in tests
	}
```