### PR TITLE
JACOBIN-933 Cryptography should use Ftype: types.GoByteArray for Fvalue: []byte

### DIFF
--- a/src/gfunction/javaSecurity/javaSecurityAlgorithmParameters.go
+++ b/src/gfunction/javaSecurity/javaSecurityAlgorithmParameters.go
@@ -140,7 +140,7 @@ func AlgparamsGetEncoded(params []any) any {
 	}
 
 	jBytes := object.JavaByteArrayFromGoByteArray(encoded)
-	return object.MakePrimitiveObject(types.ByteArray, types.ByteArray, jBytes)
+	return object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, jBytes)
 }
 
 func AlgparamsGetInstance(params []any) any {
@@ -242,10 +242,10 @@ func AlgparamsInit(params []any) any {
 
 	param := params[1]
 	if paramObj, ok := param.(*object.Object); ok && !object.IsNull(paramObj) {
-		if paramObj.KlassName == object.StringPoolIndexFromGoString(types.ByteArray) {
+		if paramObj.KlassName == object.StringPoolIndexFromGoString(types.JavaByteArray) {
 			// init([B) or init([B, String)
 			encoded := object.GoByteArrayFromJavaByteArray(paramObj.FieldTable["value"].Fvalue.([]types.JavaByte))
-			self.FieldTable["encoded"] = object.Field{Ftype: types.ByteArray, Fvalue: encoded}
+			self.FieldTable["encoded"] = object.Field{Ftype: types.GoByteArray, Fvalue: encoded}
 			self.FieldTable["initialized"] = object.Field{Ftype: types.Bool, Fvalue: true}
 
 			// If we know the algorithm, we might want to create a spec from the bytes
@@ -255,7 +255,7 @@ func AlgparamsInit(params []any) any {
 				// Create IvParameterSpec
 				ivSpecClass := "javax/crypto/spec/IvParameterSpec"
 				ivSpec := object.MakeEmptyObjectWithClassName(&ivSpecClass)
-				ivSpec.FieldTable["iv"] = object.Field{Ftype: types.ByteArray, Fvalue: encoded}
+				ivSpec.FieldTable["iv"] = object.Field{Ftype: types.GoByteArray, Fvalue: encoded}
 				self.FieldTable["spec"] = object.Field{Ftype: "Ljavax/crypto/spec/IvParameterSpec;", Fvalue: ivSpec}
 			}
 		} else {

--- a/src/gfunction/javaSecurity/javaSecurityAlgorithmParameters_test.go
+++ b/src/gfunction/javaSecurity/javaSecurityAlgorithmParameters_test.go
@@ -128,5 +128,5 @@ func TestAlgorithmParametersErrors(t *testing.T) {
 // Helper (copy of what's often in crypto tests)
 func makeByteArrayObject(data []byte) *object.Object {
 	jBytes := object.JavaByteArrayFromGoByteArray(data)
-	return object.MakePrimitiveObject(types.ByteArray, types.ByteArray, jBytes)
+	return object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, jBytes)
 }

--- a/src/gfunction/javaSecurity/javaSecurityKey.go
+++ b/src/gfunction/javaSecurity/javaSecurityKey.go
@@ -120,8 +120,11 @@ func keyGetEncoded(params []any) any {
 		encoded, err = x509.MarshalPKIXPublicKey(k)
 	case *ecdh.PrivateKey:
 		encoded, err = x509.MarshalPKCS8PrivateKey(k)
+	case []types.JavaByte:
+		// Java byte arrays (signed)
+		encoded = object.GoByteArrayFromJavaByteArray(k)
 	case []byte:
-		// Some keys (X25519, X448) might be stored as raw bytes
+		// Go byte arrays (unsigned)
 		encoded = k
 	case *big.Int:
 		// DH keys often stored as *big.Int
@@ -134,7 +137,7 @@ func keyGetEncoded(params []any) any {
 		return ghelpers.GetGErrBlk(excNames.GeneralSecurityException, "keyGetEncoded: encoding failed: "+err.Error())
 	}
 
-	return object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(encoded))
+	return object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(encoded))
 }
 
 func keyGetFormat(params []any) any {

--- a/src/gfunction/javaSecurity/javaSecurityMessageDigest.go
+++ b/src/gfunction/javaSecurity/javaSecurityMessageDigest.go
@@ -168,7 +168,7 @@ func appendToBuffer(this *object.Object, bytes []types.JavaByte) {
 	current := this.FieldTable["buffer"].Fvalue.([]types.JavaByte)
 	current = append(current, bytes...)
 	this.FieldTable["buffer"] = object.Field{
-		Ftype:  types.ByteArray,
+		Ftype:  types.JavaByteArray,
 		Fvalue: current,
 	}
 }
@@ -230,7 +230,7 @@ func msgdigGetInstance(params []any) any {
 
 	// Initialize empty buffer for accumulating data
 	md.FieldTable["buffer"] = object.Field{
-		Ftype:  types.ByteArray,
+		Ftype:  types.JavaByteArray,
 		Fvalue: []types.JavaByte{},
 	}
 
@@ -351,9 +351,9 @@ func msgdigDigest(params []any) any {
 	digest := h.Sum(nil)
 	javaDigest := object.JavaByteArrayFromGoByteArray(digest)
 
-	this.FieldTable["buffer"] = object.Field{Ftype: types.ByteArray, Fvalue: []types.JavaByte{}}
+	this.FieldTable["buffer"] = object.Field{Ftype: types.JavaByteArray, Fvalue: []types.JavaByte{}}
 
-	return object.MakePrimitiveObject(types.ByteArray, types.ByteArray, javaDigest)
+	return object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, javaDigest)
 }
 
 func msgdigDigestBytes(params []any) any {
@@ -403,7 +403,7 @@ func msgdigDigestBytesII(params []any) any {
 
 	digestBytes := digestObj.(*object.Object).FieldTable["value"].Fvalue.([]types.JavaByte)
 	copy(buf[offset:], digestBytes)
-	bufObj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: buf}
+	bufObj.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: buf}
 
 	return int64(len(digestBytes))
 }
@@ -411,7 +411,7 @@ func msgdigDigestBytesII(params []any) any {
 func msgdigReset(params []any) any {
 	const fname = "msgdigReset"
 	this := params[0].(*object.Object)
-	this.FieldTable["buffer"] = object.Field{Ftype: types.ByteArray, Fvalue: []types.JavaByte{}}
+	this.FieldTable["buffer"] = object.Field{Ftype: types.JavaByteArray, Fvalue: []types.JavaByte{}}
 	return nil
 }
 
@@ -447,7 +447,7 @@ func msgdigClone(params []any) any {
 	buffer := this.FieldTable["buffer"].Fvalue.([]types.JavaByte)
 	bufferCopy := make([]types.JavaByte, len(buffer))
 	copy(bufferCopy, buffer)
-	clone.FieldTable["buffer"] = object.Field{Ftype: types.ByteArray, Fvalue: bufferCopy}
+	clone.FieldTable["buffer"] = object.Field{Ftype: types.JavaByteArray, Fvalue: bufferCopy}
 
 	return clone
 }

--- a/src/gfunction/javaSecurity/javaSecuritySignature.go
+++ b/src/gfunction/javaSecurity/javaSecuritySignature.go
@@ -177,7 +177,7 @@ func signatureGetInstance(params []any) any {
 
 	// Initialize buffer for update() calls
 	sigObj.FieldTable["buffer"] = object.Field{
-		Ftype:  types.ByteArray,
+		Ftype:  types.JavaByteArray,
 		Fvalue: []types.JavaByte{},
 	}
 
@@ -263,7 +263,7 @@ func signatureInitSign(params []any) any {
 
 	// Reset buffer
 	sigObj.FieldTable["buffer"] = object.Field{
-		Ftype:  types.ByteArray,
+		Ftype:  types.JavaByteArray,
 		Fvalue: []types.JavaByte{},
 	}
 
@@ -336,7 +336,7 @@ func signatureInitVerify(params []any) any {
 
 	// Reset buffer
 	sigObj.FieldTable["buffer"] = object.Field{
-		Ftype:  types.ByteArray,
+		Ftype:  types.JavaByteArray,
 		Fvalue: []types.JavaByte{},
 	}
 
@@ -377,7 +377,7 @@ func signatureUpdateByte(params []any) any {
 
 	// Store updated buffer
 	sigObj.FieldTable["buffer"] = object.Field{
-		Ftype:  types.ByteArray,
+		Ftype:  types.JavaByteArray,
 		Fvalue: object.JavaByteArrayFromGoByteArray(buffer),
 	}
 
@@ -421,7 +421,7 @@ func signatureUpdateBytes(params []any) any {
 
 	// Store updated buffer
 	sigObj.FieldTable["buffer"] = object.Field{
-		Ftype:  types.ByteArray,
+		Ftype:  types.JavaByteArray,
 		Fvalue: object.JavaByteArrayFromGoByteArray(buffer),
 	}
 
@@ -489,7 +489,7 @@ func signatureUpdateBytesRange(params []any) any {
 
 	// Store updated buffer
 	sigObj.FieldTable["buffer"] = object.Field{
-		Ftype:  types.ByteArray,
+		Ftype:  types.JavaByteArray,
 		Fvalue: object.JavaByteArrayFromGoByteArray(buffer),
 	}
 
@@ -559,7 +559,7 @@ func signatureSign(params []any) any {
 
 	// Return signature as byte array object
 	sigJbytes := object.JavaByteArrayFromGoByteArray(signature)
-	sigArrayObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, sigJbytes)
+	sigArrayObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, sigJbytes)
 	return sigArrayObj
 }
 
@@ -630,7 +630,7 @@ func signatureSignToBuffer(params []any) any {
 	// Copy output buffer to signature.
 	copy(outbuf[offset:], signature)
 	sigJbytes = object.JavaByteArrayFromGoByteArray(signature)
-	sigArrayObj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: sigJbytes}
+	sigArrayObj.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: sigJbytes}
 
 	// Return length of signature
 	return int64(len(signature))
@@ -756,7 +756,7 @@ func signatureVerifyRange(params []any) any {
 	sigJbytes = object.JavaByteArrayFromGoByteArray(sigRange)
 
 	// Create new signature array object
-	sigRangeObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, sigJbytes)
+	sigRangeObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, sigJbytes)
 
 	// Call regular verify with extracted range
 	return signatureVerify([]any{params[0], sigRangeObj})

--- a/src/gfunction/javaSecurity/javaSecuritySignature_test.go
+++ b/src/gfunction/javaSecurity/javaSecuritySignature_test.go
@@ -75,7 +75,7 @@ func TestSignatureGFunctions_RSA(t *testing.T) {
 
 	// 4. update
 	data := []byte("hello world")
-	dataObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(data))
+	dataObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(data))
 	signatureUpdateBytes([]any{sigObj, dataObj})
 
 	// 5. sign
@@ -109,7 +109,7 @@ func TestSignatureGFunctions_RSA(t *testing.T) {
 	invalidSigBytes := make([]byte, len(signatureBytes))
 	copy(invalidSigBytes, signatureBytes)
 	invalidSigBytes[0] ^= 0xFF
-	invalidSigObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(invalidSigBytes))
+	invalidSigObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(invalidSigBytes))
 
 	signatureUpdateBytes([]any{sigObj, dataObj}) // Reset buffer by re-updating? No, buffer needs to be reset.
 	// Actually, signatureVerify doesn't reset buffer in current implementation, but it should probably if we want to re-verify.
@@ -138,7 +138,7 @@ func TestSignatureGFunctions_ECDSA(t *testing.T) {
 	signatureInitSign([]any{sigObj, privKeyObj})
 
 	data := []byte("ecdsa test")
-	dataObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(data))
+	dataObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(data))
 	signatureUpdateBytes([]any{sigObj, dataObj})
 
 	res = signatureSign([]any{sigObj})
@@ -177,7 +177,7 @@ func TestSignatureGFunctions_DSA(t *testing.T) {
 	signatureInitSign([]any{sigObj, privKeyObj})
 
 	data := []byte("dsa test")
-	dataObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(data))
+	dataObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(data))
 	signatureUpdateBytes([]any{sigObj, dataObj})
 
 	res = signatureSign([]any{sigObj})
@@ -212,7 +212,7 @@ func TestSignatureGFunctions_Ed25519(t *testing.T) {
 	signatureInitSign([]any{sigObj, privKeyObj})
 
 	data := []byte("ed25519 test")
-	dataObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(data))
+	dataObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(data))
 	signatureUpdateBytes([]any{sigObj, dataObj})
 
 	res = signatureSign([]any{sigObj})
@@ -242,7 +242,7 @@ func TestSignature_UpdateVariants(t *testing.T) {
 
 	// Update range
 	data := []byte("ZZhelloZZ")
-	dataObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(data))
+	dataObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(data))
 	signatureUpdateBytesRange([]any{sigObj, dataObj, int64(2), int64(5)})
 
 	buffer := sigObj.FieldTable["buffer"].Fvalue.([]types.JavaByte)

