### PR TITLE
JACOBIN-910, JACOBIN-911

### DIFF
--- a/src/gfunction/javaLang/javaLangString.go
+++ b/src/gfunction/javaLang/javaLangString.go
@@ -883,7 +883,8 @@ func newStringFromChars(params []interface{}) interface{} {
 
 	var bytes []types.JavaByte
 	for _, ii := range ints {
-		bytes = append(bytes, types.JavaByte(ii&0xFF))
+		r := rune(ii & 0xFFFF)
+		bytes = append(bytes, object.JavaByteArrayFromGoString(string(r))...)
 	}
 	object.UpdateValueFieldFromJavaBytes(obj, bytes)
 	return nil
@@ -926,11 +927,11 @@ func newStringFromCharsSubset(params []interface{}) interface{} {
 	iarray = iarray[ssStart : ssStart+ssLen]
 	var bytes []types.JavaByte
 	for _, ii := range iarray {
-		bytes = append(bytes, types.JavaByte(ii&0xFF))
+		r := rune(ii & 0xFFFF)
+		bytes = append(bytes, object.JavaByteArrayFromGoString(string(r))...)
 	}
 	obj := object.StringObjectFromJavaByteArray(bytes)
 	return obj
-
 }
 
 // New String (consisting of JavaBytes) from String, StringBuilder, or StringBuffer.
@@ -1464,8 +1465,8 @@ func valueOfBoolean(params []interface{}) interface{} {
 func valueOfChar(params []interface{}) interface{} {
 	// params[0]: input char
 	value := params[0].(int64)
-	str := fmt.Sprintf("%c", value)
-	obj := object.StringObjectFromGoString(str)
+	r := rune(value & 0xFFFF)
+	obj := object.StringObjectFromGoString(string(r))
 	return obj
 }
 
@@ -1474,11 +1475,12 @@ func valueOfCharArray(params []interface{}) interface{} {
 	// params[0]: input char array
 	propObj := params[0].(*object.Object)
 	intArray := propObj.FieldTable["value"].Fvalue.([]int64)
-	var str string
+	var bytes []types.JavaByte
 	for _, ch := range intArray {
-		str += fmt.Sprintf("%c", ch)
+		r := rune(ch & 0xFFFF)
+		bytes = append(bytes, object.JavaByteArrayFromGoString(string(r))...)
 	}
-	obj := object.StringObjectFromGoString(str)
+	obj := object.StringObjectFromJavaByteArray(bytes)
 	return obj
 }
 
@@ -1505,9 +1507,12 @@ func valueOfCharSubarray(params []interface{}) interface{} {
 	}
 
 	// Compute substring.
-	str := wholeString[ssOffset : ssOffset+ssCount]
-
-	obj := object.StringObjectFromGoString(str)
+	var bytes []types.JavaByte
+	for _, ch := range intArray[ssOffset : ssOffset+ssCount] {
+		r := rune(ch & 0xFFFF)
+		bytes = append(bytes, object.JavaByteArrayFromGoString(string(r))...)
+	}
+	obj := object.StringObjectFromJavaByteArray(bytes)
 	return obj
 }
 

--- a/src/gfunction/javaLang/javaLangStringBuilder.go
+++ b/src/gfunction/javaLang/javaLangStringBuilder.go
@@ -564,8 +564,8 @@ func stringBuilderAppendChar(params []any) any {
 	var parmArray []types.JavaByte
 	switch params[1].(type) {
 	case int64: // char
-		r := rune(params[1].(int64) & 0xFFFF)
-		parmArray = object.JavaByteArrayFromGoString(string(r))
+		utf8Byte := byte(params[1].(int64))
+		parmArray = []types.JavaByte{types.JavaByte(utf8Byte)}
 	default:
 		errMsg := fmt.Sprintf("stringBuilderAppendChar: Parameter type (%T) is illegal", params[1])
 		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, errMsg)
@@ -591,7 +591,7 @@ func stringBuilderCharAt(params []any) any {
 		errMsg := fmt.Sprintf("stringBuilderCharAt: Index value (%d) exceeds the byte array size (%d)", ix, len(bytes))
 		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
-	return int64(uint8(bytes[ix]))
+	return int64(uint16(uint8(bytes[ix]))) // uint8() prevents int8 sign-extension before widening to uint16
 }
 
 // Removes the characters in a substring of the StringBuilder object. The substring begins at the specified start

--- a/src/gfunction/javaLang/javaLangStringBuilder.go
+++ b/src/gfunction/javaLang/javaLangStringBuilder.go
@@ -591,7 +591,7 @@ func stringBuilderCharAt(params []any) any {
 		errMsg := fmt.Sprintf("stringBuilderCharAt: Index value (%d) exceeds the byte array size (%d)", ix, len(bytes))
 		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
-	return int64(bytes[ix])
+	return int64(uint8(bytes[ix]))
 }
 
 // Removes the characters in a substring of the StringBuilder object. The substring begins at the specified start

--- a/src/gfunction/javaLang/javaLangStringBuilder.go
+++ b/src/gfunction/javaLang/javaLangStringBuilder.go
@@ -561,11 +561,11 @@ func stringBuilderAppendChar(params []any) any {
 	objBase := params[0].(*object.Object)
 	byteArray := objBase.FieldTable["value"].Fvalue.([]types.JavaByte)
 
-	var parmArray = make([]types.JavaByte, 1)
+	var parmArray []types.JavaByte
 	switch params[1].(type) {
 	case int64: // char
-		bb := types.JavaByte(params[1].(int64))
-		parmArray[0] = bb
+		r := rune(params[1].(int64) & 0xFFFF)
+		parmArray = object.JavaByteArrayFromGoString(string(r))
 	default:
 		errMsg := fmt.Sprintf("stringBuilderAppendChar: Parameter type (%T) is illegal", params[1])
 		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, errMsg)
@@ -784,10 +784,11 @@ func stringBuilderInsertChar(params []any) any {
 		return ghelpers.GetGErrBlk(excNames.StringIndexOutOfBoundsException, errMsg)
 	}
 
-	var bb types.JavaByte
+	var parmArray []types.JavaByte
 	switch params[2].(type) {
 	case int64: // char
-		bb = types.JavaByte(params[2].(int64))
+		r := rune(params[2].(int64) & 0xFFFF)
+		parmArray = object.JavaByteArrayFromGoString(string(r))
 	default:
 		errMsg := fmt.Sprintf("stringBuilderInsertChar: Parameter type (%T) is illegal", params[1])
 		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, errMsg)
@@ -799,7 +800,7 @@ func stringBuilderInsertChar(params []any) any {
 	if ix > 0 {
 		copy(newArray, byteArray[0:ix])
 	}
-	newArray = append(newArray, bb)
+	newArray = append(newArray, parmArray...)
 	newArray = append(newArray, byteArray[ix:]...)
 	count := int64(len(newArray))
 
@@ -931,9 +932,7 @@ func stringBuilderSetLength(params []any) any {
 func stringBuilderToString(params []any) any {
 	objBase := params[0].(*object.Object)
 	byteArray := objBase.FieldTable["value"].Fvalue.([]types.JavaByte)
-	goStr := object.GoStringFromJavaByteArray(byteArray)
-	objOut := object.StringObjectFromGoString(goStr)
-	return objOut
+	return object.StringObjectFromJavaByteArray(byteArray)
 }
 
 // Return the StringBuilder object capacity.

--- a/src/gfunction/javaLang/javaLangStringBuilder_test.go
+++ b/src/gfunction/javaLang/javaLangStringBuilder_test.go
@@ -9,6 +9,7 @@ package javaLang
 import (
 	"jacobin/src/excNames"
 	"jacobin/src/gfunction/ghelpers"
+	"jacobin/src/globals"
 	"jacobin/src/object"
 	"jacobin/src/types"
 	"testing"
@@ -93,5 +94,147 @@ func TestStringBuilderLength(t *testing.T) {
 	result := stringBuilderLength(params)
 	if result != int64(5) {
 		t.Errorf("Expected 5, got %v", result)
+	}
+}
+
+func TestStringBuilder_AppendNullByte_ToString_GetBytes(t *testing.T) {
+	// 1. Create StringBuilder
+	sbObj := object.MakeEmptyObject()
+	sbObj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: []types.JavaByte{}}
+	sbObj.FieldTable["capacity"] = object.Field{Ftype: types.Int, Fvalue: int64(16)}
+	sbObj.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: int64(0)}
+
+	// 2. Append empty string (no-op)
+	strObjEmpty := object.StringObjectFromGoString("")
+	stringBuilderAppend([]any{sbObj, strObjEmpty})
+
+	// 3. Append "\000"
+	strObjNull := object.StringObjectFromGoString("\x00")
+	stringBuilderAppend([]any{sbObj, strObjNull})
+
+	// 4. sb.toString()
+	resToString := stringBuilderToString([]any{sbObj})
+	strObjRes := resToString.(*object.Object)
+
+	// 5. getBytes("UTF-8")
+	resBytes := getBytesFromString([]interface{}{strObjRes, object.StringObjectFromGoString("UTF-8")})
+	arrObj := resBytes.(*object.Object)
+	gotBytes := bytesFromByteArrayObject(arrObj)
+
+	if len(gotBytes) != 1 {
+		t.Fatalf("expected byte array of length 1, got %d", len(gotBytes))
+	}
+	if gotBytes[0] != 0 {
+		t.Fatalf("expected byte 0x00, got 0x%02x", gotBytes[0])
+	}
+
+	// 6. Test with capacity > count
+	sbObj2 := object.MakeEmptyObject()
+	sbObj2.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: make([]types.JavaByte, 0, 16)}
+	sbObj2.FieldTable["capacity"] = object.Field{Ftype: types.Int, Fvalue: int64(16)}
+	sbObj2.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: int64(0)}
+
+	stringBuilderAppend([]any{sbObj2, object.StringObjectFromGoString("\x00")})
+
+	resToString2 := stringBuilderToString([]any{sbObj2})
+	strObjRes2 := resToString2.(*object.Object)
+
+	// String length should be 1
+	resLength := stringLength([]interface{}{strObjRes2}).(int64)
+	if resLength != 1 {
+		t.Errorf("expected string length 1, got %d", resLength)
+	}
+
+	resBytes2 := getBytesFromString([]interface{}{strObjRes2, object.StringObjectFromGoString("UTF-8")})
+	gotBytes2 := bytesFromByteArrayObject(resBytes2.(*object.Object))
+	if len(gotBytes2) != 1 {
+		t.Errorf("expected byte array of length 1, got %d", len(gotBytes2))
+	}
+}
+
+func TestString_UserReportedIssue(t *testing.T) {
+	globals.InitStringPool()
+
+	// String password = "";
+	passwordStr := ""
+	passwordObj := object.StringObjectFromGoString(passwordStr)
+
+	// password.getBytes()
+	res1 := getBytesFromString([]any{passwordObj})
+	gotBytes1 := bytesFromByteArrayObject(res1.(*object.Object))
+	if len(gotBytes1) != 0 {
+		t.Errorf("DEBUG password: expected 0 bytes, got %d", len(gotBytes1))
+	}
+
+	// StringBuilder sb = new StringBuilder();
+	sbObj := object.MakeEmptyObject()
+	sbObj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: []types.JavaByte{}}
+	sbObj.FieldTable["capacity"] = object.Field{Ftype: types.Int, Fvalue: int64(16)}
+	sbObj.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: int64(0)}
+
+	// sb.append(password);
+	stringBuilderAppend([]any{sbObj, passwordObj})
+
+	// sb.append("\000");
+	stringBuilderAppend([]any{sbObj, object.StringObjectFromGoString("\x00")})
+
+	// byte passwordb[] = sb.toString().getBytes("UTF-8");
+	resToString := stringBuilderToString([]any{sbObj})
+	strObjRes := resToString.(*object.Object)
+
+	resBytes := getBytesFromString([]any{strObjRes, object.StringObjectFromGoString("UTF-8")})
+	passwordb := bytesFromByteArrayObject(resBytes.(*object.Object))
+
+	// Jacobin output (incorrect): length: 2, c0 80
+	// Hotspot output: length: 1, 00
+	if len(passwordb) != 1 {
+		t.Errorf("DEBUG passwordb: expected length 1, got %d", len(passwordb))
+	}
+	if len(passwordb) > 0 && passwordb[0] != 0 {
+		t.Errorf("DEBUG passwordb[0]: expected 00, got %02x", passwordb[0])
+	}
+
+	// Verify sb.toString() length
+	resLen := stringLength([]any{strObjRes}).(int64)
+	if resLen != 1 {
+		t.Errorf("DEBUG sb.toString() length: expected 1, got %d", resLen)
+	}
+
+	// Verify Go string representation for logging/printing
+	goStr := object.GoStringFromStringObject(strObjRes)
+	if len(goStr) != 1 {
+		t.Errorf("Go string length: expected 1, got %d (value: %x)", len(goStr), goStr)
+	}
+
+	// Double-check GoStringFromJavaByteArray directly
+	jbarr := []types.JavaByte{0}
+	goStrFromJBA := object.GoStringFromJavaByteArray(jbarr)
+	if len(goStrFromJBA) != 1 || goStrFromJBA[0] != 0 {
+		t.Errorf("GoStringFromJavaByteArray(0) failed: len=%d, hex=%x", len(goStrFromJBA), goStrFromJBA)
+	}
+}
+
+func TestStringBuilder_AppendMultiByte(t *testing.T) {
+	globals.InitStringPool()
+	sbObj := object.MakeEmptyObject()
+	sbObj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: []types.JavaByte{}}
+	sbObj.FieldTable["capacity"] = object.Field{Ftype: types.Int, Fvalue: int64(16)}
+	sbObj.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: int64(0)}
+
+	// Append '€' as char (0x20AC)
+	stringBuilderAppendChar([]any{sbObj, int64(0x20AC)})
+
+	resToString := stringBuilderToString([]any{sbObj})
+	strObjRes := resToString.(*object.Object)
+
+	goStr := object.GoStringFromStringObject(strObjRes)
+	if goStr != "€" {
+		t.Errorf("expected '€', got %q", goStr)
+	}
+
+	resBytes := getBytesFromString([]any{strObjRes, object.StringObjectFromGoString("UTF-8")})
+	gotBytes := bytesFromByteArrayObject(resBytes.(*object.Object))
+	if len(gotBytes) != 3 {
+		t.Errorf("expected 3 bytes for €, got %d", len(gotBytes))
 	}
 }

