### PR TITLE
JACOBIN-923 Call a J function from a G function

### DIFF
--- a/src/exceptions/throw.go
+++ b/src/exceptions/throw.go
@@ -87,11 +87,17 @@ func ThrowEx(which int, msg string, f *frames.Frame) bool {
 
 	var fs *list.List
 	glob.ThreadLock.RLock()
-	th, ok := glob.Threads[f.Thread].(*object.Object)
+	rawTh, ok := glob.Threads[f.Thread]
 	glob.ThreadLock.RUnlock()
 	if !ok {
-		errMsg := fmt.Sprintf("[ThrowEx] glob.Threads index not found or entry corrupted, thread index: %d, FQN: %s",
+		errMsg := fmt.Sprintf("[ThrowEx] glob.Threads index not found, thread index: %d, FQN: %s",
 			f.Thread, frames.FormatFQN(f))
+		MinimalAbort(excNames.InternalException, errMsg)
+	}
+	th, ok := rawTh.(*object.Object)
+	if !ok {
+		errMsg := fmt.Sprintf("[ThrowEx] glob.Threads entry corrupted (expected *object.Object, got %T), thread index: %d, FQN: %s",
+			rawTh, f.Thread, frames.FormatFQN(f))
 		MinimalAbort(excNames.InternalException, errMsg)
 	}
 	fs = th.FieldTable["framestack"].Fvalue.(*list.List)

--- a/src/gfunction/gfunction.go
+++ b/src/gfunction/gfunction.go
@@ -99,7 +99,12 @@ func MTableLoadGFunctions(MTable *classloader.MT) {
 	javaMath.Load_Math_Rounding_Mode()
 
 	// java/nio/*
+	javaNio.Load_Nio_File_Attribute_BasicFileAttributes()
+	javaNio.Load_Nio_File_Attribute_FileTime()
 	javaNio.Load_Nio_File_Files()
+	javaNio.Load_Nio_File_FileVisitResult()
+	javaNio.Load_Nio_File_FileVisitor()
+	javaNio.Load_Nio_File_SimpleFileVisitor()
 	javaNio.Load_Nio_File_Path()
 	javaNio.Load_Nio_File_Paths()
 

--- a/src/gfunction/javaNio/javaNioFileAttributeBasicFileAttributes.go
+++ b/src/gfunction/javaNio/javaNioFileAttributeBasicFileAttributes.go
@@ -1,0 +1,103 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2026 by the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package javaNio
+
+import (
+	"io/fs"
+	"jacobin/src/gfunction/ghelpers"
+	"jacobin/src/object"
+	"jacobin/src/types"
+	"time"
+)
+
+func Load_Nio_File_Attribute_BasicFileAttributes() {
+	// isRegularFile()Z
+	ghelpers.MethodSignatures["java/nio/file/attribute/BasicFileAttributes.isRegularFile()Z"] =
+		ghelpers.GMeth{ParamSlots: 1, GFunction: bfaIsRegularFile}
+
+	// isDirectory()Z
+	ghelpers.MethodSignatures["java/nio/file/attribute/BasicFileAttributes.isDirectory()Z"] =
+		ghelpers.GMeth{ParamSlots: 1, GFunction: bfaIsDirectory}
+
+	// isSymbolicLink()Z
+	ghelpers.MethodSignatures["java/nio/file/attribute/BasicFileAttributes.isSymbolicLink()Z"] =
+		ghelpers.GMeth{ParamSlots: 1, GFunction: bfaIsSymbolicLink}
+
+	// isOther()Z
+	ghelpers.MethodSignatures["java/nio/file/attribute/BasicFileAttributes.isOther()Z"] =
+		ghelpers.GMeth{ParamSlots: 1, GFunction: bfaIsOther}
+
+	// size()J
+	ghelpers.MethodSignatures["java/nio/file/attribute/BasicFileAttributes.size()J"] =
+		ghelpers.GMeth{ParamSlots: 1, GFunction: bfaSize}
+
+	// lastModifiedTime()Ljava/nio/file/attribute/FileTime;
+	ghelpers.MethodSignatures["java/nio/file/attribute/BasicFileAttributes.lastModifiedTime()Ljava/nio/file/attribute/FileTime;"] =
+		ghelpers.GMeth{ParamSlots: 1, GFunction: bfaLastModifiedTime}
+}
+
+func bfaIsRegularFile(params []interface{}) interface{} {
+	obj := params[0].(*object.Object)
+	info := obj.FieldTable["info"].Fvalue.(fs.FileInfo)
+	return boolToJava(info.Mode().IsRegular())
+}
+
+func bfaIsDirectory(params []interface{}) interface{} {
+	obj := params[0].(*object.Object)
+	info := obj.FieldTable["info"].Fvalue.(fs.FileInfo)
+	return boolToJava(info.IsDir())
+}
+
+func bfaIsSymbolicLink(params []interface{}) interface{} {
+	obj := params[0].(*object.Object)
+	info := obj.FieldTable["info"].Fvalue.(fs.FileInfo)
+	return boolToJava(info.Mode()&fs.ModeSymlink != 0)
+}
+
+func bfaIsOther(params []interface{}) interface{} {
+	obj := params[0].(*object.Object)
+	info := obj.FieldTable["info"].Fvalue.(fs.FileInfo)
+	mode := info.Mode()
+	return boolToJava(!mode.IsRegular() && !info.IsDir() && mode&fs.ModeSymlink == 0)
+}
+
+func bfaSize(params []interface{}) interface{} {
+	obj := params[0].(*object.Object)
+	info := obj.FieldTable["info"].Fvalue.(fs.FileInfo)
+	return info.Size()
+}
+
+func bfaLastModifiedTime(params []interface{}) interface{} {
+	obj := params[0].(*object.Object)
+	info := obj.FieldTable["info"].Fvalue.(fs.FileInfo)
+	return newFileTime(info.ModTime())
+}
+
+func newBasicFileAttributes(info fs.FileInfo) *object.Object {
+	className := "java/nio/file/attribute/BasicFileAttributes"
+	obj := object.MakeEmptyObjectWithClassName(&className)
+	obj.FieldTable["info"] = object.Field{Ftype: "any", Fvalue: info}
+	return obj
+}
+
+func newFileTime(t time.Time) *object.Object {
+	className := "java/nio/file/attribute/FileTime"
+	obj := object.MakeEmptyObjectWithClassName(&className)
+	obj.FieldTable["value"] = object.Field{Ftype: types.Long, Fvalue: t.UnixMilli()}
+	return obj
+}
+
+func Load_Nio_File_Attribute_FileTime() {
+	// toMillis()J
+	ghelpers.MethodSignatures["java/nio/file/attribute/FileTime.toMillis()J"] =
+		ghelpers.GMeth{ParamSlots: 1, GFunction: fileTimeToMillis}
+}
+
+func fileTimeToMillis(params []interface{}) interface{} {
+	obj := params[0].(*object.Object)
+	return obj.FieldTable["value"].Fvalue.(int64)
+}

--- a/src/gfunction/javaNio/javaNioFileAttributeBasicFileAttributes_test.go
+++ b/src/gfunction/javaNio/javaNioFileAttributeBasicFileAttributes_test.go
@@ -1,0 +1,67 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2026 by the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package javaNio
+
+import (
+	"jacobin/src/globals"
+	"jacobin/src/object"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_BasicFileAttributes(t *testing.T) {
+	globals.InitGlobals("test")
+	Load_Nio_File_Attribute_BasicFileAttributes()
+	Load_Nio_File_Attribute_FileTime()
+
+	dir := t.TempDir()
+	f := filepath.Join(dir, "test.txt")
+	data := []byte("hello world")
+	if err := os.WriteFile(f, data, 0o644); err != nil {
+		t.Fatalf("prep: %v", err)
+	}
+
+	info, err := os.Stat(f)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+
+	attrs := newBasicFileAttributes(info)
+
+	// Test isRegularFile
+	if res := bfaIsRegularFile([]interface{}{attrs}); res.(int64) != 1 {
+		t.Errorf("expected isRegularFile to be true")
+	}
+
+	// Test isDirectory
+	if res := bfaIsDirectory([]interface{}{attrs}); res.(int64) != 0 {
+		t.Errorf("expected isDirectory to be false")
+	}
+
+	// Test size
+	if res := bfaSize([]interface{}{attrs}); res.(int64) != int64(len(data)) {
+		t.Errorf("expected size %d, got %d", len(data), res.(int64))
+	}
+
+	// Test lastModifiedTime
+	ft := bfaLastModifiedTime([]interface{}{attrs}).(*object.Object)
+	milli := fileTimeToMillis([]interface{}{ft})
+	if milli.(int64) != info.ModTime().UnixMilli() {
+		t.Errorf("expected lastModifiedTime %d, got %d", info.ModTime().UnixMilli(), milli.(int64))
+	}
+
+	// Test directory
+	dirInfo, _ := os.Stat(dir)
+	dirAttrs := newBasicFileAttributes(dirInfo)
+	if res := bfaIsDirectory([]interface{}{dirAttrs}); res.(int64) != 1 {
+		t.Errorf("expected isDirectory to be true for directory")
+	}
+	if res := bfaIsRegularFile([]interface{}{dirAttrs}); res.(int64) != 0 {
+		t.Errorf("expected isRegularFile to be false for directory")
+	}
+}

--- a/src/gfunction/javaNio/javaNioFileFileVisitResult.go
+++ b/src/gfunction/javaNio/javaNioFileFileVisitResult.go
@@ -1,0 +1,94 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2026 by the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package javaNio
+
+import (
+	"jacobin/src/excNames"
+	"jacobin/src/gfunction/ghelpers"
+	"jacobin/src/object"
+	"jacobin/src/statics"
+	"jacobin/src/types"
+	"sync"
+)
+
+func Load_Nio_File_FileVisitResult() {
+	ghelpers.MethodSignatures["java/nio/file/FileVisitResult.<clinit>()V"] =
+		ghelpers.GMeth{
+			ParamSlots: 0,
+			GFunction:  fvResultClinit,
+		}
+
+	ghelpers.MethodSignatures["java/nio/file/FileVisitResult.valueOf(Ljava/lang/String;)Ljava/nio/file/FileVisitResult;"] =
+		ghelpers.GMeth{
+			ParamSlots: 1,
+			GFunction:  fvResultValueOfString,
+		}
+
+	ghelpers.MethodSignatures["java/nio/file/FileVisitResult.values()[Ljava/nio/file/FileVisitResult;"] =
+		ghelpers.GMeth{
+			ParamSlots: 0,
+			GFunction:  fvResultValues,
+		}
+}
+
+var fvResultMutex = sync.Mutex{}
+var fvResultOnceInitialized bool = false
+var fvResultClassName = "java/nio/file/FileVisitResult"
+var fvResultNames = []string{"CONTINUE", "TERMINATE", "SKIP_SUBTREE", "SKIP_SIBLINGS"}
+var fvResultInstances []*object.Object
+
+func ensureFvResultInited() {
+	fvResultMutex.Lock()
+	defer fvResultMutex.Unlock()
+	if fvResultOnceInitialized {
+		return
+	}
+	fvResultInstances = make([]*object.Object, len(fvResultNames))
+	for i, nm := range fvResultNames {
+		obj := object.MakeEmptyObjectWithClassName(&fvResultClassName)
+		obj.FieldTable["name"] = object.Field{Ftype: types.StringClassRef, Fvalue: object.StringObjectFromGoString(nm)}
+		obj.FieldTable["ordinal"] = object.Field{Ftype: types.Int, Fvalue: int64(i)}
+		fvResultInstances[i] = obj
+		_ = statics.AddStatic(fvResultClassName+"."+nm, statics.Static{Type: "Ljava/nio/file/FileVisitResult;", Value: obj})
+	}
+	fvResultOnceInitialized = true
+}
+
+func fvResultClinit([]interface{}) interface{} {
+	ensureFvResultInited()
+	return nil
+}
+
+func fvResultValueOfString(params []interface{}) interface{} {
+	ensureFvResultInited()
+	if len(params) < 1 {
+		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, "FileVisitResult.valueOf(String): missing argument")
+	}
+	strObj, ok := params[0].(*object.Object)
+	if !ok || object.IsNull(strObj) {
+		return ghelpers.GetGErrBlk(excNames.NullPointerException, "FileVisitResult.valueOf(String): name is null")
+	}
+	if !object.IsStringObject(strObj) {
+		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, "FileVisitResult.valueOf(String): argument is not a String")
+	}
+	name := object.GoStringFromStringObject(strObj)
+	for i, nm := range fvResultNames {
+		if nm == name {
+			return fvResultInstances[i]
+		}
+	}
+	return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, "FileVisitResult.valueOf(String): no enum constant "+name)
+}
+
+func fvResultValues(params []interface{}) interface{} {
+	ensureFvResultInited()
+	arr := object.Make1DimRefArray("Ljava/nio/file/FileVisitResult;", int64(len(fvResultInstances)))
+	slot := arr.FieldTable["value"].Fvalue.([]*object.Object)
+	copy(slot, fvResultInstances)
+	arr.FieldTable["value"] = object.Field{Ftype: types.RefArray + "Ljava/nio/file/FileVisitResult;", Fvalue: slot}
+	return arr
+}

--- a/src/gfunction/javaNio/javaNioFileFileVisitResult_test.go
+++ b/src/gfunction/javaNio/javaNioFileFileVisitResult_test.go
@@ -1,0 +1,85 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2026 by the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package javaNio
+
+import (
+	"jacobin/src/excNames"
+	"jacobin/src/gfunction/ghelpers"
+	"jacobin/src/globals"
+	"jacobin/src/object"
+	"testing"
+)
+
+func Test_FileVisitResult_Enum(t *testing.T) {
+	globals.InitGlobals("test")
+	Load_Nio_File_FileVisitResult()
+
+	// Test clinit
+	fvResultClinit(nil)
+
+	// Test values()
+	res := fvResultValues(nil)
+	arr, ok := res.(*object.Object)
+	if !ok || arr == nil {
+		t.Fatalf("values() should return array object")
+	}
+	vals := arr.FieldTable["value"].Fvalue.([]*object.Object)
+	if len(vals) != 4 {
+		t.Fatalf("expected 4 FileVisitResult values, got %d", len(vals))
+	}
+
+	expectedNames := []string{"CONTINUE", "TERMINATE", "SKIP_SUBTREE", "SKIP_SIBLINGS"}
+	for i, name := range expectedNames {
+		nmObj := vals[i].FieldTable["name"].Fvalue.(*object.Object)
+		if object.GoStringFromStringObject(nmObj) != name {
+			t.Errorf("expected %s at index %d, got %s", name, i, object.GoStringFromStringObject(nmObj))
+		}
+		ord := vals[i].FieldTable["ordinal"].Fvalue.(int64)
+		if ord != int64(i) {
+			t.Errorf("expected ordinal %d for %s, got %d", i, name, ord)
+		}
+	}
+
+	// Test valueOf(String) success
+	for _, name := range expectedNames {
+		sObj := object.StringObjectFromGoString(name)
+		v := fvResultValueOfString([]interface{}{sObj})
+		if v == nil || object.IsNull(v) {
+			t.Fatalf("valueOf(%s) returned null", name)
+		}
+		resObj := v.(*object.Object)
+		nmObj := resObj.FieldTable["name"].Fvalue.(*object.Object)
+		if object.GoStringFromStringObject(nmObj) != name {
+			t.Errorf("valueOf(%s) returned wrong constant: %s", name, object.GoStringFromStringObject(nmObj))
+		}
+	}
+
+	// Test valueOf(String) error cases
+	// 1. Missing argument
+	err1 := fvResultValueOfString([]interface{}{})
+	if geb, ok := err1.(*ghelpers.GErrBlk); !ok || geb.ExceptionType != excNames.IllegalArgumentException {
+		t.Errorf("expected IllegalArgumentException for missing arg, got %T", err1)
+	}
+
+	// 2. Null argument
+	err2 := fvResultValueOfString([]interface{}{object.Null})
+	if geb, ok := err2.(*ghelpers.GErrBlk); !ok || geb.ExceptionType != excNames.NullPointerException {
+		t.Errorf("expected NullPointerException for null arg, got %T", err2)
+	}
+
+	// 3. Not a String
+	err3 := fvResultValueOfString([]interface{}{object.MakeEmptyObjectWithClassName(new(string))})
+	if geb, ok := err3.(*ghelpers.GErrBlk); !ok || geb.ExceptionType != excNames.IllegalArgumentException {
+		t.Errorf("expected IllegalArgumentException for non-string arg, got %T", err3)
+	}
+
+	// 4. Invalid name
+	err4 := fvResultValueOfString([]interface{}{object.StringObjectFromGoString("INVALID")})
+	if geb, ok := err4.(*ghelpers.GErrBlk); !ok || geb.ExceptionType != excNames.IllegalArgumentException {
+		t.Errorf("expected IllegalArgumentException for invalid name, got %T", err4)
+	}
+}

--- a/src/gfunction/javaNio/javaNioFileFileVisitor.go
+++ b/src/gfunction/javaNio/javaNioFileFileVisitor.go
@@ -1,0 +1,53 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2026 by the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package javaNio
+
+import (
+	"jacobin/src/gfunction/ghelpers"
+)
+
+func Load_Nio_File_FileVisitor() {
+	// preVisitDirectory(Object dir, BasicFileAttributes attrs)
+	ghelpers.MethodSignatures["java/nio/file/FileVisitor.preVisitDirectory(Ljava/lang/Object;Ljava/nio/file/attribute/BasicFileAttributes;)Ljava/nio/file/FileVisitResult;"] =
+		ghelpers.GMeth{ParamSlots: 3, GFunction: fileVisitorPreVisitDirectory, NeedsContext: true}
+
+	// visitFile(Object file, BasicFileAttributes attrs)
+	ghelpers.MethodSignatures["java/nio/file/FileVisitor.visitFile(Ljava/lang/Object;Ljava/nio/file/attribute/BasicFileAttributes;)Ljava/nio/file/FileVisitResult;"] =
+		ghelpers.GMeth{ParamSlots: 3, GFunction: fileVisitorVisitFile, NeedsContext: true}
+
+	// visitFileFailed(Object file, IOException exc)
+	ghelpers.MethodSignatures["java/nio/file/FileVisitor.visitFileFailed(Ljava/lang/Object;Ljava/io/IOException;)Ljava/nio/file/FileVisitResult;"] =
+		ghelpers.GMeth{ParamSlots: 3, GFunction: fileVisitorVisitFileFailed, NeedsContext: true}
+
+	// postVisitDirectory(Object dir, IOException exc)
+	ghelpers.MethodSignatures["java/nio/file/FileVisitor.postVisitDirectory(Ljava/lang/Object;Ljava/io/IOException;)Ljava/nio/file/FileVisitResult;"] =
+		ghelpers.GMeth{ParamSlots: 3, GFunction: fileVisitorPostVisitDirectory, NeedsContext: true}
+}
+
+func fileVisitorPreVisitDirectory(params []interface{}) interface{} {
+	ensureFvResultInited()
+	// Default behavior: CONTINUE
+	return fvResultInstances[0] // CONTINUE
+}
+
+func fileVisitorVisitFile(params []interface{}) interface{} {
+	ensureFvResultInited()
+	// Default behavior: CONTINUE
+	return fvResultInstances[0] // CONTINUE
+}
+
+func fileVisitorVisitFileFailed(params []interface{}) interface{} {
+	ensureFvResultInited()
+	// Default behavior: CONTINUE
+	return fvResultInstances[0] // CONTINUE
+}
+
+func fileVisitorPostVisitDirectory(params []interface{}) interface{} {
+	ensureFvResultInited()
+	// Default behavior: CONTINUE
+	return fvResultInstances[0] // CONTINUE
+}

--- a/src/gfunction/javaNio/javaNioFileFileVisitor_test.go
+++ b/src/gfunction/javaNio/javaNioFileFileVisitor_test.go
@@ -1,0 +1,73 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2026 by the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package javaNio
+
+import (
+	"jacobin/src/frames"
+	"jacobin/src/globals"
+	"jacobin/src/object"
+	"testing"
+)
+
+func Test_FileVisitor(t *testing.T) {
+	globals.InitGlobals("test")
+	Load_Nio_File_FileVisitor()
+	Load_Nio_File_FileVisitResult()
+
+	fs := frames.CreateFrameStack()
+	// CONTINUE is fvResultInstances[0]
+
+	// params: [fs, this, arg...]
+	p := []interface{}{fs, object.Null, object.Null, object.Null}
+
+	if res := fileVisitorPreVisitDirectory(p); res != fvResultInstances[0] {
+		t.Errorf("preVisitDirectory should return CONTINUE")
+	}
+	if res := fileVisitorVisitFile(p); res != fvResultInstances[0] {
+		t.Errorf("visitFile should return CONTINUE")
+	}
+	if res := fileVisitorVisitFileFailed(p); res != fvResultInstances[0] {
+		t.Errorf("visitFileFailed should return CONTINUE")
+	}
+	if res := fileVisitorPostVisitDirectory(p); res != fvResultInstances[0] {
+		t.Errorf("postVisitDirectory should return CONTINUE")
+	}
+}
+
+func Test_SimpleFileVisitor(t *testing.T) {
+	globals.InitGlobals("test")
+	Load_Nio_File_SimpleFileVisitor()
+	Load_Nio_File_FileVisitResult()
+
+	fs := frames.CreateFrameStack()
+	p := []interface{}{fs, object.Null, object.Null, object.Null}
+
+	if res := simpleFileVisitorPreVisitDirectory(p); res != fvResultInstances[0] {
+		t.Errorf("preVisitDirectory should return CONTINUE")
+	}
+	if res := simpleFileVisitorVisitFile(p); res != fvResultInstances[0] {
+		t.Errorf("visitFile should return CONTINUE")
+	}
+
+	// visitFileFailed: if exc is present, return it
+	exc := object.MakeEmptyObjectWithClassName(new(string))
+	pFailed := []interface{}{fs, object.Null, object.Null, exc}
+	if res := simpleFileVisitorVisitFileFailed(pFailed); res != exc {
+		t.Errorf("visitFileFailed should return exception if present")
+	}
+	if res := simpleFileVisitorVisitFileFailed(p); res != fvResultInstances[0] {
+		t.Errorf("visitFileFailed should return CONTINUE if no exception")
+	}
+
+	// postVisitDirectory: if exc is present, return it
+	if res := simpleFileVisitorPostVisitDirectory(pFailed); res != exc {
+		t.Errorf("postVisitDirectory should return exception if present")
+	}
+	if res := simpleFileVisitorPostVisitDirectory(p); res != fvResultInstances[0] {
+		t.Errorf("postVisitDirectory should return CONTINUE if no exception")
+	}
+}

--- a/src/gfunction/javaNio/javaNioFileFiles.go
+++ b/src/gfunction/javaNio/javaNioFileFiles.go
@@ -7,14 +7,19 @@
 package javaNio
 
 import (
+	"container/list"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 
+	"jacobin/src/classloader"
 	"jacobin/src/excNames"
+	"jacobin/src/frames"
 	"jacobin/src/gfunction/ghelpers"
+	"jacobin/src/globals"
 	"jacobin/src/object"
+	"jacobin/src/stringPool"
 	"jacobin/src/types"
 )
 
@@ -138,13 +143,13 @@ func Load_Nio_File_Files() {
 
 	// walk / walkFileTree
 	ghelpers.MethodSignatures["java/nio/file/Files.walk(Ljava/nio/file/Path;[Ljava/nio/file/FileVisitOption;)Ljava/util/stream/Stream;"] =
-		ghelpers.GMeth{ParamSlots: 2, GFunction: ghelpers.TrapFunction}
+		ghelpers.GMeth{ParamSlots: 2, GFunction: filesWalk}
 	ghelpers.MethodSignatures["java/nio/file/Files.walk(Ljava/nio/file/Path;I[Ljava/nio/file/FileVisitOption;)Ljava/util/stream/Stream;"] =
-		ghelpers.GMeth{ParamSlots: 3, GFunction: ghelpers.TrapFunction}
+		ghelpers.GMeth{ParamSlots: 3, GFunction: filesWalk}
 	ghelpers.MethodSignatures["java/nio/file/Files.walkFileTree(Ljava/nio/file/Path;Ljava/util/Set;ILjava/nio/file/FileVisitor;)Ljava/nio/file/Path;"] =
-		ghelpers.GMeth{ParamSlots: 4, GFunction: ghelpers.TrapFunction}
+		ghelpers.GMeth{ParamSlots: 4, GFunction: filesWalkFileTree, NeedsContext: true}
 	ghelpers.MethodSignatures["java/nio/file/Files.walkFileTree(Ljava/nio/file/Path;Ljava/nio/file/FileVisitor;)Ljava/nio/file/Path;"] =
-		ghelpers.GMeth{ParamSlots: 2, GFunction: ghelpers.TrapFunction}
+		ghelpers.GMeth{ParamSlots: 2, GFunction: filesWalkFileTree, NeedsContext: true}
 
 	// write / writeString
 	ghelpers.MethodSignatures["java/nio/file/Files.write(Ljava/nio/file/Path;[B[Ljava/nio/file/OpenOption;)Ljava/nio/file/Path;"] =
@@ -156,12 +161,14 @@ func Load_Nio_File_Files() {
 // --- Helpers ---
 func pathToGoString(p interface{}) (string, *ghelpers.GErrBlk) {
 	if p == nil || p == object.Null {
-		return "", ghelpers.GetGErrBlk(excNames.NullPointerException, "Path is null")
+		return "", ghelpers.GetGErrBlk(excNames.NullPointerException,
+			"Path is null")
 	}
 	obj := p.(*object.Object)
 	sval, ok := obj.FieldTable["value"].Fvalue.(*object.Object)
 	if !ok || sval == nil {
-		return "", ghelpers.GetGErrBlk(excNames.IOException, "Path.value missing")
+		return "", ghelpers.GetGErrBlk(excNames.IOException,
+			"Path.value missing")
 	}
 	return object.GoStringFromStringObject(sval), nil
 }
@@ -275,7 +282,8 @@ func filesSize(params []interface{}) interface{} {
 	}
 	fi, err := os.Stat(p)
 	if err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.size: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.size: %s", err.Error()))
 	}
 	return int64(fi.Size())
 }
@@ -287,7 +295,8 @@ func filesCreateFile(params []interface{}) interface{} {
 	}
 	f, err := os.OpenFile(p, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o666)
 	if err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.createFile: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.createFile: %s", err.Error()))
 	}
 	_ = f.Close()
 	return newPath(p)