--- a/src/gfunction/javaxCrypto/javaxCryptoCipher.go
+++ b/src/gfunction/javaxCrypto/javaxCryptoCipher.go
@@ -292,9 +292,15 @@ func cipherDoFinal(params []any) any {
 		}
 	}
 
-	buffer, _ := self.FieldTable["buffer"].Fvalue.([]byte)
+	var buffer []byte
+	switch v := self.FieldTable["buffer"].Fvalue.(type) {
+	case []types.JavaByte:
+		buffer = object.GoByteArrayFromJavaByteArray(v)
+	case []byte:
+		buffer = v
+	}
 	fullInput := append(buffer, input...)
-	self.FieldTable["buffer"] = object.Field{Ftype: types.ByteArray, Fvalue: []byte{}}
+	self.FieldTable["buffer"] = object.Field{Ftype: types.JavaByteArray, Fvalue: []types.JavaByte{}}
 
 	config, ok := self.FieldTable["config"].Fvalue.(CipherTransformation)
 	if !ok {
@@ -315,7 +321,12 @@ func cipherDoFinal(params []any) any {
 	var keyBytes []byte
 
 	if kb, ok := keyObj.FieldTable["key"]; ok {
-		keyBytes, _ = kb.Fvalue.([]byte)
+		switch v := kb.Fvalue.(type) {
+		case []types.JavaByte:
+			keyBytes = object.GoByteArrayFromJavaByteArray(v)
+		case []byte:
+			keyBytes = v
+		}
 		config, ok := self.FieldTable["config"].Fvalue.(CipherTransformation)
 		if ok && strings.Contains(config.Name, "PBEWith") && !strings.Contains(config.Name, "Hmac") && !strings.Contains(config.Name, "HMAC") {
 			// Legacy PBE keys generated via SecretKeyFactory may contain both Key and IV.
@@ -368,7 +379,7 @@ func cipherDoFinal(params []any) any {
 		case []byte:
 			iv = v
 		case *object.Object:
-			if v.KlassName == object.StringPoolIndexFromGoString(types.ByteArray) {
+			if v.KlassName == object.StringPoolIndexFromGoString(types.JavaByteArray) {
 				iv = object.GoByteArrayFromJavaByteArray(v.FieldTable["value"].Fvalue.([]types.JavaByte))
 			}
 		}
@@ -424,12 +435,12 @@ func cipherDoFinal(params []any) any {
 		}
 		jResult := object.JavaByteArrayFromGoByteArray(result)
 		copy(dest[outputOffset:], jResult)
-		outputBuf.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: dest}
+		outputBuf.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: dest}
 		return int64(len(result))
 	}
 
 	jBytes := object.JavaByteArrayFromGoByteArray(result)
-	return object.MakePrimitiveObject(types.ByteArray, types.ByteArray, jBytes)
+	return object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, jBytes)
 }
 
 func cipherGetAlgorithm(params []any) any {
@@ -519,7 +530,7 @@ func cipherGetInstance(params []any) any {
 
 	// Internal state to hold transformation info
 	cipher.FieldTable["config"] = object.Field{
-		Ftype:  types.ByteArray,
+		Ftype:  types.Struct,
 		Fvalue: config,
 	}
 
@@ -541,10 +552,10 @@ func cipherGetIV(params []any) any {
 	// Ensure it's returned as a Java byte array object.
 	switch v := ivField.Fvalue.(type) {
 	case []types.JavaByte:
-		return object.MakePrimitiveObject(types.ByteArray, types.ByteArray, v)
+		return object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, v)
 	case []byte:
 		jBytes := object.JavaByteArrayFromGoByteArray(v)
-		return object.MakePrimitiveObject(types.ByteArray, types.ByteArray, jBytes)
+		return object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, jBytes)
 	default:
 		// Fallback for cases where it might already be an object (unlikely here but safe)
 		return object.MakeArrayFromRawArray(v)
@@ -563,7 +574,13 @@ func cipherGetOutputSize(params []any) any {
 	}
 
 	inputLen := params[1].(int64)
-	buffer, _ := self.FieldTable["buffer"].Fvalue.([]byte)
+	var buffer []byte
+	switch v := self.FieldTable["buffer"].Fvalue.(type) {
+	case []types.JavaByte:
+		buffer = object.GoByteArrayFromJavaByteArray(v)
+	case []byte:
+		buffer = v
+	}
 	totalLen := inputLen + int64(len(buffer))
 
 	blockSize := cipherGetBlockSize(params).(int64)
@@ -613,9 +630,9 @@ func cipherGetParameters(params []any) any {
 	case *object.Object:
 		ivObj = v
 	case []types.JavaByte:
-		ivObj = object.MakePrimitiveObject(types.ByteArray, types.ByteArray, v)
+		ivObj = object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, v)
 	case []byte:
-		ivObj = object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(v))
+		ivObj = object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(v))
 	}
 
 	if ivObj != nil {
@@ -720,12 +737,12 @@ func cipherInit(params []any) any {
 			if isLegacyPBE || isHmacPBE {
 				// For legacy PBE, a null spec might mean "use defaults/extract from key"
 				// So we DON'T set ivProvided = true yet.
-				self.FieldTable["iv"] = object.Field{Ftype: types.ByteArray, Fvalue: object.Null}
+				self.FieldTable["iv"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.Null}
 				ivProvided = false
 			} else {
 				// If spec is explicitly provided as null, we treat it as "provided" but empty.
 				// This prevents auto-generation.
-				self.FieldTable["iv"] = object.Field{Ftype: types.ByteArray, Fvalue: object.Null}
+				self.FieldTable["iv"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.Null}
 				ivProvided = true
 			}
 		}
@@ -761,14 +778,14 @@ func cipherInit(params []any) any {
 
 		ivObj, ok := self.FieldTable["iv"]
 		if !ok || object.IsNull(ivObj.Fvalue) {
-			self.FieldTable["iv"] = object.Field{Ftype: types.ByteArray, Fvalue: object.Null}
+			self.FieldTable["iv"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.Null}
 			ivProvided = false
 		} else if isLegacyPBE {
 			// Keep existing derived IV for legacy PBE
 			ivProvided = true
 		} else {
 			// For non-legacy PBE, we typically want a fresh IV if none provided
-			self.FieldTable["iv"] = object.Field{Ftype: types.ByteArray, Fvalue: object.Null}
+			self.FieldTable["iv"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.Null}
 			ivProvided = false
 		}
 	}
@@ -790,7 +807,13 @@ func cipherInit(params []any) any {
 					if ok {
 						keyObj := keyField.Fvalue.(*object.Object)
 						if kb, ok := keyObj.FieldTable["key"]; ok {
-							keyBytes := kb.Fvalue.([]byte)
+							var keyBytes []byte
+							switch v := kb.Fvalue.(type) {
+							case []types.JavaByte:
+								keyBytes = object.GoByteArrayFromJavaByteArray(v)
+							case []byte:
+								keyBytes = v
+							}
 							// Legacy PBE: Extract Key AND IV if not provided
 							var derivedIV []byte
 							if strings.Contains(config.Name, "DESede") || strings.Contains(config.Name, "TripleDES") {
@@ -813,8 +836,8 @@ func cipherInit(params []any) any {
 
 							if len(derivedIV) > 0 {
 								jBytes := object.JavaByteArrayFromGoByteArray(derivedIV)
-								ivObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, jBytes)
-								self.FieldTable["iv"] = object.Field{Ftype: types.ByteArray, Fvalue: ivObj}
+								ivObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, jBytes)
+								self.FieldTable["iv"] = object.Field{Ftype: types.JavaByteArray, Fvalue: ivObj}
 								ivProvided = true
 							}
 						}
@@ -827,8 +850,8 @@ func cipherInit(params []any) any {
 						iv := make([]byte, ivLen)
 						if _, err := rand.Read(iv); err == nil {
 							jBytes := object.JavaByteArrayFromGoByteArray(iv)
-							ivObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, jBytes)
-							self.FieldTable["iv"] = object.Field{Ftype: types.ByteArray, Fvalue: ivObj}
+							ivObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, jBytes)
+							self.FieldTable["iv"] = object.Field{Ftype: types.JavaByteArray, Fvalue: ivObj}
 						}
 					} else {
 						// For decryption and other modes, if IV is still not provided and it's not a legacy PBE,
@@ -837,8 +860,8 @@ func cipherInit(params []any) any {
 						if strings.Contains(config.Name, "PBEWith") {
 							iv := make([]byte, ivLen)
 							jBytes := object.JavaByteArrayFromGoByteArray(iv)
-							ivObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, jBytes)
-							self.FieldTable["iv"] = object.Field{Ftype: types.ByteArray, Fvalue: ivObj}
+							ivObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, jBytes)
+							self.FieldTable["iv"] = object.Field{Ftype: types.JavaByteArray, Fvalue: ivObj}
 						}
 					}
 				}