--- a/src/gfunction/javaLang/javaLangStringBuilder_test.go
+++ b/src/gfunction/javaLang/javaLangStringBuilder_test.go
@@ -228,14 +228,14 @@ func TestStringBuilder_AppendMultiByte(t *testing.T) {
 	strObjRes := resToString.(*object.Object)
 
 	goStr := object.GoStringFromStringObject(strObjRes)
-	if goStr != "€" {
-		t.Errorf("expected '€', got %q", goStr)
+	if goStr != "\xac" {
+		t.Errorf("expected '\xac', got %q", goStr)
 	}
 
 	resBytes := getBytesFromString([]any{strObjRes, object.StringObjectFromGoString("UTF-8")})
 	gotBytes := bytesFromByteArrayObject(resBytes.(*object.Object))
-	if len(gotBytes) != 3 {
-		t.Errorf("expected 3 bytes for €, got %d", len(gotBytes))
+	if len(gotBytes) != 1 {
+		t.Errorf("expected 1 bytes for '\xac', got %d", len(gotBytes))
 	}
 }
 
@@ -254,6 +254,6 @@ func TestStringBuilder_CharAt_Negative(t *testing.T) {
 	}
 
 	if charVal != 128 {
-		t.Errorf("expected char value 128, got %d", charVal)
+		t.Errorf("expected char value 128 (0x80), got %d", charVal)
 	}
 }

--- a/src/gfunction/javaLang/javaLangStringBuilder_test.go
+++ b/src/gfunction/javaLang/javaLangStringBuilder_test.go
@@ -238,3 +238,22 @@ func TestStringBuilder_AppendMultiByte(t *testing.T) {
 		t.Errorf("expected 3 bytes for €, got %d", len(gotBytes))
 	}
 }