@@ -299,7 +308,8 @@ func filesCreateDirectory(params []interface{}) interface{} {
 		return gerr
 	}
 	if err := os.Mkdir(p, 0o777); err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.createDirectory: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.createDirectory: %s", err.Error()))
 	}
 	return newPath(p)
 }
@@ -310,7 +320,8 @@ func filesCreateDirectories(params []interface{}) interface{} {
 		return gerr
 	}
 	if err := os.MkdirAll(p, 0o777); err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.createDirectories: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.createDirectories: %s", err.Error()))
 	}
 	return newPath(p)
 }
@@ -321,7 +332,8 @@ func filesDelete(params []interface{}) interface{} {
 		return gerr
 	}
 	if err := os.Remove(p); err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.delete: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.delete: %s", err.Error()))
 	}
 	return nil
 }
@@ -338,7 +350,8 @@ func filesDeleteIfExists(params []interface{}) interface{} {
 	if os.IsNotExist(err) {
 		return types.JavaBoolFalse
 	}
-	return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.deleteIfExists: %s", err.Error()))
+	return ghelpers.GetGErrBlk(excNames.IOException,
+		fmt.Sprintf("Files.deleteIfExists: %s", err.Error()))
 }
 
 func filesCopyPath(params []interface{}) interface{} {
@@ -353,17 +366,21 @@ func filesCopyPath(params []interface{}) interface{} {
 	// Only support file-to-file regular copy for now.
 	sfi, err := os.Stat(src)
 	if err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.copy: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.copy: %s", err.Error()))
 	}
 	if sfi.IsDir() {
-		return ghelpers.GetGErrBlk(excNames.UnsupportedOperationException, "Files.copy: directory copy not supported")
+		return ghelpers.GetGErrBlk(excNames.UnsupportedOperationException,
+			"Files.copy: directory copy not supported")
 	}
 	data, err := os.ReadFile(src)
 	if err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.copy: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.copy: %s", err.Error()))
 	}
 	if err := os.WriteFile(dst, data, 0o666); err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.copy: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.copy: %s", err.Error()))
 	}
 	return newPath(dst)
 }