@@ -846,7 +869,7 @@ func cipherInit(params []any) any {
 		}
 	}
 
-	self.FieldTable["buffer"] = object.Field{Ftype: types.ByteArray, Fvalue: []byte{}}
+	self.FieldTable["buffer"] = object.Field{Ftype: types.JavaByteArray, Fvalue: []types.JavaByte{}}
 
 	return nil
 }
@@ -890,7 +913,13 @@ func handleInitSpec(self *object.Object, spec *object.Object, ivProvided *bool) 
 				// A derived key will have a "key" field in its FieldTable.
 				if _, ok := keyObj.FieldTable["key"]; !ok {
 					// Create a PBEKeySpec from the existing password and the new salt/iterations
-					passwordBytes := keyObj.FieldTable["value"].Fvalue.([]byte)
+					var passwordBytes []byte
+					switch v := keyObj.FieldTable["value"].Fvalue.(type) {
+					case []types.JavaByte:
+						passwordBytes = object.GoByteArrayFromJavaByteArray(v)
+					case []byte:
+						passwordBytes = v
+					}
 					passwordChars := make([]int64, len(passwordBytes))
 					for i, b := range passwordBytes {
 						passwordChars[i] = int64(b)
@@ -908,7 +937,7 @@ func handleInitSpec(self *object.Object, spec *object.Object, ivProvided *bool) 
 					case []byte:
 						jSalt = object.JavaByteArrayFromGoByteArray(v)
 					}
-					pbeKeySpec.FieldTable["salt"] = object.Field{Ftype: "[B", Fvalue: object.MakePrimitiveObject(types.ByteArray, types.ByteArray, jSalt)}
+ 				pbeKeySpec.FieldTable["salt"] = object.Field{Ftype: "[B", Fvalue: object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, jSalt)}
 					pbeKeySpec.FieldTable["iterationCount"] = object.Field{Ftype: types.Int, Fvalue: iterations}
 
 					keyLength := int64(0)
@@ -934,7 +963,7 @@ func handleInitSpec(self *object.Object, spec *object.Object, ivProvided *bool) 
 						// we signal that the IV is NOT provided so that cipherInit can extract it from the newly derived key.
 						// We also clear any existing salt-based IV to ensure extraction happens.
 						if strings.Contains(config.Name, "PBEWith") && !strings.Contains(config.Name, "Hmac") && !strings.Contains(config.Name, "HMAC") {
-							self.FieldTable["iv"] = object.Field{Ftype: types.ByteArray, Fvalue: object.Null}
+   				self.FieldTable["iv"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.Null}
 							*ivProvided = false
 						} else if strings.Contains(config.Name, "PBEWith") {
 							// For HMAC-based PBE, we use salt as IV by default (if 16 bytes).
@@ -970,10 +999,16 @@ func cipherUpdate(params []any) any {
 		}
 	}
 