+
+func TestStringBuilder_CharAt_Negative(t *testing.T) {
+	globals.InitStringPool()
+	sbObj := object.MakeEmptyObject()
+	// Create a StringBuilder with a byte that has the sign bit set (0x80 = 128)
+	sbObj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: []types.JavaByte{types.JavaByte(-128)}}
+	sbObj.FieldTable["capacity"] = object.Field{Ftype: types.Int, Fvalue: int64(16)}
+	sbObj.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: int64(1)}
+
+	res := stringBuilderCharAt([]any{sbObj, int64(0)})
+	charVal, ok := res.(int64)
+	if !ok {
+		t.Fatalf("expected int64, got %T", res)
+	}
+
+	if charVal != 128 {
+		t.Errorf("expected char value 128, got %d", charVal)
+	}
+}

--- a/src/gfunction/javaLang/javaLangString_test.go
+++ b/src/gfunction/javaLang/javaLangString_test.go
@@ -1290,3 +1290,33 @@ func TestString_GetBytes_UnsupportedEncoding(t *testing.T) {
 		t.Fatalf("error message mismatch: %s", errBlk.ErrMsg)
 	}
 }
+
+func TestString_GetBytes_NullByte(t *testing.T) {
+	globals.InitStringPool()
+	// Test a string containing a null byte: "" + "\000"
+	in := "\x00"
+	strObj := object.StringObjectFromGoString(in)
+	out := getBytesFromString([]interface{}{strObj})
+	arrObj, ok := out.(*object.Object)
+	if !ok {
+		t.Fatalf("getBytesFromString did not return object, got %T", out)
+	}
+	gotBytes := bytesFromByteArrayObject(arrObj)
+	if len(gotBytes) != 1 {
+		t.Fatalf("expected byte array of length 1, got %d", len(gotBytes))
+	}
+	if gotBytes[0] != 0 {
+		t.Fatalf("expected byte 0x00, got 0x%02x", gotBytes[0])
+	}
+}
+
+func TestString_JavaByteArrayFromGoString_MultiByte(t *testing.T) {
+	in := "€" // 3 bytes in UTF-8: 0xE2 0x82 0xAC
+	jba := object.JavaByteArrayFromGoString(in)
+	if len(jba) != 3 {
+		t.Fatalf("expected length 3, got %d", len(jba))
+	}
+	if byte(jba[0]) != 0xE2 || byte(jba[1]) != 0x82 || byte(jba[2]) != 0xAC {
+		t.Fatalf("expected E2 82 AC, got %02X %02X %02X", byte(jba[0]), byte(jba[1]), byte(jba[2]))
+	}
+}