@@ -378,7 +395,8 @@ func filesMove(params []interface{}) interface{} {
 		return g2
 	}
 	if err := os.Rename(src, dst); err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.move: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.move: %s", err.Error()))
 	}
 	return newPath(dst)
 }
@@ -390,7 +408,8 @@ func filesNewInputStream(params []interface{}) interface{} {
 	}
 	fh, err := os.Open(p)
 	if err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.newInputStream: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.newInputStream: %s", err.Error()))
 	}
 	return newFileInputStreamObj(p, fh)
 }
@@ -403,7 +422,8 @@ func filesNewOutputStream(params []interface{}) interface{} {
 	// Simplified: create/truncate
 	fh, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o666)
 	if err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.newOutputStream: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.newOutputStream: %s", err.Error()))
 	}
 	return newFileOutputStreamObj(p, fh)
 }
@@ -415,7 +435,8 @@ func filesReadAllBytes(params []interface{}) interface{} {
 	}
 	data, err := os.ReadFile(p)
 	if err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.readAllBytes: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.readAllBytes: %s", err.Error()))
 	}
 	return object.MakeArrayFromRawArray(object.JavaByteArrayFromGoByteArray(data))
 }
@@ -428,11 +449,13 @@ func filesWriteBytes(params []interface{}) interface{} {
 	// params[1] is a Java byte[] wrapped in object.Object? In this codebase, a Java byte[] is passed directly as []types.JavaByte
 	jb, ok := params[1].([]types.JavaByte)
 	if !ok {
-		return ghelpers.GetGErrBlk(excNames.IOException, "Files.write: expected byte[] argument")
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			"Files.write: expected byte[] argument")
 	}
 	data := object.GoByteArrayFromJavaByteArray(jb)
 	if err := os.WriteFile(p, data, 0o666); err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.write: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.write: %s", err.Error()))
 	}
 	return newPath(p)
 }