-	buffer, _ := self.FieldTable["buffer"].Fvalue.([]byte)
-	self.FieldTable["buffer"] = object.Field{Ftype: types.ByteArray, Fvalue: append(buffer, input...)}
+	var buffer []byte
+	switch v := self.FieldTable["buffer"].Fvalue.(type) {
+	case []types.JavaByte:
+		buffer = object.GoByteArrayFromJavaByteArray(v)
+	case []byte:
+		buffer = v
+	}
+	self.FieldTable["buffer"] = object.Field{Ftype: types.JavaByteArray, Fvalue: append(buffer, input...)}
 
 	// Return null or empty byte array for now, as we buffer everything
 	jBytes := object.JavaByteArrayFromGoByteArray([]byte{})
-	return object.MakePrimitiveObject(types.ByteArray, types.ByteArray, jBytes)
+	return object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, jBytes)
 }

--- a/src/gfunction/javaxCrypto/javaxCryptoCipher_test.go
+++ b/src/gfunction/javaxCrypto/javaxCryptoCipher_test.go
@@ -91,15 +91,15 @@ func TestCipherInitAndUpdate(t *testing.T) {
 
 	// Setup Key
 	keyBytes := []byte("1234567812345678") // 16 bytes for AES
-	keyObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(keyBytes))
+	keyObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(keyBytes))
 
 	// Setup IV
 	ivBytes := []byte("iviviviviviviviv") // 16 bytes
 	ivSpecClass := "javax/crypto/spec/IvParameterSpec"
 	ivSpecObj := object.MakeEmptyObjectWithClassName(&ivSpecClass)
 	ivSpecObj.FieldTable["iv"] = object.Field{
-		Ftype:  types.ByteArray,
-		Fvalue: object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(ivBytes)),
+		Ftype:  types.JavaByteArray,
+		Fvalue: object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(ivBytes)),
 	}
 
 	// cipherInit(opmode, key, spec)
@@ -118,10 +118,16 @@ func TestCipherInitAndUpdate(t *testing.T) {
 
 	// cipherUpdate
 	input := []byte("hello world")
-	inputObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(input))
+	inputObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(input))
 	cipherUpdate([]any{cipherObj, inputObj})
 
-	buffered := cipherObj.FieldTable["buffer"].Fvalue.([]byte)
+	var buffered []byte
+	switch v := cipherObj.FieldTable["buffer"].Fvalue.(type) {
+	case []types.JavaByte:
+		buffered = object.GoByteArrayFromJavaByteArray(v)
+	case []byte:
+		buffered = v
+	}
 	if !bytes.Equal(buffered, input) {
 		t.Errorf("Expected buffer %v, got %v", input, buffered)
 	}
@@ -154,7 +160,13 @@ func TestCipherInitAndUpdate(t *testing.T) {
 	}
 
 	// Buffer should be empty after doFinal
-	bufferedPost := cipherObj.FieldTable["buffer"].Fvalue.([]byte)
+	var bufferedPost []byte
+	switch v := cipherObj.FieldTable["buffer"].Fvalue.(type) {
+	case []types.JavaByte:
+		bufferedPost = object.GoByteArrayFromJavaByteArray(v)
+	case []byte:
+		bufferedPost = v
+	}
 	if len(bufferedPost) != 0 {
 		t.Errorf("Expected empty buffer after doFinal, got len %d", len(bufferedPost))
 	}
@@ -173,13 +185,13 @@ func TestCipherGetIV(t *testing.T) {
 	ivSpecClass := "javax/crypto/spec/IvParameterSpec"
 	ivSpecObj := object.MakeEmptyObjectWithClassName(&ivSpecClass)
 	ivSpecObj.FieldTable["iv"] = object.Field{
-		Ftype:  types.ByteArray,
-		Fvalue: object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(ivBytes)),
+		Ftype:  types.JavaByteArray,
+		Fvalue: object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(ivBytes)),
 	}
 
 	// cipherInit(opmode, key, spec)
 	keyBytes := []byte("1234567812345678")
-	keyObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(keyBytes))
+	keyObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(keyBytes))
 	cipherInit([]any{cipherObj, int64(1), keyObj, ivSpecObj})
 
 	// cipherGetIV
@@ -212,22 +224,33 @@ func TestCipherUpdateAndDoFinalWithOffset(t *testing.T) {
 	cipherObj := cipherGetInstance([]any{transObj}).(*object.Object)
 
 	keyBytes := []byte("1234567812345678")
-	keyObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(keyBytes))
+	keyObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(keyBytes))
 	cipherInit([]any{cipherObj, int64(1), keyObj})
 
 	// cipherUpdate with offset and length
 	input := []byte("0123456789ABCDEF")
-	inputObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(input))
+	inputObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(input))
 	cipherUpdate([]any{cipherObj, inputObj, int64(2), int64(4)}) // "2345"
 
-	buffered := cipherObj.FieldTable["buffer"].Fvalue.([]byte)
+	var buffered []byte
+	switch v := cipherObj.FieldTable["buffer"].Fvalue.(type) {
+	case []types.JavaByte:
+		buffered = object.GoByteArrayFromJavaByteArray(v)
+	case []byte:
+		buffered = v
+	}
 	if !bytes.Equal(buffered, []byte("2345")) {
 		t.Errorf("Expected buffer 2345, got %s", string(buffered))
 	}
 
 	// multiple updates
 	cipherUpdate([]any{cipherObj, inputObj, int64(6), int64(2)}) // "67"
-	buffered = cipherObj.FieldTable["buffer"].Fvalue.([]byte)
+	switch v := cipherObj.FieldTable["buffer"].Fvalue.(type) {
+	case []types.JavaByte:
+		buffered = object.GoByteArrayFromJavaByteArray(v)
+	case []byte:
+		buffered = v
+	}
 	if !bytes.Equal(buffered, []byte("234567")) {
 		t.Errorf("Expected buffer 234567, got %s", string(buffered))
 	}
@@ -244,7 +267,7 @@ func TestCipherUpdateAndDoFinalWithOffset(t *testing.T) {
 	ivObj := cipherObj.FieldTable["iv"].Fvalue.(*object.Object)
 	ivSpecClass := "javax/crypto/spec/IvParameterSpec"
 	ivSpecObj := object.MakeEmptyObjectWithClassName(&ivSpecClass)
-	ivSpecObj.FieldTable["iv"] = object.Field{Ftype: types.ByteArray, Fvalue: ivObj}
+	ivSpecObj.FieldTable["iv"] = object.Field{Ftype: types.JavaByteArray, Fvalue: ivObj}
 
 	cipherInit([]any{cipherObj, int64(2), keyObj, ivSpecObj}) // DECRYPT_MODE
 	// We need the IV that was auto-generated or the one we started with.
@@ -299,7 +322,7 @@ func TestCipherGetters(t *testing.T) {
 	// Set IV and check getParameters
 	iv := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	ivObj := makeByteArrayObject(iv)
-	cipherObj.FieldTable["iv"] = object.Field{Ftype: types.ByteArray, Fvalue: ivObj}
+	cipherObj.FieldTable["iv"] = object.Field{Ftype: types.JavaByteArray, Fvalue: ivObj}
 	resParams = cipherGetParameters([]any{cipherObj})
 	if object.IsNull(resParams) {
 		t.Error("Expected non-null parameters after IV is set")
@@ -373,7 +396,7 @@ func TestCipherInitVariations(t *testing.T) {
 	cipherObj := cipherGetInstance([]any{transObj}).(*object.Object)
 
 	keyBytes := []byte("1234567812345678")
-	keyObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(keyBytes))
+	keyObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(keyBytes))
 
 	// init(opmode, key)
 	cipherInit([]any{cipherObj, int64(2), keyObj}) // DECRYPT_MODE

--- a/src/gfunction/javaxCrypto/javaxCryptoKeyAgreement.go
+++ b/src/gfunction/javaxCrypto/javaxCryptoKeyAgreement.go
@@ -195,10 +195,22 @@ func genSecretECDH(privateKeyObj, publicKeyObj *object.Object) ([]byte, error) {
 
 func genSecretX25519(privateKeyObj, publicKeyObj *object.Object) ([]byte, error) {
 	// Extract private key (32 bytes)
-	privKey := privateKeyObj.FieldTable["value"].Fvalue.([]byte)
+	var privKey []byte
+	switch v := privateKeyObj.FieldTable["value"].Fvalue.(type) {
+	case []types.JavaByte:
+		privKey = object.GoByteArrayFromJavaByteArray(v)
+	case []byte:
+		privKey = v
+	}
 
 	// Extract public key (32 bytes)
-	pubKey := publicKeyObj.FieldTable["value"].Fvalue.([]byte)
+	var pubKey []byte
+	switch v := publicKeyObj.FieldTable["value"].Fvalue.(type) {
+	case []types.JavaByte:
+		pubKey = object.GoByteArrayFromJavaByteArray(v)
+	case []byte:
+		pubKey = v
+	}
 
 	// Perform X25519 scalar multiplication
 	secret, err := curve25519.X25519(privKey, pubKey)
@@ -359,7 +371,7 @@ func keyagreementGenerateSecret(params []any) any {
 	}
 
 	// Return as byte array
-	return object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(secretBytes))
+	return object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(secretBytes))
 }
 
 func keyagreementGetAlgorithm(params []any) any {

--- a/src/gfunction/javaxCrypto/javaxCryptoPBE_test.go
+++ b/src/gfunction/javaxCrypto/javaxCryptoPBE_test.go
@@ -28,7 +28,7 @@ func TestPBEWithMD5AndDES(t *testing.T) {
 		passwordChars[i] = int64(c)
 	}
 	passwordCharsObj := object.MakePrimitiveObject(types.CharArray, types.CharArray, passwordChars)
-	saltObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(salt))
+	saltObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(salt))
 
 	// 2. Derive Key using SecretKeyFactory
 	skfAlgo := "PBEWithMD5AndDES"