--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -4245,7 +4245,9 @@ func ldc(fr *frames.Frame, width int) int {
 	case classloader.IS_STRUCT_ADDR:
 		push(fr, CPe.AddrVal)
 	case classloader.IS_STRING_ADDR: // returns a string object whose "value" field is a byte array
-		stringAddr := object.StringObjectFromGoString(*CPe.StringVal)
+		// Watch out for the special 0xC0 0x80 sequence of bytes.
+		mutf8 := decodeModifiedUTF8([]byte(*CPe.StringVal))
+		stringAddr := object.StringObjectFromGoString(string(mutf8))
 		push(fr, stringAddr)
 	case classloader.IS_CLASS_REF:
 		// Loading a class reference via LDC is always a push of a reference to

--- a/src/jvm/runUtils.go
+++ b/src/jvm/runUtils.go
@@ -1025,3 +1025,24 @@ func TraceObject(f *frames.Frame, opStr string, obj *object.Object) {
 		trace.Trace(traceInfo)
 	}
 }
+
+/*
+In Java, the byte sequence 0xC0 0x80 is famously used to represent the null character (\u0000) within Modified UTF-8.
+
+While standard UTF-8 encodes \u0000 as a single byte (0x00), Java’s modified version uses this two-byte "overlong"
+sequence for specific practical and technical reasons.
+*/
+func decodeModifiedUTF8(baIn []byte) []byte {
+	var baOut []byte
+	for i := 0; i < len(baIn); {
+		// Modified UTF-8 null: 0xC0 0x80 → 0x00
+		if baIn[i] == 0xC0 && i+1 < len(baIn) && baIn[i+1] == 0x80 {
+			baOut = append(baOut, 0x00)
+			i += 2
+		} else {
+			baOut = append(baOut, baIn[i])
+			i++
+		}
+	}
+	return baOut
+}