@@ -444,7 +467,8 @@ func filesReadString(params []interface{}) interface{} {
 	}
 	data, err := os.ReadFile(p)
 	if err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.readString: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.readString: %s", err.Error()))
 	}
 	return object.StringObjectFromGoString(string(data))
 }
@@ -458,7 +482,8 @@ func filesWriteString(params []interface{}) interface{} {
 	sObj := params[1].(*object.Object)
 	text := object.GoStringFromStringObject(sObj)
 	if err := os.WriteFile(p, []byte(text), 0o666); err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.writeString: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.writeString: %s", err.Error()))
 	}
 	return newPath(p)
 }
@@ -512,7 +537,8 @@ func filesReadSymbolicLink(params []interface{}) interface{} {
 	}
 	target, err := os.Readlink(p)
 	if err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.readSymbolicLink: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.readSymbolicLink: %s", err.Error()))
 	}
 	return newPath(target)
 }
@@ -527,7 +553,8 @@ func filesCreateSymbolicLink(params []interface{}) interface{} {
 		return g2
 	}
 	if err := os.Symlink(target, link); err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.createSymbolicLink: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.createSymbolicLink: %s", err.Error()))
 	}
 	return newPath(link)
 }
@@ -542,7 +569,8 @@ func filesCreateLink(params []interface{}) interface{} {
 		return g2
 	}
 	if err := os.Link(existing, link); err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.createLink: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.createLink: %s", err.Error()))
 	}
 	return newPath(link)
 }
@@ -557,7 +585,8 @@ func filesCreateTempFileInDir(params []interface{}) interface{} {
 	pattern := prefix + "*" + suffix
 	f, err := os.CreateTemp(dir, pattern)
 	if err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.createTempFile: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.createTempFile: %s", err.Error()))
 	}
 	_ = f.Close()
 	return newPath(f.Name())
@@ -569,7 +598,8 @@ func filesCreateTempFile(params []interface{}) interface{} {
 	pattern := prefix + "*" + suffix
 	f, err := os.CreateTemp("", pattern)
 	if err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.createTempFile: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.createTempFile: %s", err.Error()))
 	}
 	_ = f.Close()
 	return newPath(f.Name())
@@ -583,7 +613,8 @@ func filesCreateTempDirectoryInDir(params []interface{}) interface{} {
 	prefix := object.GoStringFromStringObject(params[1].(*object.Object))
 	path, err := os.MkdirTemp(dir, prefix+"*")
 	if err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.createTempDirectory: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.createTempDirectory: %s", err.Error()))
 	}
 	return newPath(path)
 }