@@ -58,14 +58,14 @@ func TestPBEWithMD5AndDES(t *testing.T) {
 	// PBEParameterSpec
 	pbeParamSpecClass := "javax/crypto/spec/PBEParameterSpec"
 	pbeParamSpec := object.MakeEmptyObjectWithClassName(&pbeParamSpecClass)
-	pbeParamSpec.FieldTable["salt"] = object.Field{Ftype: types.ByteArray, Fvalue: salt}
+	pbeParamSpec.FieldTable["salt"] = object.Field{Ftype: types.JavaByteArray, Fvalue: salt}
 	pbeParamSpec.FieldTable["iterationCount"] = object.Field{Ftype: types.Int, Fvalue: iterations}
 
 	// 4. Encrypt
 	cipherInit([]any{cipherObj, int64(1), genKey, pbeParamSpec}) // ENCRYPT_MODE with PBEParameterSpec
 
 	plaintext := []byte("This is a secret message")
-	inputObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(plaintext))
+	inputObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(plaintext))
 
 	resEnc := cipherDoFinal([]any{cipherObj, inputObj})
 	if errBlk, ok := resEnc.(*ghelpers.GErrBlk); ok {
@@ -105,7 +105,7 @@ func TestPBEWithSHA1AndRC2(t *testing.T) {
 		passwordChars[i] = int64(c)
 	}
 	passwordCharsObj := object.MakePrimitiveObject(types.CharArray, types.CharArray, passwordChars)
-	saltObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(salt))
+	saltObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(salt))
 
 	// 2. Derive Key using SecretKeyFactory
 	skfAlgo := "PBEWithSHA1AndRC2_128"
@@ -135,14 +135,14 @@ func TestPBEWithSHA1AndRC2(t *testing.T) {
 	// PBEParameterSpec
 	pbeParamSpecClass := "javax/crypto/spec/PBEParameterSpec"
 	pbeParamSpec := object.MakeEmptyObjectWithClassName(&pbeParamSpecClass)
-	pbeParamSpec.FieldTable["salt"] = object.Field{Ftype: types.ByteArray, Fvalue: salt}
+	pbeParamSpec.FieldTable["salt"] = object.Field{Ftype: types.JavaByteArray, Fvalue: salt}
 	pbeParamSpec.FieldTable["iterationCount"] = object.Field{Ftype: types.Int, Fvalue: iterations}
 
 	// 4. Encrypt
 	cipherInit([]any{cipherObj, int64(1), genKey, pbeParamSpec}) // ENCRYPT_MODE
 
 	plaintext := []byte("This is a secret message")
-	inputObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(plaintext))
+	inputObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(plaintext))
 
 	resEnc := cipherDoFinal([]any{cipherObj, inputObj})
 	if errBlk, ok := resEnc.(*ghelpers.GErrBlk); ok {
@@ -182,7 +182,7 @@ func TestPBEWithSHA1AndDESede(t *testing.T) {
 		passwordChars[i] = int64(c)
 	}
 	passwordCharsObj := object.MakePrimitiveObject(types.CharArray, types.CharArray, passwordChars)
-	saltObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(salt))
+	saltObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(salt))
 
 	// 2. Derive Key using SecretKeyFactory
 	skfAlgo := "PBEWithSHA1AndDESede"
@@ -212,14 +212,14 @@ func TestPBEWithSHA1AndDESede(t *testing.T) {
 	// PBEParameterSpec
 	pbeParamSpecClass := "javax/crypto/spec/PBEParameterSpec"
 	pbeParamSpec := object.MakeEmptyObjectWithClassName(&pbeParamSpecClass)
-	pbeParamSpec.FieldTable["salt"] = object.Field{Ftype: types.ByteArray, Fvalue: salt}
+	pbeParamSpec.FieldTable["salt"] = object.Field{Ftype: types.JavaByteArray, Fvalue: salt}
 	pbeParamSpec.FieldTable["iterationCount"] = object.Field{Ftype: types.Int, Fvalue: iterations}
 
 	// 4. Encrypt
 	cipherInit([]any{cipherObj, int64(1), genKey, pbeParamSpec}) // ENCRYPT_MODE
 
 	plaintext := []byte("TripleDES PBE test message")
-	inputObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(plaintext))
+	inputObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(plaintext))
 
 	resEnc := cipherDoFinal([]any{cipherObj, inputObj})
 	if errBlk, ok := resEnc.(*ghelpers.GErrBlk); ok {
@@ -254,7 +254,7 @@ func runPBEWithHmacTest(t *testing.T, algo string) {
 		passwordChars[i] = int64(c)
 	}
 	passwordCharsObj := object.MakePrimitiveObject(types.CharArray, types.CharArray, passwordChars)
-	saltObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(salt))
+	saltObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(salt))
 
 	// 2. Derive Key using SecretKeyFactory
 	skfAlgoObj := object.StringObjectFromGoString(algo)
@@ -283,13 +283,13 @@ func runPBEWithHmacTest(t *testing.T, algo string) {
 	iv := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 	ivSpecClass := "javax/crypto/spec/IvParameterSpec"
 	ivSpec := object.MakeEmptyObjectWithClassName(&ivSpecClass)
-	ivSpec.FieldTable["iv"] = object.Field{Ftype: types.ByteArray, Fvalue: object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(iv))}
+	ivSpec.FieldTable["iv"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(iv))}
 
 	// 4. Encrypt
 	cipherInit([]any{cipherObj, int64(1), genKey, ivSpec}) // ENCRYPT_MODE
 
 	plaintext := []byte("AES PBE test message for " + algo)