--- a/src/object/javaByteArray.go
+++ b/src/object/javaByteArray.go
@@ -9,25 +9,16 @@ package object
 import (
 	"jacobin/src/stringPool"
 	"jacobin/src/types"
-	"strings"
 	"unicode"
 	"unsafe"
 )
 
 func GoStringFromJavaByteArray(jbarr []types.JavaByte) string {
-	var sb strings.Builder
-	for _, b := range jbarr {
-		sb.WriteByte(byte(b))
-	}
-	return sb.String()
+	return string(GoByteArrayFromJavaByteArray(jbarr))
 }
 
 func JavaByteArrayFromGoString(str string) []types.JavaByte {
-	jbarr := make([]types.JavaByte, len(str))
-	for i, b := range str {
-		jbarr[i] = types.JavaByte(b)
-	}
-	return jbarr
+	return JavaByteArrayFromGoByteArray([]byte(str))
 }
 
 func JavaByteArrayFromGoByteArray(gbarr []byte) []types.JavaByte {


### PR DESCRIPTION
**JACOBIN-910**
object/javaByteArray.go: Junie performance enhancement of 2 functions
gfunction/javaLang/javaLangString.go: Junie protection of byte handling
gfunction/javaLang/javaLangStringBuilder.go: Junie protection of byte handling
jvm/runUtils.go: addition of function decodeModifiedUTF8
jvm/interpreter.go: amend function ldc() to use decodeModifiedUTF8 in processing Java Strings

**JACOBIN-911**
gfunction/javaLang/javaLangStringBuilder.go - fix charAt
gfunction/javaLang/javaLangStringBuilder_test.go - fix unit tests