@@ -592,7 +623,239 @@ func filesCreateTempDirectory(params []interface{}) interface{} {
 	prefix := object.GoStringFromStringObject(params[0].(*object.Object))
 	path, err := os.MkdirTemp("", prefix+"*")
 	if err != nil {
-		return ghelpers.GetGErrBlk(excNames.IOException, fmt.Sprintf("Files.createTempDirectory: %s", err.Error()))
+		return ghelpers.GetGErrBlk(excNames.IOException,
+			fmt.Sprintf("Files.createTempDirectory: %s", err.Error()))
 	}
 	return newPath(path)
+}
+
+func filesWalk([]interface{}) interface{} {
+	return ghelpers.GetGErrBlk(excNames.UnsupportedOperationException,
+		"Files.walk is not yet supported (requires java.util.stream.Stream)")
+}
+
+func invokeVisitor(fs *list.List, visitor *object.Object, methodName, methodType string, params []interface{}) interface{} {
+	className := "java/nio/file/FileVisitor"
+	fullSignature := className + "." + methodName + methodType
+
+	// Try dynamic dispatch if visitor is a real object
+	if visitor != nil && !object.IsNull(visitor) {
+		objClassName := *(stringPool.GetStringPointer(visitor.KlassName))
+		// Search up the class hierarchy for an implementation (G-function or Java)
+		currClass := objClassName
+		for currClass != "" {
+			specificFQN := currClass + "." + methodName + methodType
+
+			// 1. Check if it's a registered G-function
+			if gm, ok := ghelpers.MethodSignatures[specificFQN]; ok {
+				if gm.NeedsContext {
+					params = append([]interface{}{fs}, params...)
+				}
+				return ghelpers.Invoke(specificFQN, params)
+			}
+
+			// 2. Check if it's a Java method in the current class
+			mtEntry := classloader.GetMtableEntry(specificFQN)
+			if mtEntry.Meth == nil {
+				// Try fetching it (might need to load class or look closer)
+				mtEntry, _ = classloader.FetchMethodAndCP(currClass, methodName, methodType)
+			}
+
+			if mtEntry.Meth != nil {
+				if mtEntry.MType == 'G' {
+					gm := mtEntry.Meth.(ghelpers.GMeth)
+					if gm.NeedsContext {
+						params = append([]interface{}{fs}, params...)
+					}
+					return gm.GFunction(params)
+				}
+				if mtEntry.MType == 'J' {
+					// It's a Java method.
+					// Call the Java method from G-function using RunJavaFromG
+					globals.GetGlobalRef().FuncRunJavaFromG(fs, currClass, methodName, methodType, params...)
+
+					// Retrieve the return value from the top frame's operand stack.
+					// After RunJavaFromG returns, the frame it created has been popped,
+					// and the return value was pushed to the operand stack of the frame below it.
+					fr := fs.Front().Value.(*frames.Frame)
+					if fr.TOS >= 0 {
+						res := fr.OpStack[fr.TOS]
+						fr.TOS--
+						return res
+					}
+					return nil
+				}
+			}
+
+			// Get superclass
+			klass := classloader.MethAreaFetch(currClass)
+			if klass == nil || klass.Data.SuperclassIndex == types.InvalidStringIndex {
+				break
+			}
+			currClass = *stringPool.GetStringPointer(uint32(klass.Data.SuperclassIndex))
+		}
+	}
+
+	// Fallback to default FileVisitor G-function if found
+	if gm, ok := ghelpers.MethodSignatures[fullSignature]; ok {
+		if gm.NeedsContext {
+			params = append([]interface{}{fs}, params...)
+		}
+		return ghelpers.Invoke(fullSignature, params)
+	}
+
+	return ghelpers.GetGErrBlk(excNames.NoSuchMethodException, "invokeVisitor: method not found: "+fullSignature)
+}
+
+func filesWalkFileTree(params []interface{}) interface{} {
+	var fsStack *list.List
+	var realParams []interface{}
+
+	// If NeedsContext is true, the frame stack (*list.List) is prepended to the parameter list
+	// because RunGfunction reverses the parameters after appending the frame stack.
+	if len(params) > 0 {
+		if l, ok := params[0].(*list.List); ok {
+			fsStack = l
+			realParams = params[1:]
+		} else {
+			realParams = params
+		}
+	} else {
+		realParams = params
+	}
+
+	if len(realParams) < 2 {
+		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, "Files.walkFileTree: missing arguments")
+	}
+
+	startPathObj := realParams[0].(*object.Object)
+	startStr, gerr := pathToGoString(startPathObj)
+	if gerr != nil {
+		return gerr
+	}
+
+	var visitor *object.Object
+	maxDepth := int64(2147483647) // Integer.MAX_VALUE
+
+	if len(realParams) == 2 {
+		// walkFileTree(Path start, FileVisitor visitor)
+		visitor = realParams[1].(*object.Object)
+	} else if len(realParams) == 4 {
+		// walkFileTree(Path start, Set options, int maxDepth, FileVisitor visitor)
+		maxDepth = realParams[2].(int64)
+		visitor = realParams[3].(*object.Object)
+	} else {
+		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, "Files.walkFileTree: unexpected number of arguments")
+	}
+
+	if visitor == nil || object.IsNull(visitor) {
+		return ghelpers.GetGErrBlk(excNames.NullPointerException, "Files.walkFileTree: visitor is null")
+	}
+
+	// We need to keep track of the root depth to respect maxDepth
+	rootDepth := len(getPathParts(startStr))
+	if !filepath.IsAbs(startStr) {
+		// Best effort for relative paths
+		absStart, _ := filepath.Abs(startStr)
+		rootDepth = len(getPathParts(absStart))
+	}
+
+	err := filepath.WalkDir(startStr, func(path string, d fs.DirEntry, err error) error {
+		currentDepth := len(getPathParts(path))
+		if !filepath.IsAbs(path) {
+			absPath, _ := filepath.Abs(path)
+			currentDepth = len(getPathParts(absPath))
+		}
+
+		if int64(currentDepth-rootDepth) > maxDepth {
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		javaPath := newPath(path)
+		var result interface{}
+
+		// Get file attributes
+		var attrs *object.Object
+		if d != nil {
+			info, _ := d.Info()
+			if info != nil {
+				attrs = newBasicFileAttributes(info)
+			}
+		}
+		if attrs == nil {
+			attrs = object.Null
+		}
+
+		if err != nil {
+			// visitFileFailed(Path, IOException)
+			result = invokeVisitor(fsStack,
+				visitor, "visitFileFailed",
+				"(Ljava/lang/Object;Ljava/io/IOException;)Ljava/nio/file/FileVisitResult;",
+				[]interface{}{visitor, javaPath, ghelpers.GetGErrBlk(excNames.IOException, err.Error())})
+		} else if d.IsDir() {
+			// preVisitDirectory(Path, BasicFileAttributes)
+			result = invokeVisitor(fsStack,
+				visitor, "preVisitDirectory",
+				"(Ljava/lang/Object;Ljava/nio/file/attribute/BasicFileAttributes;)Ljava/nio/file/FileVisitResult;",
+				[]interface{}{visitor, javaPath, attrs})
+		} else {
+			// visitFile(Path, BasicFileAttributes)
+			result = invokeVisitor(fsStack, visitor, "visitFile", "(Ljava/lang/Object;Ljava/nio/file/attribute/BasicFileAttributes;)Ljava/nio/file/FileVisitResult;",
+				[]interface{}{visitor, javaPath, attrs})
+		}
+
+		if gerr, ok := result.(*ghelpers.GErrBlk); ok {
+			return fmt.Errorf("java exception: %s", gerr.ErrMsg)
+		}
+
+		// Handle FileVisitResult
+		var name string
+		if resObj, ok := result.(*object.Object); ok && !object.IsNull(resObj) {
+			// Check enum constant name
+			if nameField, ok := resObj.FieldTable["name"]; ok {
+				if nameStrObj, ok := nameField.Fvalue.(*object.Object); ok {
+					name = object.GoStringFromStringObject(nameStrObj)
+					switch name {
+					case "TERMINATE":
+						return filepath.SkipAll
+					case "SKIP_SUBTREE":
+						return filepath.SkipDir
+					case "SKIP_SIBLINGS":
+						// Go's WalkDir doesn't have a direct SKIP_SIBLINGS, but we can approximate
+						return nil
+					case "CONTINUE":
+						// continue
+					}
+				}
+			}
+		}
+
+		// postVisitDirectory
+		if d != nil && d.IsDir() && name != "SKIP_SUBTREE" {
+			// Note: filepath.WalkDir doesn't naturally support post-visit in the same callback,
+			// but for a single directory entry that is a directory, we've already done preVisit.
+			// True walkFileTree calls postVisit after ALL entries in the directory are visited.
+			// This implementation is still simplified.
+			_ = invokeVisitor(fsStack,
+				visitor,
+				"postVisitDirectory",
+				"(Ljava/lang/Object;Ljava/io/IOException;)Ljava/nio/file/FileVisitResult;",
+				[]interface{}{visitor, javaPath, object.Null})
+		}
+
+		return nil
+	})
+
+	// postVisitDirectory(Path, IOException) - simplified: called only if no walk error so far or if we want to be thorough.
+	// filepath.WalkDir doesn't have a post-visit hook in the same way, but we can implement it by wrapping the traversal.
+	// However, for a first implementation, this might be sufficient.
+
+	if err != nil {
+		return ghelpers.GetGErrBlk(excNames.IOException, err.Error())
+	}
+
+	return startPathObj
 }

--- a/src/gfunction/javaNio/javaNioFileFiles_test.go
+++ b/src/gfunction/javaNio/javaNioFileFiles_test.go
@@ -11,7 +11,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"jacobin/src/classloader"
 	"jacobin/src/excNames"