-	inputObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, object.JavaByteArrayFromGoByteArray(plaintext))
+	inputObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(plaintext))
 
 	resEnc := cipherDoFinal([]any{cipherObj, inputObj})
 	if errBlk, ok := resEnc.(*ghelpers.GErrBlk); ok {

--- a/src/gfunction/javaxCrypto/javaxCryptoSecretKeyFactory.go
+++ b/src/gfunction/javaxCrypto/javaxCryptoSecretKeyFactory.go
@@ -157,7 +157,7 @@ func secretKeyFactoryGenerateSecret(params []any) any {
 		if (isPBKDF2 || isPBEAES) && (len(salt) == 0 || iterations == 0 || keyLength == 0) {
 			// If salt, iterations or keyLength are missing, we can't derive the key yet.
 			// Return a SecretKey that just contains the password and needs derivation.
-			sk := object.MakePrimitiveObject(types.ClassNameSecretKey, types.ByteArray, []byte(password))
+			sk := object.MakePrimitiveObject(types.ClassNameSecretKey, types.JavaByteArray, object.JavaByteArrayFromGoByteArray([]byte(password)))
 			sk.FieldTable["algorithm"] = object.Field{Ftype: types.StringClassName, Fvalue: algorithmObj}
 			if keyLength > 0 {
 				sk.FieldTable["inferred_key_length"] = object.Field{Ftype: types.Int, Fvalue: keyLength}
@@ -172,7 +172,7 @@ func secretKeyFactoryGenerateSecret(params []any) any {
 			if salt == nil {
 				// Salt is required for legacy PBE derivation.
 				// If not provided, we must defer derivation.
-				sk := object.MakePrimitiveObject(types.ClassNameSecretKey, types.ByteArray, []byte(password))
+				sk := object.MakePrimitiveObject(types.ClassNameSecretKey, types.JavaByteArray, object.JavaByteArrayFromGoByteArray([]byte(password)))
 				sk.FieldTable["algorithm"] = object.Field{Ftype: types.StringClassName, Fvalue: algorithmObj}
 				return sk
 			}
@@ -300,9 +300,9 @@ func secretKeyFactoryGenerateSecret(params []any) any {
 			}
 		}
 
-		sk := object.MakePrimitiveObject(types.ClassNameSecretKey, types.ByteArray, keyPart)
+		sk := object.MakePrimitiveObject(types.ClassNameSecretKey, types.JavaByteArray, object.JavaByteArrayFromGoByteArray(keyPart))
 		sk.FieldTable["algorithm"] = object.Field{Ftype: types.StringClassName, Fvalue: algorithmObj}
-		sk.FieldTable["key"] = object.Field{Ftype: types.ByteArray, Fvalue: derivedKey} // Full material (Key + IV)
+		sk.FieldTable["key"] = object.Field{Ftype: types.GoByteArray, Fvalue: derivedKey} // Full material (Key + IV)
 		return sk
 	}
 

--- a/src/gfunction/javaxCrypto/javaxCryptoSecretKeyFactory_test.go
+++ b/src/gfunction/javaxCrypto/javaxCryptoSecretKeyFactory_test.go
@@ -61,7 +61,7 @@ func TestSecretKeyFactory(t *testing.T) {
 	key := []byte("0123456789abcdef")
 	specClassName := "javax/crypto/spec/SecretKeySpec"
 	specObj := object.MakeEmptyObjectWithClassName(&specClassName)
-	specObj.FieldTable["key"] = object.Field{Ftype: types.ByteArray, Fvalue: key}
+	specObj.FieldTable["key"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoByteArray(key)}
 	specObj.FieldTable["algorithm"] = object.Field{Ftype: types.StringClassName, Fvalue: algoObj}
 
 	res = secretKeyFactoryGenerateSecret([]any{skf, specObj})
@@ -76,7 +76,7 @@ func TestSecretKeyFactory(t *testing.T) {
 	// Test generateSecret with algorithm mismatch
 	otherAlgoObj := object.StringObjectFromGoString("DES")
 	specObjMismatch := object.MakeEmptyObjectWithClassName(&specClassName)
-	specObjMismatch.FieldTable["key"] = object.Field{Ftype: types.ByteArray, Fvalue: key}
+	specObjMismatch.FieldTable["key"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoByteArray(key)}
 	specObjMismatch.FieldTable["algorithm"] = object.Field{Ftype: types.StringClassName, Fvalue: otherAlgoObj}
 
 	res = secretKeyFactoryGenerateSecret([]any{skf, specObjMismatch})
@@ -105,7 +105,7 @@ func TestSecretKeyFactory(t *testing.T) {
 	passwordCharsObj := object.MakePrimitiveObject(types.CharArray, types.CharArray, passwordChars)
 
 	saltJavaBytes := object.JavaByteArrayFromGoByteArray(salt)
-	saltObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, saltJavaBytes)
+	saltObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, saltJavaBytes)
 
 	pbeKeySpecClassName := "javax/crypto/spec/PBEKeySpec"
 	pbeKeySpec := object.MakeEmptyObjectWithClassName(&pbeKeySpecClassName)
@@ -127,7 +127,7 @@ func TestSecretKeyFactory(t *testing.T) {
 		t.Fatalf("Expected generated key object, got %T", res)
 	}
 
-	derivedKey := genKey.FieldTable["value"].Fvalue.([]byte)
+	derivedKey := genKey.FieldTable["value"].Fvalue.([]types.JavaByte)
 	if len(derivedKey) != int(keyLength/8) {
 		t.Errorf("Expected key length %d, got %d", keyLength/8, len(derivedKey))
 	}
@@ -157,7 +157,7 @@ func TestSecretKeyFactory(t *testing.T) {
 		t.Fatalf("Expected generated key object for %s, got %T", pbeAesAlgo, res)
 	}
 
-	derivedKey = genKey.FieldTable["value"].Fvalue.([]byte)
+	derivedKey = genKey.FieldTable["value"].Fvalue.([]types.JavaByte)
 	if len(derivedKey) != 256/8 {
 		t.Errorf("Expected key length %d, got %d for %s", 256/8, len(derivedKey), pbeAesAlgo)
 	}
@@ -187,7 +187,7 @@ func TestSecretKeyFactory(t *testing.T) {
 		t.Fatalf("Expected generated key object for %s, got %T", pbeLegacyAlgo, res)
 	}
 
-	derivedKey = genKey.FieldTable["value"].Fvalue.([]byte)
+	derivedKey = genKey.FieldTable["value"].Fvalue.([]types.JavaByte)
 	if len(derivedKey) != 64/8 {
 		t.Errorf("Expected key length %d, got %d for %s", 64/8, len(derivedKey), pbeLegacyAlgo)
 	}

--- a/src/gfunction/javaxCrypto/javaxCryptoSpecGCMParameterSpec.go
+++ b/src/gfunction/javaxCrypto/javaxCryptoSpecGCMParameterSpec.go
@@ -52,14 +52,20 @@ func gcmParameterSpecGetIV(params []any) any {
 			"gcmParameterSpecGetIV: 'this' is not an object")
 	}
 
-	iv, ok := self.FieldTable["iv"].Fvalue.([]byte)
-	if !ok {
+	var iv []byte
+	switch v := self.FieldTable["iv"].Fvalue.(type) {
+	case []types.JavaByte:
+		iv = object.GoByteArrayFromJavaByteArray(v)
+	case []byte:
+		iv = v
+	}
+	if iv == nil {
 		return ghelpers.ReturnNull(params)
 	}
 
 	// Returns a copy of the IV
 	jBytes := object.JavaByteArrayFromGoByteArray(slices.Clone(iv))
-	return object.MakePrimitiveObject(types.ByteArray, types.ByteArray, jBytes)
+	return object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, jBytes)
 }
 
 func gcmParameterSpecGetTLen(params []any) any {
@@ -129,7 +135,7 @@ func gcmParameterSpecInit(params []any) any {
 	}
 
 	self.FieldTable["iv"] = object.Field{
-		Ftype:  types.ByteArray,
+		Ftype:  types.GoByteArray,
 		Fvalue: iv,
 	}
 	self.FieldTable["tLen"] = object.Field{

--- a/src/gfunction/javaxCrypto/javaxCryptoSpecGCMParameterSpec_test.go
+++ b/src/gfunction/javaxCrypto/javaxCryptoSpecGCMParameterSpec_test.go
@@ -18,7 +18,7 @@ import (
 
 func makeByteArrayObject(b []byte) *object.Object {
 	jBytes := object.JavaByteArrayFromGoByteArray(b)
-	return object.MakePrimitiveObject(types.ByteArray, types.ByteArray, jBytes)
+	return object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, jBytes)
 }
 
 func TestGCMParameterSpec(t *testing.T) {

--- a/src/gfunction/javaxCrypto/javaxCryptoSpecIvParameterSpec.go
+++ b/src/gfunction/javaxCrypto/javaxCryptoSpecIvParameterSpec.go
@@ -46,14 +46,20 @@ func ivParameterSpecGetIV(params []any) any {
 			"ivParameterSpecGetIV: 'this' is not an object")
 	}
 
-	iv, ok := self.FieldTable["iv"].Fvalue.([]byte)
-	if !ok {
+	var iv []byte
+	switch v := self.FieldTable["iv"].Fvalue.(type) {
+	case []types.JavaByte:
+		iv = object.GoByteArrayFromJavaByteArray(v)
+	case []byte:
+		iv = v
+	}
+	if iv == nil {
 		return ghelpers.ReturnNull(params)
 	}
 
 	// Returns a copy of the IV
 	jBytes := object.JavaByteArrayFromGoByteArray(slices.Clone(iv))
-	return object.MakePrimitiveObject(types.ByteArray, types.ByteArray, jBytes)
+	return object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, jBytes)
 }
 
 func ivParameterSpecInit(params []any) any {
@@ -101,7 +107,7 @@ func ivParameterSpecInit(params []any) any {
 	}
 
 	self.FieldTable["iv"] = object.Field{
-		Ftype:  types.ByteArray,
+		Ftype:  types.GoByteArray,
 		Fvalue: iv,
 	}
 

--- a/src/gfunction/javaxCrypto/javaxCryptoSpecIvParameterSpec_test.go
+++ b/src/gfunction/javaxCrypto/javaxCryptoSpecIvParameterSpec_test.go
@@ -31,7 +31,13 @@ func TestIvParameterSpec(t *testing.T) {
 		t.Errorf("Expected nil result, got %v", res1)
 	}
 
-	ivStored := spec1.FieldTable["iv"].Fvalue.([]byte)
+	var ivStored []byte
+	switch v := spec1.FieldTable["iv"].Fvalue.(type) {
+	case []types.JavaByte:
+		ivStored = object.GoByteArrayFromJavaByteArray(v)
+	case []byte:
+		ivStored = v
+	}
 	if !bytes.Equal(ivStored, iv) {
 		t.Errorf("Expected IV %v, got %v", iv, ivStored)
 	}
@@ -50,7 +56,8 @@ func TestIvParameterSpec(t *testing.T) {
 
 	// Verify getIV returns a copy
 	resIVGoBytes[0] ^= 0xFF
-	if bytes.Equal(spec1.FieldTable["iv"].Fvalue.([]byte), resIVGoBytes) {
+	ivStoredAfter := spec1.FieldTable["iv"].Fvalue.([]byte)
+	if bytes.Equal(ivStoredAfter, resIVGoBytes) {
 		t.Error("getIV() should return a copy")
 	}
 

--- a/src/gfunction/javaxCrypto/javaxCryptoSpecPBEParameterSpec.go
+++ b/src/gfunction/javaxCrypto/javaxCryptoSpecPBEParameterSpec.go
@@ -78,14 +78,20 @@ func pbeParameterSpecGetSalt(params []any) any {
 			"pbeParameterSpecGetSalt: 'this' is not an object")
 	}
 
-	salt, ok := self.FieldTable["salt"].Fvalue.([]byte)
-	if !ok {
+	var salt []byte
+	switch v := self.FieldTable["salt"].Fvalue.(type) {
+	case []types.JavaByte:
+		salt = object.GoByteArrayFromJavaByteArray(v)
+	case []byte:
+		salt = v
+	}
+	if salt == nil {
 		return ghelpers.ReturnNull(params)
 	}
 
 	// Returns a copy of the salt
 	jBytes := object.JavaByteArrayFromGoByteArray(slices.Clone(salt))
-	return object.MakePrimitiveObject(types.ByteArray, types.ByteArray, jBytes)
+	return object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, jBytes)
 }
 
 func pbeParameterSpecGetParameterSpec(params []any) any {
@@ -135,7 +141,7 @@ func pbeParameterSpecInit(params []any) any {
 	salt := object.GoByteArrayFromJavaByteArray(saltObj.FieldTable["value"].Fvalue.([]types.JavaByte))
 
 	self.FieldTable["salt"] = object.Field{
-		Ftype:  types.ByteArray,
+		Ftype:  types.GoByteArray,
 		Fvalue: slices.Clone(salt),
 	}
 	self.FieldTable["iterationCount"] = object.Field{
@@ -176,7 +182,7 @@ func pbeParameterSpecInitWithSpec(params []any) any {
 	salt := object.GoByteArrayFromJavaByteArray(saltObj.FieldTable["value"].Fvalue.([]types.JavaByte))
 
 	self.FieldTable["salt"] = object.Field{
-		Ftype:  types.ByteArray,
+		Ftype:  types.GoByteArray,
 		Fvalue: slices.Clone(salt),
 	}
 	self.FieldTable["iterationCount"] = object.Field{

--- a/src/gfunction/javaxCrypto/javaxCryptoSpecPBEParameterSpec_test.go
+++ b/src/gfunction/javaxCrypto/javaxCryptoSpecPBEParameterSpec_test.go
@@ -97,7 +97,7 @@ func TestPBEParameterSpecWithSpec(t *testing.T) {
 	iv := []byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
 	ivSpecClass := "javax/crypto/spec/IvParameterSpec"
 	ivSpec := object.MakeEmptyObjectWithClassName(&ivSpecClass)
-	ivSpec.FieldTable["iv"] = object.Field{Ftype: types.ByteArray, Fvalue: makeByteArrayObject(iv)}
+	ivSpec.FieldTable["iv"] = object.Field{Ftype: types.JavaByteArray, Fvalue: makeByteArrayObject(iv)}
 
 	// 1. Test constructor with AlgorithmParameterSpec
 	specObj := object.MakeEmptyObjectWithClassName(&className)

--- a/src/gfunction/javaxCrypto/javaxCryptoSpecSecretKeySpec.go
+++ b/src/gfunction/javaxCrypto/javaxCryptoSpecSecretKeySpec.go
@@ -148,13 +148,19 @@ func secretKeySpecGetEncoded(params []any) any {
 			"secretKeySpecGetEncoded: 'this' is not an object")
 	}
 
-	keyBytes, ok := obj.FieldTable["key"].Fvalue.([]byte)
-	if !ok {
+	var keyBytes []byte
+	switch v := obj.FieldTable["key"].Fvalue.(type) {
+	case []types.JavaByte:
+		keyBytes = object.GoByteArrayFromJavaByteArray(v)
+	case []byte:
+		keyBytes = v
+	}
+	if keyBytes == nil {
 		return ghelpers.GetGErrBlk(excNames.IllegalStateException,
 			"secretKeySpecGetEncoded: key field not found or invalid")
 	}
 
-	return object.MakePrimitiveObject(types.ByteArray, types.ByteArray,
+	return object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray,
 		object.JavaByteArrayFromGoByteArray(slices.Clone(keyBytes)))
 }
 
@@ -187,8 +193,14 @@ func secretKeySpecHashCode(params []any) any {
 	}
 
 	algorithmObj, ok1 := obj.FieldTable["algorithm"].Fvalue.(*object.Object)
-	keyBytes, ok2 := obj.FieldTable["key"].Fvalue.([]byte)
-	if !ok1 || !ok2 {
+	var keyBytes []byte
+	switch v := obj.FieldTable["key"].Fvalue.(type) {
+	case []types.JavaByte:
+		keyBytes = object.GoByteArrayFromJavaByteArray(v)
+	case []byte:
+		keyBytes = v
+	}
+	if !ok1 || keyBytes == nil {
 		return ghelpers.GetGErrBlk(excNames.IllegalStateException,
 			"secretKeySpecHashCode: fields not found or invalid")
 	}
@@ -240,7 +252,12 @@ func secretKeySpecInit(params []any) any {
 			return ghelpers.GetGErrBlk(excNames.IllegalArgumentException,
 				"secretKeySpecInit: key is not a valid byte array")
 		}
-		keyBytes = object.GoByteArrayFromJavaByteArray(keyObj.FieldTable["value"].Fvalue.([]types.JavaByte))
+		fval := keyObj.FieldTable["value"].Fvalue
+		if jBytes, ok := fval.([]types.JavaByte); ok {
+			keyBytes = object.GoByteArrayFromJavaByteArray(jBytes)
+		} else {
+			keyBytes = fval.([]byte)
+		}
 
 		algoObj, ok = params[2].(*object.Object)
 		if !ok || algoObj == nil {
@@ -256,7 +273,13 @@ func secretKeySpecInit(params []any) any {
 			return ghelpers.GetGErrBlk(excNames.IllegalArgumentException,
 				"secretKeySpecInit: key is not a valid byte array")
 		}
-		fullKeyBytes := object.GoByteArrayFromJavaByteArray(keyObj.FieldTable["value"].Fvalue.([]types.JavaByte))
+		var fullKeyBytes []byte
+		fval := keyObj.FieldTable["value"].Fvalue
+		if jBytes, ok := fval.([]types.JavaByte); ok {
+			fullKeyBytes = object.GoByteArrayFromJavaByteArray(jBytes)
+		} else {
+			fullKeyBytes = fval.([]byte)
+		}
 
 		offset, ok := params[2].(int64)
 		if !ok {
@@ -306,11 +329,11 @@ func secretKeySpecInit(params []any) any {
 
 	// Store the key and algorithm in the object's fields
 	obj.FieldTable["key"] = object.Field{
-		Ftype:  types.ByteArray,
+		Ftype:  types.GoByteArray,
 		Fvalue: slices.Clone(keyBytes),
 	}
 	obj.FieldTable["value"] = object.Field{
-		Ftype:  types.ByteArray,
+		Ftype:  types.GoByteArray,
 		Fvalue: slices.Clone(keyBytes),
 	}
 	obj.FieldTable["algorithm"] = object.Field{

--- a/src/gfunction/javaxCrypto/javaxCryptoSpecSecretKeySpec_test.go
+++ b/src/gfunction/javaxCrypto/javaxCryptoSpecSecretKeySpec_test.go
@@ -42,7 +42,13 @@ func TestSecretKeySpecInit(t *testing.T) {
 		t.Errorf("Expected algorithm %s, got %s", algo, specAlgo)
 	}
 
-	specKey := specObj1.FieldTable["key"].Fvalue.([]byte)
+	var specKey []byte
+	switch v := specObj1.FieldTable["key"].Fvalue.(type) {
+	case []types.JavaByte:
+		specKey = object.GoByteArrayFromJavaByteArray(v)
+	case []byte:
+		specKey = v
+	}
 	if !bytes.Equal(specKey, key) {
 		t.Errorf("Expected key %v, got %v", key, specKey)
 	}
@@ -54,11 +60,17 @@ func TestSecretKeySpecInit(t *testing.T) {
 	params2 := []any{specObj2, keyObj, offset, length, algoObj}
 	result2 := secretKeySpecInit(params2)
 	if result2 != nil {
-		t.Errorf("Expected nil result, got %v", result2)
+		t.Fatalf("SecretKeySpecInit failed: %v", result2)
 	}
 
 	expectedSubKey := key[offset : offset+length]
-	observedSubKey := specObj2.FieldTable["key"].Fvalue.([]byte)
+	var observedSubKey []byte
+	switch v := specObj2.FieldTable["key"].Fvalue.(type) {
+	case []types.JavaByte:
+		observedSubKey = object.GoByteArrayFromJavaByteArray(v)
+	case []byte:
+		observedSubKey = v
+	}
 	if !bytes.Equal(observedSubKey, expectedSubKey) {
 		t.Errorf("Expected subset key %v, got %v", expectedSubKey, observedSubKey)
 	}
@@ -99,7 +111,7 @@ func TestSecretKeySpecMethods(t *testing.T) {
 	algo := "HmacSHA256"
 
 	specObj := object.MakeEmptyObjectWithClassName(&className)
-	specObj.FieldTable["key"] = object.Field{Ftype: types.ByteArray, Fvalue: key}
+ specObj.FieldTable["key"] = object.Field{Ftype: types.JavaByteArray, Fvalue: key}
 	specObj.FieldTable["algorithm"] = object.Field{Ftype: types.StringClassName, Fvalue: object.StringObjectFromGoString(algo)}
 
 	// Test getAlgorithm()
@@ -130,7 +142,14 @@ func TestSecretKeySpecMethods(t *testing.T) {
 
 	// Verify getEncoded returns a copy
 	goBytes[0] ^= 0xFF
-	if bytes.Equal(specObj.FieldTable["key"].Fvalue.([]byte), goBytes) {
+	var keyStored []byte
+	switch v := specObj.FieldTable["key"].Fvalue.(type) {
+	case []types.JavaByte:
+		keyStored = object.GoByteArrayFromJavaByteArray(v)
+	case []byte:
+		keyStored = v
+	}
+	if bytes.Equal(keyStored, goBytes) {
 		t.Error("getEncoded() should return a copy, but modifying the result affected the original")
 	}
 }
@@ -145,19 +164,19 @@ func TestSecretKeySpecEqualsAndHashCode(t *testing.T) {
 	algo2 := "DES"
 
 	spec1 := object.MakeEmptyObjectWithClassName(&className)
-	spec1.FieldTable["key"] = object.Field{Ftype: types.ByteArray, Fvalue: key1}
+	spec1.FieldTable["key"] = object.Field{Ftype: types.JavaByteArray, Fvalue: key1}
 	spec1.FieldTable["algorithm"] = object.Field{Ftype: types.StringClassName, Fvalue: object.StringObjectFromGoString(algo1)}
 
 	spec1Clone := object.MakeEmptyObjectWithClassName(&className)
-	spec1Clone.FieldTable["key"] = object.Field{Ftype: types.ByteArray, Fvalue: key1}
+	spec1Clone.FieldTable["key"] = object.Field{Ftype: types.JavaByteArray, Fvalue: key1}
 	spec1Clone.FieldTable["algorithm"] = object.Field{Ftype: types.StringClassName, Fvalue: object.StringObjectFromGoString(algo1)}
 
 	spec2 := object.MakeEmptyObjectWithClassName(&className)
-	spec2.FieldTable["key"] = object.Field{Ftype: types.ByteArray, Fvalue: key2}
+	spec2.FieldTable["key"] = object.Field{Ftype: types.JavaByteArray, Fvalue: key2}
 	spec2.FieldTable["algorithm"] = object.Field{Ftype: types.StringClassName, Fvalue: object.StringObjectFromGoString(algo1)}
 
 	spec3 := object.MakeEmptyObjectWithClassName(&className)
-	spec3.FieldTable["key"] = object.Field{Ftype: types.ByteArray, Fvalue: key1}
+	spec3.FieldTable["key"] = object.Field{Ftype: types.JavaByteArray, Fvalue: key1}
 	spec3.FieldTable["algorithm"] = object.Field{Ftype: types.StringClassName, Fvalue: object.StringObjectFromGoString(algo2)}
 
 	// Test equals


### PR DESCRIPTION
See YouTrack for details.
Impacted files:
* gfunction/javaSecurity/javaSecurityAlgorithmParameters.go
* gfunction/javaSecurity/javaSecurityAlgorithmParameters_test.go
* gfunction/javaSecurity/javaSecurityKey.go
* gfunction/javaSecurity/javaSecurityMessageDigest.go
* gfunction/javaSecurity/javaSecuritySignature.go
* gfunction/javaSecurity/javaSecuritySignature_test.go
* gfunction/javaxCrypto/javaxCryptoCipher.go
* gfunction/javaxCrypto/javaxCryptoCipher_test.go
* gfunction/javaxCrypto/javaxCryptoKeyAgreement.go
* gfunction/javaxCrypto/javaxCryptoPBE_test.go
* gfunction/javaxCrypto/javaxCryptoSecretKeyFactory.go
* gfunction/javaxCrypto/javaxCryptoSecretKeyFactory_test.go
* gfunction/javaxCrypto/javaxCryptoSpecGCMParameterSpec.go
* gfunction/javaxCrypto/javaxCryptoSpecGCMParameterSpec_test.go
* gfunction/javaxCrypto/javaxCryptoSpecIvParameterSpec.go
* gfunction/javaxCrypto/javaxCryptoSpecIvParameterSpec_test.go
* gfunction/javaxCrypto/javaxCryptoSpecPBEParameterSpec.go
* gfunction/javaxCrypto/javaxCryptoSpecPBEParameterSpec_test.go
* gfunction/javaxCrypto/javaxCryptoSpecSecretKeySpec.go
* gfunction/javaxCrypto/javaxCryptoSpecSecretKeySpec_test.go