+	"jacobin/src/frames"
 	"jacobin/src/gfunction/ghelpers"
 	"jacobin/src/globals"
 	"jacobin/src/object"
@@ -307,5 +309,94 @@ func Test_Files_Symlink_Paths(t *testing.T) {
 	rl := filesReadSymbolicLink([]interface{}{newPath(link)})
 	if _, ok := rl.(*object.Object); !ok {
 		t.Fatalf("readSymbolicLink should return Path")
+	}
+}
+
+func Test_Files_Walk_And_WalkFileTree(t *testing.T) {
+	globals.InitGlobals("test")
+	classloader.InitMethodArea()
+	dir := t.TempDir()
+	p := newPath(dir)
+
+	// Walk should return UnsupportedOperationException
+	res := filesWalk([]interface{}{p, object.Null})
+	if geb, ok := res.(*ghelpers.GErrBlk); !ok || geb.ExceptionType != excNames.UnsupportedOperationException {
+		t.Fatalf("expected UnsupportedOperationException for walk, got %T %+v", res, res)
+	}
+
+	// WalkFileTree with null visitor should return NullPointerException
+	res2 := filesWalkFileTree([]interface{}{p, object.Null})
+	if geb, ok := res2.(*ghelpers.GErrBlk); !ok || geb.ExceptionType != excNames.NullPointerException {
+		t.Fatalf("expected NullPointerException for walkFileTree with null visitor, got %T %+v", res2, res2)
+	}
+
+	// WalkFileTree with too few arguments should return IllegalArgumentException
+	res3 := filesWalkFileTree([]interface{}{p})
+	if geb, ok := res3.(*ghelpers.GErrBlk); !ok || geb.ExceptionType != excNames.IllegalArgumentException {
+		t.Fatalf("expected IllegalArgumentException for walkFileTree with 1 arg, got %T %+v", res3, res3)
+	}
+
+	Load_Nio_File_FileVisitResult()
+	fs := frames.CreateFrameStack()
+	res4 := fvResultValues(nil)
+	arr, ok := res4.(*object.Object)
+	if !ok || arr == nil {
+		t.Fatalf("fvResultValues should return array object")
+	}
+	vals := arr.FieldTable["value"].Fvalue.([]*object.Object)
+	if len(vals) != 4 {
+		t.Fatalf("expected 4 FileVisitResult values, got %d", len(vals))
+	}
+	if object.GoStringFromStringObject(vals[0].FieldTable["name"].Fvalue.(*object.Object)) != "CONTINUE" {
+		t.Fatalf("expected CONTINUE at index 0")
+	}
+
+	// Test FileVisitor default G-functions
+	Load_Nio_File_FileVisitor()
+	res5 := ghelpers.Invoke("java/nio/file/FileVisitor.preVisitDirectory(Ljava/lang/Object;Ljava/nio/file/attribute/BasicFileAttributes;)Ljava/nio/file/FileVisitResult;", []interface{}{fs, object.Null, object.Null, object.Null})
+	if res5 != vals[0] {
+		t.Fatalf("FileVisitor.preVisitDirectory should return CONTINUE by default")
+	}
+
+	// Test SimpleFileVisitor
+	Load_Nio_File_SimpleFileVisitor()
+	res6 := ghelpers.Invoke("java/nio/file/SimpleFileVisitor.visitFile(Ljava/lang/Object;Ljava/nio/file/attribute/BasicFileAttributes;)Ljava/nio/file/FileVisitResult;", []interface{}{fs, object.Null, object.Null, object.Null})
+	if res6 != vals[0] {
+		t.Fatalf("SimpleFileVisitor.visitFile should return CONTINUE")
+	}
+
+	// Test BasicFileAttributes
+	Load_Nio_File_Attribute_BasicFileAttributes()
+	info, _ := os.Stat(dir)
+	attrs := newBasicFileAttributes(info)
+	res7 := bfaIsDirectory([]interface{}{attrs})
+	if res7.(int64) != 1 {
+		t.Fatalf("expected isDirectory to be true for temp dir")
+	}
+
+	// Test Dynamic Dispatch in WalkFileTree
+	// Create a dummy visitor subclass
+	visitorClassName := "org/jacobin/test/MyVisitor"
+	visitorObj := object.MakeEmptyObjectWithClassName(&visitorClassName)
+
+	// Create some files to visit
+	f1 := filepath.Join(dir, "f1.txt")
+	os.WriteFile(f1, []byte("f1"), 0o644)
+
+	visited := false
+	// Register a specific G-function for MyVisitor
+	ghelpers.MethodSignatures[visitorClassName+".visitFile(Ljava/lang/Object;Ljava/nio/file/attribute/BasicFileAttributes;)Ljava/nio/file/FileVisitResult;"] =
+		ghelpers.GMeth{
+			ParamSlots: 3,
+			GFunction: func(params []interface{}) interface{} {
+				visited = true
+				return vals[0] // CONTINUE
+			},
+			NeedsContext: true,
+		}
+
+	filesWalkFileTree([]interface{}{fs, p, visitorObj})
+	if !visited {
+		t.Fatalf("dynamic dispatch failed: MyVisitor.visitFile was not called")
 	}
 }

--- a/src/gfunction/javaNio/javaNioFileSimpleFileVisitor.go
+++ b/src/gfunction/javaNio/javaNioFileSimpleFileVisitor.go
@@ -1,0 +1,70 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2026 by the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package javaNio
+
+import (
+	"jacobin/src/gfunction/ghelpers"
+	"jacobin/src/object"
+)
+
+func Load_Nio_File_SimpleFileVisitor() {
+	// preVisitDirectory(Object dir, BasicFileAttributes attrs)
+	ghelpers.MethodSignatures["java/nio/file/SimpleFileVisitor.preVisitDirectory(Ljava/lang/Object;Ljava/nio/file/attribute/BasicFileAttributes;)Ljava/nio/file/FileVisitResult;"] =
+		ghelpers.GMeth{ParamSlots: 3, GFunction: simpleFileVisitorPreVisitDirectory, NeedsContext: true}
+
+	// visitFile(Object file, BasicFileAttributes attrs)
+	ghelpers.MethodSignatures["java/nio/file/SimpleFileVisitor.visitFile(Ljava/lang/Object;Ljava/nio/file/attribute/BasicFileAttributes;)Ljava/nio/file/FileVisitResult;"] =
+		ghelpers.GMeth{ParamSlots: 3, GFunction: simpleFileVisitorVisitFile, NeedsContext: true}
+
+	// visitFileFailed(Object file, IOException exc)
+	ghelpers.MethodSignatures["java/nio/file/SimpleFileVisitor.visitFileFailed(Ljava/lang/Object;Ljava/io/IOException;)Ljava/nio/file/FileVisitResult;"] =
+		ghelpers.GMeth{ParamSlots: 3, GFunction: simpleFileVisitorVisitFileFailed, NeedsContext: true}
+
+	// postVisitDirectory(Object dir, IOException exc)
+	ghelpers.MethodSignatures["java/nio/file/SimpleFileVisitor.postVisitDirectory(Ljava/lang/Object;Ljava/io/IOException;)Ljava/nio/file/FileVisitResult;"] =
+		ghelpers.GMeth{ParamSlots: 3, GFunction: simpleFileVisitorPostVisitDirectory, NeedsContext: true}
+}
+
+func simpleFileVisitorPreVisitDirectory(params []interface{}) interface{} {
+	ensureFvResultInited()
+	// Default behavior: CONTINUE
+	return fvResultInstances[0] // CONTINUE
+}
+
+func simpleFileVisitorVisitFile(params []interface{}) interface{} {
+	ensureFvResultInited()
+	// Default behavior: CONTINUE
+	return fvResultInstances[0] // CONTINUE
+}
+
+func simpleFileVisitorVisitFileFailed(params []interface{}) interface{} {
+	ensureFvResultInited()
+	// params[0] is frame stack if NeedsContext is true
+	// params[1] is 'this', params[2] is 'file', params[3] is 'exc'
+	if len(params) >= 4 {
+		exc := params[3]
+		if exc != nil && !object.IsNull(exc) {
+			// SimpleFileVisitor.visitFileFailed throws the exception it's passed
+			return exc
+		}
+	}
+	return fvResultInstances[0] // CONTINUE
+}
+
+func simpleFileVisitorPostVisitDirectory(params []interface{}) interface{} {
+	ensureFvResultInited()
+	// params[0] is frame stack if NeedsContext is true
+	// params[1] is 'this', params[2] is 'dir', params[3] is 'exc'
+	if len(params) >= 4 {
+		exc := params[3]
+		if exc != nil && !object.IsNull(exc) {
+			// SimpleFileVisitor.postVisitDirectory throws the exception it's passed
+			return exc
+		}
+	}
+	return fvResultInstances[0] // CONTINUE
+}

--- a/src/gfunction/javaNio/javaNioFileSimpleFileVisitor_test.go
+++ b/src/gfunction/javaNio/javaNioFileSimpleFileVisitor_test.go
@@ -1,0 +1,86 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2026 by the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package javaNio
+
+import (
+	"jacobin/src/frames"
+	"jacobin/src/globals"
+	"jacobin/src/object"
+	"testing"
+)
+
+func Test_SimpleFileVisitorDetailed(t *testing.T) {
+	globals.InitGlobals("test")
+	Load_Nio_File_SimpleFileVisitor()
+	Load_Nio_File_FileVisitResult()
+
+	fs := frames.CreateFrameStack()
+
+	t.Run("preVisitDirectory", func(t *testing.T) {
+		p := []interface{}{fs, object.Null, object.Null, object.Null}
+		res := simpleFileVisitorPreVisitDirectory(p)
+		if res != fvResultInstances[0] {
+			t.Errorf("expected CONTINUE, got %v", res)
+		}
+	})
+
+	t.Run("visitFile", func(t *testing.T) {
+		p := []interface{}{fs, object.Null, object.Null, object.Null}
+		res := simpleFileVisitorVisitFile(p)
+		if res != fvResultInstances[0] {
+			t.Errorf("expected CONTINUE, got %v", res)
+		}
+	})
+
+	t.Run("visitFileFailed", func(t *testing.T) {
+		// Case 1: No exception
+		p1 := []interface{}{fs, object.Null, object.Null, object.Null}
+		res1 := simpleFileVisitorVisitFileFailed(p1)
+		if res1 != fvResultInstances[0] {
+			t.Errorf("expected CONTINUE when no exception, got %v", res1)
+		}
+
+		// Case 2: Exception present
+		exc := object.MakeEmptyObjectWithClassName(new(string))
+		p2 := []interface{}{fs, object.Null, object.Null, exc}
+		res2 := simpleFileVisitorVisitFileFailed(p2)
+		if res2 != exc {
+			t.Errorf("expected exception to be returned, got %v", res2)
+		}
+
+		// Case 3: Too few params
+		p3 := []interface{}{fs, object.Null, object.Null}
+		res3 := simpleFileVisitorVisitFileFailed(p3)
+		if res3 != fvResultInstances[0] {
+			t.Errorf("expected CONTINUE with too few params, got %v", res3)
+		}
+	})
+
+	t.Run("postVisitDirectory", func(t *testing.T) {
+		// Case 1: No exception
+		p1 := []interface{}{fs, object.Null, object.Null, object.Null}
+		res1 := simpleFileVisitorPostVisitDirectory(p1)
+		if res1 != fvResultInstances[0] {
+			t.Errorf("expected CONTINUE when no exception, got %v", res1)
+		}
+
+		// Case 2: Exception present
+		exc := object.MakeEmptyObjectWithClassName(new(string))
+		p2 := []interface{}{fs, object.Null, object.Null, exc}
+		res2 := simpleFileVisitorPostVisitDirectory(p2)
+		if res2 != exc {
+			t.Errorf("expected exception to be returned, got %v", res2)
+		}
+
+		// Case 3: Too few params
+		p3 := []interface{}{fs, object.Null, object.Null}
+		res3 := simpleFileVisitorPostVisitDirectory(p3)
+		if res3 != fvResultInstances[0] {
+			t.Errorf("expected CONTINUE with too few params, got %v", res3)
+		}
+	})
+}

--- a/src/globals/globals.go
+++ b/src/globals/globals.go
@@ -113,6 +113,7 @@ type Globals struct {
 	FuncInvokeGFunction  func(string, []any) any
 	FuncMinimalAbort     func(int, string)
 	FuncRunThread        func([]any)
+	FuncRunJavaFromG     func(*list.List, string, string, string, ...any)
 	FuncThrowException   func(int, string) bool
 	FuncFillInStackTrace func([]any) any
 }
@@ -163,6 +164,7 @@ func InitGlobals(progName string) Globals {
 		FuncInvokeGFunction:  fakeInvokeGFunction,
 		FuncMinimalAbort:     fakeMinimalAbort,
 		FuncRunThread:        fakeRunThread,
+		FuncRunJavaFromG:     fakeRunJavaFromG,
 		FuncThrowException:   fakeThrowEx,
 		GoStackShown:         false,
 		JacobinBuildData:     nil,
@@ -377,9 +379,15 @@ func fakeMinimalAbort(whichEx int, msg string) {
 	fmt.Fprintf(os.Stderr, "%s", errMsg)
 }
 
-// Fake RunThread() in run.go
+// Fake RunThread() in jvm/run.go
 func fakeRunThread(_ []interface{}) {
 	errMsg := fmt.Sprintf("\n*Attempt to access uninitialized RunThread pointer func\n")
+	fmt.Fprintf(os.Stderr, "%s", errMsg)
+}
+
+// Fake RunRunJavaFromG() in jvm/runJavaFromG.go
+func fakeRunJavaFromG(_ *list.List, _, _, _ string, a_ ...any) {
+	errMsg := fmt.Sprintf("\n*Attempt to access uninitialized RunJavaFromG pointer func\n")
 	fmt.Fprintf(os.Stderr, "%s", errMsg)
 }
 

--- a/src/jvm/jvmStart.go
+++ b/src/jvm/jvmStart.go
@@ -243,6 +243,7 @@ func InitGlobalFunctionPointers() {
 	globalPtr.FuncInvokeGFunction = ghelpers.Invoke
 	globalPtr.FuncMinimalAbort = exceptions.MinimalAbort
 	globalPtr.FuncRunThread = RunJavaThread
+	globalPtr.FuncRunJavaFromG = RunJavaFromG
 	globalPtr.FuncThrowException = exceptions.ThrowExNil
 	globalPtr.FuncFillInStackTrace = javaLang.FillInStackTrace
 }

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -124,17 +124,6 @@ func RunJavaThread(args []any) {
 		}
 	}
 
-	// JACOBIN-824:
-	// cl := classloader.MethAreaFetch(clName) // JACOBIN-824
-	// // if cl == nil {
-	// // 	errMsg := fmt.Sprintf("RunJavaThread: Could not load class %s", clName)
-	// // 	exceptions.ThrowEx(excNames.ClassNotFoundException, errMsg, nil)
-	// // 	return
-	// // }
-	// if cl != nil {
-	// 	f.Locals[0] = cl.Data
-	// }
-
 	// Add the initial frame and the frame stack to the thread's field table.
 	t.ThMutex.Lock()
 	t.FieldTable["frame"] = object.Field{Ftype: types.Ref, Fvalue: f}

--- a/src/jvm/runJavaFromG.go
+++ b/src/jvm/runJavaFromG.go
@@ -1,0 +1,109 @@
+package jvm
+
+import (
+	"container/list"
+	"fmt"
+	"jacobin/src/classloader"
+	"jacobin/src/excNames"
+	"jacobin/src/exceptions"
+	"jacobin/src/frames"
+	"jacobin/src/globals"
+	"jacobin/src/shutdown"
+	"jacobin/src/trace"
+	"runtime/debug"
+)
+
+/*
+Run an FQN Java function, called from a G function (JACOBIN-923)
+================================================================
+* Create a new frame and push it onto the current frame stack.
+* In the new frame, set the class name, method name, and method type.
+* Handle the method's parameters by pushing them in reverse order onto the frame's OpStack.
+* Run the frame by calling interpret, passing the current frame stack.
+* Return to the calling G function.
+*/
+func RunJavaFromG(fs *list.List, clName, methName, methType string, args ...any) {
+
+	// Set up thread ID.
+	prevF := fs.Front().Value.(*frames.Frame)
+	threadID := prevF.Thread
+
+	// Set up panic recovery.
+	defer func() int {
+		// only an untrapped panic gets us here
+		if r := recover(); r != nil {
+			stack := string(debug.Stack())
+			glob := globals.GetGlobalRef()
+			glob.ErrorGoStack = stack
+			exceptions.ShowPanicCause(r)
+			exceptions.ShowFrameStack(threadID)
+			exceptions.ShowGoStackTrace(nil)
+			return shutdown.Exit(shutdown.APP_EXCEPTION)
+		}
+		return shutdown.OK
+	}()
+
+	// Set up the method and CPool for the method's class.
+	mte, err := classloader.FetchMethodAndCP(clName, methName, methType)
+	if err != nil {
+		errMsg := fmt.Sprintf("RunJavaFromG: Could not find run method (%s.%s%s): %v", clName, methName, methType, err)
+		exceptions.ThrowEx(excNames.NoSuchMethodError, errMsg, nil)
+		return
+	}
+
+	// trace.Trace(fmt.Sprintf("DEBUG RunJavaFromG: Found run method: %s.%s%s", clName, methName, methType))
+
+	// Get Mtable entry for the method.
+	meth, ok := mte.Meth.(classloader.JmEntry)
+	if !ok {
+		errMsg := fmt.Sprintf("RunJavaFromG: Method found but it is not a Java method (MType: %c)", mte.MType)
+		exceptions.ThrowEx(excNames.NoSuchMethodError, errMsg, nil)
+		return
+	}
+
+	// Create the frame.
+	f := frames.CreateFrame(meth.MaxStack)
+	f.Thread = threadID
+	f.ClName = clName
+	f.MethName = methName
+	f.MethType = methType
+	f.AccessFlags = meth.AccessFlags
+	f.Locals = make([]any, 0, meth.MaxLocals)
+
+	// Add the Mtable pointer to the class CP.
+	f.CP = meth.Cp
+	// Copy the bytecodes into the frame.
+	f.Meth = append(f.Meth, meth.Code...)
+
+	// Populate the method's local variables for this frame with args.
+	for k := 0; k < len(args); k++ {
+		f.Locals = append(f.Locals, args[k])
+	}
+
+	// Allocate the remaining method's local variables.
+	for k := len(args); k < meth.MaxLocals; k++ {
+		f.Locals = append(f.Locals, int64(0))
+	}
+
+	// Push the frame onto the frame stack.
+	if frames.PushFrame(fs, f) != nil {
+		errMsg := fmt.Sprintf("RunJavaFromG: frames.PushFrame failed on thread: %d", f.Thread)
+		exceptions.ThrowEx(excNames.OutOfMemoryError, errMsg, nil)
+		return
+	}
+
+	if globals.TraceInst {
+		traceInfo := fmt.Sprintf("RunJavaFromG: class=%s, meth=%s%s, maxStack=%d, maxLocals=%d, code size=%d",
+			f.ClName, f.MethName, f.MethType, meth.MaxStack, meth.MaxLocals, len(meth.Code))
+		trace.Trace(traceInfo)
+	}
+
+	// Execute the frame until it's popped.
+	originalLen := fs.Len()
+	for fs.Len() >= originalLen {
+		interpret(fs)
+	}
+
+	// Return to the G function.
+
+}

--- a/src/jvm/runJavaFromG_test.go
+++ b/src/jvm/runJavaFromG_test.go
@@ -1,0 +1,138 @@
+package jvm
+
+import (
+	"container/list"
+	"jacobin/src/classloader"
+	"jacobin/src/frames"
+	"jacobin/src/globals"
+	"jacobin/src/opcodes"
+	"testing"
+)
+
+func TestRunJavaFromG_ArgsCount(t *testing.T) {
+	globals.InitGlobals("test")
+	classloader.InitMethodArea()
+	fs := list.New()
+
+	baseFrame := frames.CreateFrame(1)
+	baseFrame.Thread = 1
+	fs.PushFront(baseFrame)
+
+	// We removed the arg count check, so this should try to execute and fail
+	// because "Dummy" class is not found, but it shouldn't panic on arg count.
+	RunJavaFromG(fs, "Dummy", "meth", "()V", 1, 2, 3)
+}
+
+func TestRunJavaFromG_Success_4Args(t *testing.T) {
+	globals.InitGlobals("test")
+	classloader.InitMethodArea()
+	fs := list.New()
+
+	baseFrame := frames.CreateFrame(1)
+	baseFrame.Thread = 1
+	fs.PushFront(baseFrame)
+
+	clName := "com/test/Dummy4"
+	methName := "testMeth"
+	methType := "()V"
+	methFQN := clName + "." + methName + methType
+
+	// Create Klass and insert into MethArea to bypass LoadClassFromNameOnly
+	k := &classloader.Klass{
+		Status: 'I', // Initialized
+		Data: &classloader.ClData{
+			Name: clName,
+		},
+	}
+	classloader.MethAreaInsert(clName, k)
+
+	jme := classloader.JmEntry{
+		MaxStack:  4,
+		MaxLocals: 4,
+		Code:      []byte{opcodes.RETURN},
+		Cp:        &classloader.CPool{},
+	}
+
+	classloader.AddEntry(&classloader.MTable, methFQN, classloader.MTentry{
+		Meth:  jme,
+		MType: 'J',
+	})
+
+	args := []any{int64(1), int64(2), int64(3), int64(4)}
+	initializeDispatchTable()
+	RunJavaFromG(fs, clName, methName, methType, args...)
+
+	if fs.Len() != 1 {
+		t.Errorf("Expected base frame to remain on stack, got length %d", fs.Len())
+	}
+}
+
+func TestRunJavaFromG_Success_5Args(t *testing.T) {
+	globals.InitGlobals("test")
+	classloader.InitMethodArea()
+	fs := list.New()
+
+	// Create a base frame for thread ID
+	baseFrame := frames.CreateFrame(1)
+	baseFrame.Thread = 1
+	fs.PushFront(baseFrame)
+
+	clName := "com/test/Dummy5"
+	methName := "testMeth"
+	methType := "()V"
+	methFQN := clName + "." + methName + methType
+
+	// Create Klass and insert into MethArea
+	k := &classloader.Klass{
+		Status: 'I',
+		Data: &classloader.ClData{
+			Name: clName,
+		},
+	}
+	classloader.MethAreaInsert(clName, k)
+
+	// Mock JmEntry with a RETURN instruction
+	jme := classloader.JmEntry{
+		MaxStack:  5,
+		MaxLocals: 5,
+		Code:      []byte{opcodes.RETURN},
+		Cp:        &classloader.CPool{},
+	}
+
+	classloader.AddEntry(&classloader.MTable, methFQN, classloader.MTentry{
+		Meth:  jme,
+		MType: 'J',
+	})
+
+	// RunJavaFromG expects at least 4 arguments
+	args := []any{int64(10), int64(20), int64(30), int64(40), int64(50)}
+
+	// We need to initialize the dispatch table for interpret to work
+	initializeDispatchTable()
+
+	// This should run and complete because of the RETURN instruction
+	RunJavaFromG(fs, clName, methName, methType, args...)
+
+	if fs.Len() != 1 {
+		t.Errorf("Expected base frame to remain on stack, got length %d", fs.Len())
+	}
+}
+
+func TestRunJavaFromG_NotFound(t *testing.T) {
+	globals.InitGlobals("test")
+	classloader.InitMethodArea()
+	fs := list.New()
+
+	baseFrame := frames.CreateFrame(1)
+	baseFrame.Thread = 1
+	fs.PushFront(baseFrame)
+
+	// In test mode, ThrowEx should return to RunJavaFromG, which then returns to us.
+	// No panic should occur if we don't mock it to panic.
+
+	// FetchMethodAndCP will fail to find "MissingClass"
+	RunJavaFromG(fs, "MissingClass", "meth", "()V", 1, 2, 3, 4, 5)
+
+	// If it reached here without panicking, it means RunJavaFromG handled the error via ThrowEx
+	// which in test mode just prints to stderr and returns.
+}


### PR DESCRIPTION
	new file:   gfunction/javaNio/javaNioFileAttributeBasicFileAttributes.go
	new file:   gfunction/javaNio/javaNioFileAttributeBasicFileAttributes_test.go
	new file:   gfunction/javaNio/javaNioFileFileVisitResult.go
	new file:   gfunction/javaNio/javaNioFileFileVisitResult_test.go
	new file:   gfunction/javaNio/javaNioFileFileVisitor.go
	new file:   gfunction/javaNio/javaNioFileFileVisitor_test.go
	new file:   gfunction/javaNio/javaNioFileSimpleFileVisitor.go
	new file:   gfunction/javaNio/javaNioFileSimpleFileVisitor_test.go

	new file:   jvm/runJavaFromG.go
	new file:   jvm/runJavaFromG_test.go

	modified:   gfunction/javaNio/javaNioFileFiles.go
	modified:   gfunction/javaNio/javaNioFileFiles_test.go
	modified:   gfunction/javaNio/javaNioFileFiles.go
	modified:   gfunction/javaNio/javaNioFileFiles_test.go

	modified:   exceptions/throw.go - code re-arranged to enhance an error message in ThrowEx
	modified:   gfunction/gfunction.go - new loaders
	modified:   globals/globals.go - FuncRunJavaFromG to avoid cycle
	modified:   jvm/jvmStart.go - set real entry for globals FuncRunJavaFromG
	modified:   jvm/run.go - removed commented out old code
