### PR TITLE
JACOBIN-934 Migrate away from types.ByteArray

### DIFF
--- a/notes/Initialisation.txt
+++ b/notes/Initialisation.txt
@@ -58,10 +58,10 @@ Initialisation Steps
 [5] classloader/methArea.go InitMethodArea, MethAreaPreload
 
     * MethArea :: sync.Map containing all the loaded classes. Key is the class name in java/lang/Object format. Initially, nil.
-    * Load all the types for primitive arrays (E.g. types.ByteArray). Each entry having a Klass structure like this:
+    * Load all the types for primitive arrays (E.g. types.JavaByteArray). Each entry having a Klass structure like this:
         - Status: 'N', // N = instantiated
 		- Loader: "bootstrap"
-		- Data.Name: type value (E.g. types.ByteArray)
+		- Data.Name: type value (E.g. types.JavaByteArray)
 		- Data.NameIndex: string pool index of the type value
 		- Data.SuperclassIndex: string pool index of "java/lang/Object"
 

--- a/src/classloader/classloader_test.go
+++ b/src/classloader/classloader_test.go
@@ -136,7 +136,7 @@ func TestNormalizingClassReference(t *testing.T) {
 		t.Error("Unexpected normalized class reference: " + s)
 	}
 
-	s = normalizeClassReference(types.ByteArray)
+	s = normalizeClassReference(types.JavaByteArray)
 	if s != "" {
 		t.Error("Unexpected normalized class reference: " + s)
 	}
@@ -600,7 +600,7 @@ func TestCfe_ErrorFormatting(t *testing.T) {
 func TestNormalizeClassReference_Array(t *testing.T) {
 	// Test array reference normalization
 	globals.InitGlobals("test")
-	result := normalizeClassReference(types.ByteArray)
+	result := normalizeClassReference(types.JavaByteArray)
 	if result != "" {
 		t.Fatalf("expected empty string for byte array, got: %s", result)
 	}

--- a/src/classloader/methArea.go
+++ b/src/classloader/methArea.go
@@ -50,7 +50,7 @@ func MethAreaPreload() {
 
 	classesToPreload := []string{
 		types.BoolArray,
-		types.ByteArray,
+		types.JavaByteArray,
 		types.DoubleArray,
 		types.FloatArray,
 		types.IntArray,

--- a/src/debug/debug.go
+++ b/src/debug/debug.go
@@ -94,7 +94,7 @@ func TVO(obj *object.Object) string {
 				}
 
 			case []types.JavaByte:
-				if field.Ftype == types.ByteArray || field.Ftype == types.StringClassName || field.Ftype == types.StringClassRef {
+				if field.Ftype == types.JavaByteArray || field.Ftype == types.StringClassName || field.Ftype == types.StringClassRef {
 					str := object.GoStringFromJavaByteArray(value.([]types.JavaByte))
 					sb.WriteString(fmt.Sprintf("  %s [%s]: %s\n", fieldName, field.Ftype, str))
 				} else {

--- a/src/debug/debug_test.go
+++ b/src/debug/debug_test.go
@@ -18,11 +18,11 @@ func TestTVO(t *testing.T) {
 	obj1 := object.MakeEmptyObjectWithClassName(&clName1)
 	obj2 := object.MakeEmptyObjectWithClassName(&clName2)
 	obj1.FieldTable["field6b"] = object.Field{Ftype: types.Bool, Fvalue: types.JavaBoolFalse}
-	obj1.FieldTable["field7"] = object.Field{Ftype: types.ByteArray, Fvalue: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}}
-	obj1.FieldTable["field8"] = object.Field{Ftype: types.ByteArray, Fvalue: []types.JavaByte{61, 62, 63, 64, 65, 66, 67, 68, 69, 70}}
+	obj1.FieldTable["field7"] = object.Field{Ftype: types.JavaByteArray, Fvalue: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}}
+	obj1.FieldTable["field8"] = object.Field{Ftype: types.JavaByteArray, Fvalue: []types.JavaByte{61, 62, 63, 64, 65, 66, 67, 68, 69, 70}}
 	obj1.FieldTable["field9"] = object.Field{Ftype: types.Int, Fvalue: uint32(math.Pow(2, 27) - 1)}
 	obj1.FieldTable["field10"] = object.Field{Ftype: types.Int, Fvalue: uint16(32767)}
-	obj1.FieldTable["field1"] = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString("value1")}
+	obj1.FieldTable["field1"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString("value1")}
 	obj1.FieldTable["field2"] = object.Field{Ftype: types.Int, Fvalue: 42}
 	obj1.FieldTable["field3"] = object.Field{Ftype: types.Double, Fvalue: 3.14}
 	obj1.FieldTable["field4"] = object.Field{Ftype: types.StringClassName, Fvalue: object.JavaByteArrayFromGoString("value4")}

--- a/src/gfunction/javaIo/javaIoBufferedWriter_test.go
+++ b/src/gfunction/javaIo/javaIoBufferedWriter_test.go
@@ -25,7 +25,7 @@ func makeWriterObjForFile(t *testing.T, filePath string) *object.Object {
         t.Fatalf("failed to open test file: %v", err)
     }
     return &object.Object{FieldTable: map[string]object.Field{
-        ghelpers.FilePath:   {Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(filePath)},
+        ghelpers.FilePath:   {Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(filePath)},
         ghelpers.FileHandle: {Ftype: ghelpers.FileHandle, Fvalue: fh},
     }}
 }
@@ -190,7 +190,7 @@ func TestBufferedWriter_WriteCharBuffer_ValueTypeError(t *testing.T) {
 
     // "value" is wrong type (not []int64)
     bufObj := &object.Object{FieldTable: map[string]object.Field{
-        "value": {Ftype: types.ByteArray, Fvalue: []byte{1, 2, 3}},
+        "value": {Ftype: types.JavaByteArray, Fvalue: []byte{1, 2, 3}},
     }}
 
     res := bwWriteCharBuffer([]interface{}{target, bufObj, int64(0), int64(1)})

--- a/src/gfunction/javaIo/javaIoByteArrayOutputStream.go
+++ b/src/gfunction/javaIo/javaIoByteArrayOutputStream.go
@@ -226,7 +226,7 @@ func ByteArrayOutputStreamToByteArray(params []interface{}) interface{} {
 	newBuf := make([]types.JavaByte, count)
 	copy(newBuf, buf[:count])
 
-	return object.MakePrimitiveObject("[B", types.ByteArray, newBuf)
+	return object.MakePrimitiveObject("[B", types.JavaByteArray, newBuf)
 }
 
 func ByteArrayOutputStreamToString(params []interface{}) interface{} {

--- a/src/gfunction/javaIo/javaIoByteArrayOutputStream_test.go
+++ b/src/gfunction/javaIo/javaIoByteArrayOutputStream_test.go
@@ -81,7 +81,7 @@ func TestByteArrayOutputStreamWriteBytes(t *testing.T) {
 	ByteArrayOutputStreamInit([]any{obj, int64(2)}) // small initial size
 
 	data := []types.JavaByte{1, 2, 3, 4, 5}
-	bObj := object.MakePrimitiveObject("[B", types.ByteArray, data)
+	bObj := object.MakePrimitiveObject("[B", types.JavaByteArray, data)
 
 	// write(b, 1, 3) -> should write [2, 3, 4]
 	ByteArrayOutputStreamWriteBytes([]any{obj, bObj, int64(1), int64(3)})
@@ -116,7 +116,7 @@ func TestByteArrayOutputStreamWriteBytesAll(t *testing.T) {
 	ByteArrayOutputStreamInit([]any{obj})
 
 	data := []types.JavaByte{10, 20, 30}
-	bObj := object.MakePrimitiveObject("[B", types.ByteArray, data)
+	bObj := object.MakePrimitiveObject("[B", types.JavaByteArray, data)
 
 	ByteArrayOutputStreamWriteBytesAll([]any{obj, bObj})
 
@@ -163,7 +163,7 @@ func TestByteArrayOutputStreamToByteArray(t *testing.T) {
 	obj := object.MakeEmptyObject()
 	ByteArrayOutputStreamInit([]any{obj})
 	data := []types.JavaByte{5, 10, 15}
-	bObj := object.MakePrimitiveObject("[B", types.ByteArray, data)
+	bObj := object.MakePrimitiveObject("[B", types.JavaByteArray, data)
 	ByteArrayOutputStreamWriteBytesAll([]any{obj, bObj})
 
 	res := ByteArrayOutputStreamToByteArray([]any{obj})

--- a/src/gfunction/javaIo/javaIoFile.go
+++ b/src/gfunction/javaIo/javaIoFile.go
@@ -337,19 +337,19 @@ func fileInit(params []interface{}) interface{} {
 
 	// Fill in File attributes that might get accessed by OpenJDK library member functions.
 
-	fld = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(absPathStr)}
+	fld = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(absPathStr)}
 	objFile.FieldTable[ghelpers.FilePath] = fld
 
 	fld = object.Field{Ftype: types.Int, Fvalue: os.PathSeparator}
 	objFile.FieldTable["separatorChar"] = fld
 
-	fld = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoByteArray([]byte{os.PathSeparator})}
+	fld = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoByteArray([]byte{os.PathSeparator})}
 	objFile.FieldTable["separator"] = fld
 
 	fld = object.Field{Ftype: types.Int, Fvalue: os.PathListSeparator}
 	objFile.FieldTable["pathSeparatorChar"] = fld
 
-	fld = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoByteArray([]byte{os.PathListSeparator})}
+	fld = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoByteArray([]byte{os.PathListSeparator})}
 	objFile.FieldTable["pathSeparator"] = fld
 
 	// Set status to "checked" (=1).
@@ -454,11 +454,11 @@ func newFileObjectFromPath(pathStr string) *object.Object {
 		obj.FieldTable = make(map[string]object.Field)
 	}
 	obj.FieldTable[ghelpers.FileStatus] = object.Field{Ftype: types.Int, Fvalue: int64(1)}
-	obj.FieldTable[ghelpers.FilePath] = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(pathStr)}
+	obj.FieldTable[ghelpers.FilePath] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(pathStr)}
 	obj.FieldTable["separatorChar"] = object.Field{Ftype: types.Int, Fvalue: os.PathSeparator}
-	obj.FieldTable["separator"] = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoByteArray([]byte{os.PathSeparator})}
+	obj.FieldTable["separator"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoByteArray([]byte{os.PathSeparator})}
 	obj.FieldTable["pathSeparatorChar"] = object.Field{Ftype: types.Int, Fvalue: os.PathListSeparator}
-	obj.FieldTable["pathSeparator"] = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoByteArray([]byte{os.PathListSeparator})}
+	obj.FieldTable["pathSeparator"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoByteArray([]byte{os.PathListSeparator})}
 	return obj
 }
 
@@ -790,7 +790,7 @@ func fileRenameTo(params []interface{}) interface{} {
 		return types.JavaBoolFalse
 	}
 	// Update this object's path
-	params[0].(*object.Object).FieldTable[ghelpers.FilePath] = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(p2)}
+	params[0].(*object.Object).FieldTable[ghelpers.FilePath] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(p2)}
 	return types.JavaBoolTrue
 }
 

--- a/src/gfunction/javaIo/javaIoFileInputStream.go
+++ b/src/gfunction/javaIo/javaIoFileInputStream.go
@@ -173,7 +173,7 @@ func InitFileInputStreamString(params []interface{}) interface{} {
 	}
 
 	// Copy the file path field into the FileInputStream object.
-	fld := object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(pathStr)}
+	fld := object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(pathStr)}
 	params[0].(*object.Object).FieldTable[ghelpers.FilePath] = fld
 
 	// Copy the file handle into the FileInputStream object.
@@ -270,7 +270,7 @@ func fisReadByteArray(params []interface{}) interface{} {
 
 	// All is well - update the supplied buffer.
 	javaBytes = object.JavaByteArrayFromGoByteArray(buffer[:nbytes])
-	fld := object.Field{Ftype: types.ByteArray, Fvalue: javaBytes}
+	fld := object.Field{Ftype: types.JavaByteArray, Fvalue: javaBytes}
 	params[1].(*object.Object).FieldTable["value"] = fld
 
 	// Return the number of bytes.
@@ -325,7 +325,7 @@ func fisReadByteArrayOffset(params []interface{}) interface{} {
 
 	// Update the parameter buffer.
 	javaBytes = object.JavaByteArrayFromGoByteArray(buf1)
-	fld := object.Field{Ftype: types.ByteArray, Fvalue: javaBytes}
+	fld := object.Field{Ftype: types.JavaByteArray, Fvalue: javaBytes}
 	params[1].(*object.Object).FieldTable["value"] = fld
 
 	// Return the number of bytes.

--- a/src/gfunction/javaIo/javaIoFileInputStream_test.go
+++ b/src/gfunction/javaIo/javaIoFileInputStream_test.go
@@ -27,7 +27,7 @@ func makeTempFile(t *testing.T, content []byte) (string, func()) {
 }
 
 func newFileObjectWithPath(t *testing.T, path string) *object.Object {
-	fld := object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(path)}
+	fld := object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(path)}
 	obj := &object.Object{
 		FieldTable: map[string]object.Field{
 			ghelpers.FilePath: fld,
@@ -46,7 +46,7 @@ func newJavaByteArrayObject(size int) *object.Object {
 	ba := make([]types.JavaByte, size)
 	return &object.Object{
 		FieldTable: map[string]object.Field{
-			"value": {Ftype: types.ByteArray, Fvalue: ba},
+			"value": {Ftype: types.JavaByteArray, Fvalue: ba},
 		},
 	}
 }

--- a/src/gfunction/javaIo/javaIoFileOutputStream.go
+++ b/src/gfunction/javaIo/javaIoFileOutputStream.go
@@ -171,7 +171,7 @@ func initFileOutputStreamString(params []interface{}) interface{} {
 	}
 
 	// Copy the file path field into the FileOutputStream object.
-	fld := object.Field{Ftype: types.ByteArray, Fvalue: []byte(pathStr)}
+	fld := object.Field{Ftype: types.JavaByteArray, Fvalue: []byte(pathStr)}
 	params[0].(*object.Object).FieldTable[ghelpers.FilePath] = fld
 
 	// Copy the file handle into the FileOutputStream object.
@@ -209,7 +209,7 @@ func initFileOutputStreamStringBoolean(params []interface{}) interface{} {
 	}
 
 	// Copy the file path field into the FileOutputStream object.
-	fld := object.Field{Ftype: types.ByteArray, Fvalue: []byte(pathStr)}
+	fld := object.Field{Ftype: types.JavaByteArray, Fvalue: []byte(pathStr)}
 	params[0].(*object.Object).FieldTable[ghelpers.FilePath] = fld
 
 	// Copy the file handle into the FileOutputStream object.

--- a/src/gfunction/javaIo/javaIoFileOutputStream_test.go
+++ b/src/gfunction/javaIo/javaIoFileOutputStream_test.go
@@ -20,7 +20,7 @@ func TestInitFileOutputStreamFile(t *testing.T) {
 	filePath := filepath.Join(tmpDir, "testfile.txt")
 	fileObj := &object.Object{
 		FieldTable: map[string]object.Field{
-			"FilePath": {Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(filePath)},
+			"FilePath": {Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(filePath)},
 		},
 	}
 	emptyObj := object.MakeEmptyObject()
@@ -45,7 +45,7 @@ func TestInitFileOutputStreamFileBoolean(t *testing.T) {
 	filePath := filepath.Join(tmpDir, "testfile.txt")
 	fileObj := &object.Object{
 		FieldTable: map[string]object.Field{
-			"FilePath": {Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(filePath)},
+			"FilePath": {Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(filePath)},
 		},
 	}
 	emptyObj := object.MakeEmptyObject()
@@ -148,7 +148,7 @@ func TestFosWriteByteArray(t *testing.T) {
 	byteArray := []types.JavaByte{65, 66, 67}
 	byteArrayObj := &object.Object{
 		FieldTable: map[string]object.Field{
-			"value": {Ftype: types.ByteArray, Fvalue: byteArray},
+			"value": {Ftype: types.JavaByteArray, Fvalue: byteArray},
 		},
 	}
 	params := []interface{}{fileObj, byteArrayObj}
@@ -180,7 +180,7 @@ func TestFosWriteByteArrayOffset(t *testing.T) {
 	byteArray := []types.JavaByte{65, 66, 67, 68, 69}
 	byteArrayObj := &object.Object{
 		FieldTable: map[string]object.Field{
-			"value": {Ftype: types.ByteArray, Fvalue: byteArray},
+			"value": {Ftype: types.JavaByteArray, Fvalue: byteArray},
 		},
 	}
 	params := []interface{}{fileObj, byteArrayObj, int64(1), int64(3)}

--- a/src/gfunction/javaIo/javaIoFileReader.go
+++ b/src/gfunction/javaIo/javaIoFileReader.go
@@ -166,7 +166,7 @@ func initFileReaderString(params []interface{}) interface{} {
 	}
 
 	// Copy java/io/File path
-	fld := object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(pathStr)}
+	fld := object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(pathStr)}
 	params[0].(*object.Object).FieldTable[ghelpers.FilePath] = fld
 
 	// Field ghelpers.FileHandle = Golang *os.File

--- a/src/gfunction/javaIo/javaIoFileReader_test.go
+++ b/src/gfunction/javaIo/javaIoFileReader_test.go
@@ -14,7 +14,7 @@ import (
 // helper to create a java/io/File-like object carrying ghelpers.FilePath bytes
 func makeJavaFileObj(path string) *object.Object {
 	return &object.Object{FieldTable: map[string]object.Field{
-		ghelpers.FilePath: {Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(path)},
+		ghelpers.FilePath: {Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(path)},
 	}}
 }
 
@@ -88,7 +88,7 @@ func TestFileReader_Init_WithString_Success_And_Read(t *testing.T) {
 	}
 
 	// Verify ghelpers.FilePath set on target
-	if target.FieldTable[ghelpers.FilePath].Ftype != types.ByteArray {
+	if target.FieldTable[ghelpers.FilePath].Ftype != types.JavaByteArray {
 		t.Fatalf("ghelpers.FilePath field type unexpected: %v", target.FieldTable[ghelpers.FilePath].Ftype)
 	}
 

--- a/src/gfunction/javaIo/javaIoFilterInputStream_test.go
+++ b/src/gfunction/javaIo/javaIoFilterInputStream_test.go
@@ -26,7 +26,7 @@ func makeTempFileFIS(t *testing.T, content []byte) (string, func()) {
 
 func newJavaFileObjPath(path string) *object.Object {
 	return &object.Object{FieldTable: map[string]object.Field{
-		ghelpers.FilePath: {Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(path)},
+		ghelpers.FilePath: {Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(path)},
 	}}
 }
 
@@ -37,7 +37,7 @@ func newFilterInputStreamObj() *object.Object {
 func newJavaByteArrayObj(size int) *object.Object {
 	jb := make([]types.JavaByte, size)
 	return &object.Object{FieldTable: map[string]object.Field{
-		"value": {Ftype: types.ByteArray, Fvalue: jb},
+		"value": {Ftype: types.JavaByteArray, Fvalue: jb},
 	}}
 }
 

--- a/src/gfunction/javaIo/javaIoFilterOutputStream_test.go
+++ b/src/gfunction/javaIo/javaIoFilterOutputStream_test.go
@@ -61,7 +61,7 @@ func TestFilterOutputStream_Init_Write_Flush_Close(t *testing.T) {
 	}
 	// write byte array [0x41,0x42]
 	buf := []types.JavaByte{types.JavaByte('A'), types.JavaByte('B')}
-	arr := &object.Object{FieldTable: map[string]object.Field{"value": {Ftype: types.ByteArray, Fvalue: buf}}}
+	arr := &object.Object{FieldTable: map[string]object.Field{"value": {Ftype: types.JavaByteArray, Fvalue: buf}}}
 	if res := filteroutputstreamWriteBytes([]interface{}{target, arr}); res != nil {
 		t.Fatalf("write(byte[]) error: %v", res)
 	}

--- a/src/gfunction/javaIo/javaIoInputStreamReader_test.go
+++ b/src/gfunction/javaIo/javaIoInputStreamReader_test.go
@@ -19,7 +19,7 @@ func makeInputStreamObjForFile(t *testing.T, filePath string) *object.Object {
 		t.Fatalf("failed to open file for reading: %v", err)
 	}
 	return &object.Object{FieldTable: map[string]object.Field{
-		ghelpers.FilePath:   {Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(filePath)},
+		ghelpers.FilePath:   {Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(filePath)},
 		ghelpers.FileHandle: {Ftype: ghelpers.FileHandle, Fvalue: fh},
 	}}
 }

--- a/src/gfunction/javaIo/javaIoOutputStreamWriter_test.go
+++ b/src/gfunction/javaIo/javaIoOutputStreamWriter_test.go
@@ -20,7 +20,7 @@ func makeOutputStreamObjForFile(t *testing.T, filePath string) *object.Object {
 		t.Fatalf("failed to open test file: %v", err)
 	}
 	return &object.Object{FieldTable: map[string]object.Field{
-		ghelpers.FilePath:   {Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(filePath)},
+		ghelpers.FilePath:   {Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(filePath)},
 		ghelpers.FileHandle: {Ftype: ghelpers.FileHandle, Fvalue: fh},
 	}}
 }

--- a/src/gfunction/javaIo/javaIoRandomAccessFile.go
+++ b/src/gfunction/javaIo/javaIoRandomAccessFile.go
@@ -359,7 +359,7 @@ func rafOpen0(params []interface{}) interface{} {
 	}
 
 	// Copy the file path field into the RandomAccessFile object.
-	fld := object.Field{Ftype: types.ByteArray, Fvalue: []byte(pathStr)}
+	fld := object.Field{Ftype: types.JavaByteArray, Fvalue: []byte(pathStr)}
 	params[0].(*object.Object).FieldTable[ghelpers.FilePath] = fld
 
 	// Copy the file handle into the RandomAccessFile object.
@@ -397,7 +397,7 @@ func rafInitString(params []interface{}) interface{} {
 	}
 
 	// Copy the file path field into the RandomAccessFile object.
-	fld := object.Field{Ftype: types.ByteArray, Fvalue: []byte(pathStr)}
+	fld := object.Field{Ftype: types.JavaByteArray, Fvalue: []byte(pathStr)}
 	params[0].(*object.Object).FieldTable[ghelpers.FilePath] = fld
 
 	// Copy the file handle into the RandomAccessFile object.
@@ -442,7 +442,7 @@ func rafInitFile(params []interface{}) interface{} {
 	}
 
 	// Copy the file path field into the RandomAccessFile object.
-	fld = object.Field{Ftype: types.ByteArray, Fvalue: []byte(pathStr)}
+	fld = object.Field{Ftype: types.JavaByteArray, Fvalue: []byte(pathStr)}
 	params[0].(*object.Object).FieldTable[ghelpers.FilePath] = fld
 
 	// Copy the file handle into the RandomAccessFile object.
@@ -513,7 +513,7 @@ func rafReadFully(params []interface{}) interface{} {
 
 	// Update the byte array object with the read bytes.
 	javaBytes = object.JavaByteArrayFromGoByteArray(buffer)
-	arrObj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: javaBytes}
+	arrObj.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: javaBytes}
 
 	return nil
 }

--- a/src/gfunction/javaIo/javaIoRandomAccessFile_test.go
+++ b/src/gfunction/javaIo/javaIoRandomAccessFile_test.go
@@ -123,7 +123,7 @@ func TestRafInitFile(t *testing.T) {
 
 	fileObj := &object.Object{FieldTable: make(map[string]object.Field)}
 	fileObj.FieldTable[ghelpers.FilePath] = object.Field{
-		Ftype:  types.ByteArray,
+		Ftype:  types.JavaByteArray,
 		Fvalue: object.JavaByteArrayFromGoString(tmpFile.Name()),
 	}
 
@@ -232,7 +232,7 @@ func TestFisReadByteArray(t *testing.T) {
 
 	byteArray := make([]types.JavaByte, len(content))
 
-	javaByteArrayObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, byteArray)
+	javaByteArrayObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, byteArray)
 	params := []interface{}{rafObj, javaByteArrayObj}
 	ret := fisReadByteArray(params)
 
@@ -265,7 +265,7 @@ func TestFisReadByteArrayOffset(t *testing.T) {
 	rafObj.FieldTable[ghelpers.FileHandle] = object.Field{Ftype: ghelpers.FileHandle, Fvalue: tmpFile}
 
 	byteArray := make([]types.JavaByte, len(content))
-	javaByteArrayObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, byteArray)
+	javaByteArrayObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, byteArray)
 
 	offset := int64(2)
 	length := int64(5)
@@ -303,7 +303,7 @@ func TestRafReadFully(t *testing.T) {
 
 	// Case 1: Read fully successfully
 	byteArray := make([]types.JavaByte, 5)
-	javaByteArrayObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, byteArray)
+	javaByteArrayObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, byteArray)
 	params := []interface{}{rafObj, javaByteArrayObj}
 	ret := rafReadFully(params)
 
@@ -319,7 +319,7 @@ func TestRafReadFully(t *testing.T) {
 
 	// Case 2: Read fully to the end
 	byteArray2 := make([]types.JavaByte, len(content)-5)
-	javaByteArrayObj2 := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, byteArray2)
+	javaByteArrayObj2 := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, byteArray2)
 	params2 := []interface{}{rafObj, javaByteArrayObj2}
 	ret2 := rafReadFully(params2)
 
@@ -335,7 +335,7 @@ func TestRafReadFully(t *testing.T) {
 
 	// Case 3: Read fully past EOF - should return error
 	byteArray3 := make([]types.JavaByte, 1)
-	javaByteArrayObj3 := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, byteArray3)
+	javaByteArrayObj3 := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, byteArray3)
 	params3 := []interface{}{rafObj, javaByteArrayObj3}
 	ret3 := rafReadFully(params3)
 
@@ -441,7 +441,7 @@ func TestRafReadFullyOffset(t *testing.T) {
 	rafObj.FieldTable[ghelpers.FileHandle] = object.Field{Ftype: ghelpers.FileHandle, Fvalue: tmpFile}
 
 	byteArray := make([]types.JavaByte, 10)
-	javaByteArrayObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, byteArray)
+	javaByteArrayObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, byteArray)
 
 	// Read 4 bytes starting from index 2 in the array
 	params := []interface{}{rafObj, javaByteArrayObj, int64(2), int64(4)}
@@ -474,12 +474,12 @@ func TestRafWriteMethods(t *testing.T) {
 
 	// Test write([B)V
 	byteArray := []types.JavaByte{types.JavaByte('B'), types.JavaByte('C')}
-	javaByteArrayObj := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, byteArray)
+	javaByteArrayObj := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, byteArray)
 	rafWriteByteArray([]interface{}{rafObj, javaByteArrayObj})
 
 	// Test write([BII)V
 	byteArray2 := []types.JavaByte{types.JavaByte('X'), types.JavaByte('D'), types.JavaByte('E'), types.JavaByte('Y')}
-	javaByteArrayObj2 := object.MakePrimitiveObject(types.ByteArray, types.ByteArray, byteArray2)
+	javaByteArrayObj2 := object.MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, byteArray2)
 	rafWriteByteArrayOffset([]interface{}{rafObj, javaByteArrayObj2, int64(1), int64(2)})
 
 	tmpFile.Sync()

--- a/src/gfunction/javaLang/javaLangCharSequence_test.go
+++ b/src/gfunction/javaLang/javaLangCharSequence_test.go
@@ -105,7 +105,7 @@ func TestCharSequence_StringBuilderImplementation(t *testing.T) {
 	// Mocking a StringBuilder object
 	sbClassName := "java/lang/StringBuilder"
 	sbObj := object.MakeEmptyObjectWithClassName(&sbClassName)
-	sbObj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: []types.JavaByte{'H', 'i'}}
+	sbObj.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: []types.JavaByte{'H', 'i'}}
 	sbObj.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: int64(2)}
 
 	// length()

--- a/src/gfunction/javaLang/javaLangRunnable.go
+++ b/src/gfunction/javaLang/javaLangRunnable.go
@@ -19,9 +19,9 @@ import (
 func NewRunnable(clName, methName, signature []types.JavaByte) *object.Object {
 	runnableClassName := "java/lang/Runnable"
 	o := object.MakeEmptyObjectWithClassName(&runnableClassName)
-	o.FieldTable["clName"] = object.Field{Ftype: types.ByteArray, Fvalue: clName}
-	o.FieldTable["methName"] = object.Field{Ftype: types.ByteArray, Fvalue: methName}
-	o.FieldTable["methType"] = object.Field{Ftype: types.ByteArray, Fvalue: signature}
+	o.FieldTable["clName"] = object.Field{Ftype: types.JavaByteArray, Fvalue: clName}
+	o.FieldTable["methName"] = object.Field{Ftype: types.JavaByteArray, Fvalue: methName}
+	o.FieldTable["methType"] = object.Field{Ftype: types.JavaByteArray, Fvalue: signature}
 	return o
 }
 
@@ -31,9 +31,9 @@ func setUpRunnable(runnable *object.Object, runClassName string) *ghelpers.GErrB
 		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	runnable.ThMutex.Lock()
-	runnable.FieldTable["clName"] = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(runClassName)}
-	runnable.FieldTable["methName"] = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString("run")}
-	runnable.FieldTable["methType"] = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString("()V")}
+	runnable.FieldTable["clName"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(runClassName)}
+	runnable.FieldTable["methName"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString("run")}
+	runnable.FieldTable["methType"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString("()V")}
 	runnable.ThMutex.Unlock()
 
 	return nil

--- a/src/gfunction/javaLang/javaLangRunnable_test.go
+++ b/src/gfunction/javaLang/javaLangRunnable_test.go
@@ -36,8 +36,8 @@ func TestNewRunnable_PopulatesClassAndFields(t *testing.T) {
 		if !ok {
 			t.Fatalf("missing field %q", fieldName)
 		}
-		if fld.Ftype != types.ByteArray {
-			t.Fatalf("field %q type = %q; want %q", fieldName, fld.Ftype, types.ByteArray)
+		if fld.Ftype != types.JavaByteArray {
+			t.Fatalf("field %q type = %q; want %q", fieldName, fld.Ftype, types.JavaByteArray)
 		}
 		gotSlice, ok := fld.Fvalue.([]types.JavaByte)
 		if !ok {
@@ -82,8 +82,8 @@ func TestNewRunnable_AllowsEmptyAndNil(t *testing.T) {
 	// Verify type is []types.JavaByte and length is zero
 	for _, name := range []string{"clName", "methName", "methType"} {
 		fld := obj2.FieldTable[name]
-		if fld.Ftype != types.ByteArray {
-			t.Fatalf("field %q type = %q; want %q", name, fld.Ftype, types.ByteArray)
+		if fld.Ftype != types.JavaByteArray {
+			t.Fatalf("field %q type = %q; want %q", name, fld.Ftype, types.JavaByteArray)
 		}
 		gotSlice, ok := fld.Fvalue.([]types.JavaByte)
 		if !ok {

--- a/src/gfunction/javaLang/javaLangRuntime.go
+++ b/src/gfunction/javaLang/javaLangRuntime.go
@@ -167,7 +167,7 @@ const stringClassnameRuntime = "java/lang/Runtime"
 const stringFieldCurrentRuntime = "currentRuntime"
 
 func runtimeClinit([]interface{}) interface{} {
-	obj := object.MakePrimitiveObject(stringClassnameRuntime, types.ByteArray, nil)
+	obj := object.MakePrimitiveObject(stringClassnameRuntime, types.JavaByteArray, nil)
 	_ = statics.AddStatic(stringClassnameRuntime+"."+stringFieldCurrentRuntime, statics.Static{
 		Type:  types.Ref + stringClassnameRuntime,
 		Value: obj,

--- a/src/gfunction/javaLang/javaLangString.go
+++ b/src/gfunction/javaLang/javaLangString.go
@@ -1286,7 +1286,7 @@ func getBytesFromString(params []interface{}) interface{} {
 			return ghelpers.GetGErrBlk(excNames.UnsupportedEncodingException, errMsg)
 		}
 	}
-	return object.MakePrimitiveObject("[B", types.ByteArray, bytes)
+	return object.MakePrimitiveObject("[B", types.JavaByteArray, bytes)
 }
 
 // java/lang/String.getBytes([BIIBI)V

--- a/src/gfunction/javaLang/javaLangStringBuffer.go
+++ b/src/gfunction/javaLang/javaLangStringBuffer.go
@@ -391,7 +391,7 @@ func stringBufferInit(params []any) any {
 	obj.FieldTable["count"] = fld
 
 	// Set the value = nil byte array.
-	fld = object.Field{Ftype: types.ByteArray, Fvalue: make([]types.JavaByte, 0)}
+	fld = object.Field{Ftype: types.JavaByteArray, Fvalue: make([]types.JavaByte, 0)}
 	obj.FieldTable["value"] = fld
 
 	// Set the capacity field value.
@@ -431,7 +431,7 @@ func stringBufferInitString(params []any) any {
 	// Set the byte count.
 	count := int64(len(byteArray))
 	capacity := count + 16
-	obj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
+	obj.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: byteArray}
 	obj.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
 	obj.FieldTable["capacity"] = object.Field{Ftype: types.Int, Fvalue: capacity}
 

--- a/src/gfunction/javaLang/javaLangStringBuilder.go
+++ b/src/gfunction/javaLang/javaLangStringBuilder.go
@@ -393,7 +393,7 @@ func stringBuilderInit(params []any) any {
 	obj.FieldTable["count"] = fld
 
 	// Set the value = nil byte array.
-	fld = object.Field{Ftype: types.ByteArray, Fvalue: make([]types.JavaByte, 0)}
+	fld = object.Field{Ftype: types.JavaByteArray, Fvalue: make([]types.JavaByte, 0)}
 	obj.FieldTable["value"] = fld
 
 	// Set the capacity field value.
@@ -436,7 +436,7 @@ func stringBuilderInitString(params []any) any {
 	// Set the byte count.
 	count := int64(len(byteArray))
 	capacity := count + 16
-	obj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
+	obj.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: byteArray}
 	obj.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
 	obj.FieldTable["capacity"] = object.Field{Ftype: types.Int, Fvalue: capacity}
 
@@ -524,7 +524,7 @@ func stringBuilderAppend(params []any) any {
 	// Set the byte count.
 	byteArray = append(byteArray, parmArray...)
 	count := int64(len(byteArray))
-	objBase.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
+	objBase.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: byteArray}
 	objBase.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
 	expandCapacity(objBase, count)
 
@@ -557,7 +557,7 @@ func stringBuilderAppendBoolean(params []any) any {
 	// Set the byte count.
 	byteArray = append(byteArray, parmArray...)
 	count := int64(len(byteArray))
-	objBase.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
+	objBase.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: byteArray}
 	objBase.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
 	expandCapacity(objBase, count)
 
@@ -585,7 +585,7 @@ func stringBuilderAppendChar(params []any) any {
 	// Set the byte count.
 	byteArray = append(byteArray, parmArray...)
 	count := int64(len(byteArray))
-	objBase.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
+	objBase.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: byteArray}
 	objBase.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
 	expandCapacity(objBase, count)
 
@@ -648,7 +648,7 @@ func stringBuilderDelete(params []any) any {
 	count := int64(len(newArray))
 
 	// Finalize output object.
-	objBase.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: newArray}
+	objBase.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: newArray}
 	objBase.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
 	expandCapacity(objBase, count)
 
@@ -735,7 +735,7 @@ func stringBuilderInsert(params []any) any {
 	newArray = append(newArray, byteArray[ix:]...)
 	count := int64(len(newArray))
 
-	objBase.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: newArray}
+	objBase.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: newArray}
 	objBase.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
 	expandCapacity(objBase, count)
 
@@ -782,7 +782,7 @@ func stringBuilderInsertBoolean(params []any) any {
 	newArray = append(newArray, byteArray[ix:]...)
 	count := int64(len(newArray))
 
-	objBase.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: newArray}
+	objBase.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: newArray}
 	objBase.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
 	expandCapacity(objBase, count)
 
@@ -824,7 +824,7 @@ func stringBuilderInsertChar(params []any) any {
 	newArray = append(newArray, byteArray[ix:]...)
 	count := int64(len(newArray))
 
-	objBase.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: newArray}
+	objBase.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: newArray}
 	objBase.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
 	expandCapacity(objBase, count)
 
@@ -877,7 +877,7 @@ func stringBuilderReplace(params []any) any {
 	newArray = append(newArray, initBytes[end:]...)
 	newlen := int64(len(newArray))
 
-	objBase.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: newArray}
+	objBase.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: newArray}
 	objBase.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: newlen}
 	expandCapacity(objBase, newlen)
 
@@ -896,7 +896,7 @@ func stringBuilderReverse(params []any) any {
 		byteArray[ii], byteArray[jj] = byteArray[jj], byteArray[ii]
 	}
 
-	objBase.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
+	objBase.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: byteArray}
 	return objBase
 }
 
@@ -913,7 +913,7 @@ func stringBuilderSetCharAt(params []any) any {
 		return ghelpers.GetGErrBlk(excNames.IndexOutOfBoundsException, errMsg)
 	}
 	byteArray[ix] = types.JavaByte(ch)
-	obj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
+	obj.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: byteArray}
 
 	return nil
 }
@@ -941,7 +941,7 @@ func stringBuilderSetLength(params []any) any {
 	} else { // truncation, newlen < oldlen
 		copy(newArray, oldArray[:newlen])
 	}
-	obj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: newArray}
+	obj.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: newArray}
 	obj.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: newlen}
 	expandCapacity(obj, newlen)
 
@@ -1009,7 +1009,7 @@ func stringBuilderInitCharSequence(params []any) any {
 
 	count := int64(len(byteArray))
 	capacity := count + 16
-	obj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: byteArray}
+	obj.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: byteArray}
 	obj.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: count}
 	obj.FieldTable["capacity"] = object.Field{Ftype: types.Int, Fvalue: capacity}
 

--- a/src/gfunction/javaLang/javaLangStringBuilder_test.go
+++ b/src/gfunction/javaLang/javaLangStringBuilder_test.go
@@ -64,7 +64,7 @@ func TestStringBuilderInitString(t *testing.T) {
 func TestStringBuilderToString(t *testing.T) {
 	// Test case: convert to string
 	obj := object.NewStringObject()
-	obj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: []types.JavaByte{'H', 'e', 'l', 'l', 'o'}}
+	obj.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: []types.JavaByte{'H', 'e', 'l', 'l', 'o'}}
 	params := []any{obj}
 	result := stringBuilderToString(params)
 	if result == nil {
@@ -100,7 +100,7 @@ func TestStringBuilderLength(t *testing.T) {
 func TestStringBuilder_AppendNullByte_ToString_GetBytes(t *testing.T) {
 	// 1. Create StringBuilder
 	sbObj := object.MakeEmptyObject()
-	sbObj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: []types.JavaByte{}}
+	sbObj.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: []types.JavaByte{}}
 	sbObj.FieldTable["capacity"] = object.Field{Ftype: types.Int, Fvalue: int64(16)}
 	sbObj.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: int64(0)}
 
@@ -130,7 +130,7 @@ func TestStringBuilder_AppendNullByte_ToString_GetBytes(t *testing.T) {
 
 	// 6. Test with capacity > count
 	sbObj2 := object.MakeEmptyObject()
-	sbObj2.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: make([]types.JavaByte, 0, 16)}
+	sbObj2.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: make([]types.JavaByte, 0, 16)}
 	sbObj2.FieldTable["capacity"] = object.Field{Ftype: types.Int, Fvalue: int64(16)}
 	sbObj2.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: int64(0)}
 
@@ -168,7 +168,7 @@ func TestString_UserReportedIssue(t *testing.T) {
 
 	// StringBuilder sb = new StringBuilder();
 	sbObj := object.MakeEmptyObject()
-	sbObj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: []types.JavaByte{}}
+	sbObj.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: []types.JavaByte{}}
 	sbObj.FieldTable["capacity"] = object.Field{Ftype: types.Int, Fvalue: int64(16)}
 	sbObj.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: int64(0)}
 
@@ -217,7 +217,7 @@ func TestString_UserReportedIssue(t *testing.T) {
 func TestStringBuilder_AppendMultiByte(t *testing.T) {
 	globals.InitStringPool()
 	sbObj := object.MakeEmptyObject()
-	sbObj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: []types.JavaByte{}}
+	sbObj.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: []types.JavaByte{}}
 	sbObj.FieldTable["capacity"] = object.Field{Ftype: types.Int, Fvalue: int64(16)}
 	sbObj.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: int64(0)}
 
@@ -243,7 +243,7 @@ func TestStringBuilder_CharAt_Negative(t *testing.T) {
 	globals.InitStringPool()
 	sbObj := object.MakeEmptyObject()
 	// Create a StringBuilder with a byte that has the sign bit set (0x80 = 128)
-	sbObj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: []types.JavaByte{types.JavaByte(-128)}}
+	sbObj.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: []types.JavaByte{types.JavaByte(-128)}}
 	sbObj.FieldTable["capacity"] = object.Field{Ftype: types.Int, Fvalue: int64(16)}
 	sbObj.FieldTable["count"] = object.Field{Ftype: types.Int, Fvalue: int64(1)}
 

--- a/src/gfunction/javaLang/javaLangString_boundary_test.go
+++ b/src/gfunction/javaLang/javaLangString_boundary_test.go
@@ -427,7 +427,7 @@ func TestStringConstructor_Boundary(t *testing.T) {
 
 	// newStringFromBytes(byte[] bytes)
 	bytes := []types.JavaByte{types.JavaByte('a'), types.JavaByte('b'), types.JavaByte('c')}
-	bytesObj := object.MakePrimitiveObject("[B", types.ByteArray, bytes)
+	bytesObj := object.MakePrimitiveObject("[B", types.JavaByteArray, bytes)
 	res := newStringFromBytes([]interface{}{thisObj, bytesObj})
 	if res != nil {
 		t.Fatalf("newStringFromBytes returned error: %v", res)
@@ -438,7 +438,7 @@ func TestStringConstructor_Boundary(t *testing.T) {
 
 	// Boundary: newStringFromBytes with empty array
 	emptyBytes := []types.JavaByte{}
-	emptyBytesObj := object.MakePrimitiveObject("[B", types.ByteArray, emptyBytes)
+	emptyBytesObj := object.MakePrimitiveObject("[B", types.JavaByteArray, emptyBytes)
 	res = newStringFromBytes([]interface{}{thisObj, emptyBytesObj})
 	if object.GoStringFromStringObject(thisObj) != "" {
 		t.Errorf("newStringFromBytes(empty) expected '', got %s", object.GoStringFromStringObject(thisObj))

--- a/src/gfunction/javaLang/javaLangString_test.go
+++ b/src/gfunction/javaLang/javaLangString_test.go
@@ -1222,8 +1222,8 @@ func TestString_GetBytes_Basic(t *testing.T) {
 	}
 	// type should be byte array and contents should match
 	ft := arrObj.FieldTable["value"].Ftype
-	if ft != types.ByteArray {
-		t.Fatalf("expected Ftype %s, got %s", types.ByteArray, ft)
+	if ft != types.JavaByteArray {
+		t.Fatalf("expected Ftype %s, got %s", types.JavaByteArray, ft)
 	}
 	gotBytes := bytesFromByteArrayObject(arrObj)
 	if string(gotBytes) != in {

--- a/src/gfunction/javaLang/javaLangSystem.go
+++ b/src/gfunction/javaLang/javaLangSystem.go
@@ -314,7 +314,7 @@ func systemArrayCopy(params []interface{}) interface{} {
 	if (src != dest) || (srcPos+length <= destPos) || (destPos+length <= srcPos) {
 		// non-overlapping copy of identical items
 		switch srcType {
-		case types.ByteArray, types.BoolArray:
+		case types.JavaByteArray, types.BoolArray:
 			switch src.FieldTable["value"].Fvalue.(type) {
 			case []types.JavaByte: // byte and bool arrays
 				sArr := src.FieldTable["value"].Fvalue.([]types.JavaByte)
@@ -368,7 +368,7 @@ func systemArrayCopy(params []interface{}) interface{} {
 		tempArray := make([]interface{}, length)
 
 		switch srcType {
-		case types.ByteArray:
+		case types.JavaByteArray:
 			switch src.FieldTable["value"].Fvalue.(type) {
 			case []types.JavaByte:
 				sArr := src.FieldTable["value"].Fvalue.([]types.JavaByte)

--- a/src/gfunction/javaLang/javaLangThread.go
+++ b/src/gfunction/javaLang/javaLangThread.go
@@ -431,7 +431,7 @@ func ThreadInitWithName(params []interface{}) any {
 		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 	t.ThMutex.Lock()
-	t.FieldTable["name"] = object.Field{Ftype: types.ByteArray, Fvalue: name}
+	t.FieldTable["name"] = object.Field{Ftype: types.JavaByteArray, Fvalue: name}
 	t.ThMutex.Unlock()
 
 	return nil
@@ -502,7 +502,7 @@ func threadInitWithRunnableAndName(params []interface{}) any {
 	t.FieldTable["target"] = object.Field{
 		Ftype: types.Ref, Fvalue: runnable}
 	t.FieldTable["name"] = object.Field{
-		Ftype:  types.ByteArray,
+		Ftype:  types.JavaByteArray,
 		Fvalue: name}
 	t.ThMutex.Unlock()
 
@@ -543,7 +543,7 @@ func threadInitWithThreadGroupAndName(params []interface{}) any {
 
 	t.ThMutex.Lock()
 	t.FieldTable["threadgroup"] = object.Field{Ftype: types.Ref, Fvalue: threadGroup}
-	t.FieldTable["name"] = object.Field{Ftype: types.ByteArray, Fvalue: name}
+	t.FieldTable["name"] = object.Field{Ftype: types.JavaByteArray, Fvalue: name}
 	t.ThMutex.Unlock()
 
 	return nil
@@ -632,7 +632,7 @@ func threadInitWithThreadGroupRunnableAndName(params []interface{}) any {
 	t.FieldTable["threadgroup"] = object.Field{
 		Ftype: types.Ref, Fvalue: threadGroup}
 	t.FieldTable["name"] = object.Field{
-		Ftype: types.ByteArray, Fvalue: name}
+		Ftype: types.JavaByteArray, Fvalue: name}
 	t.ThMutex.Unlock()
 
 	return nil

--- a/src/gfunction/javaLang/javaLangThreadGroup_test.go
+++ b/src/gfunction/javaLang/javaLangThreadGroup_test.go
@@ -321,7 +321,7 @@ func TestThreadGroupGetName_AllPaths(t *testing.T) {
 		tgName := "java/lang/ThreadGroup"
 		obj := object.MakeEmptyObjectWithClassName(&tgName)
 		jb := object.JavaByteArrayFromGoString("gamma")
-		obj.FieldTable["name"] = object.Field{Ftype: types.ByteArray, Fvalue: jb}
+		obj.FieldTable["name"] = object.Field{Ftype: types.JavaByteArray, Fvalue: jb}
 		res := threadGroupGetName([]any{obj}).(*object.Object)
 		if object.GoStringFromStringObject(res) != "gamma" {
 			t.Errorf("expected gamma")

--- a/src/gfunction/javaLang/javaLangThread_helpers.go
+++ b/src/gfunction/javaLang/javaLangThread_helpers.go
@@ -93,7 +93,7 @@ func populateThreadObject(t *object.Object) {
 	// the JDK defaults to "Thread-N" where N is the thread number
 	// the sole exception is the main thread, which is called "main"
 	defaultName := fmt.Sprintf("Thread-%d", idField.Fvalue)
-	nameField := object.Field{Ftype: types.ByteArray, Fvalue: object.StringObjectFromGoString(defaultName)}
+	nameField := object.Field{Ftype: types.JavaByteArray, Fvalue: object.StringObjectFromGoString(defaultName)}
 	t.FieldTable["name"] = nameField
 
 	daemonField := object.Field{Ftype: types.Int, Fvalue: types.JavaBoolFalse}

--- a/src/gfunction/javaLang/javaLangThread_members.go
+++ b/src/gfunction/javaLang/javaLangThread_members.go
@@ -428,7 +428,7 @@ func threadSetName(params []interface{}) any {
 	}
 
 	// Update the thread's name field (stored as a Java byte string)
-	th.FieldTable["name"] = object.Field{Ftype: types.ByteArray, Fvalue: nameObj}
+	th.FieldTable["name"] = object.Field{Ftype: types.JavaByteArray, Fvalue: nameObj}
 
 	return nil
 }

--- a/src/gfunction/javaLang/javaLangThread_test.go
+++ b/src/gfunction/javaLang/javaLangThread_test.go
@@ -498,9 +498,9 @@ func TestThreadNumbering_InitAndNext(t *testing.T) {
 func makeRunnableDescriptor(className, methodName, sig string) *object.Object {
 	o := object.MakeEmptyObject()
 	o.FieldTable = map[string]object.Field{}
-	o.FieldTable["clName"] = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(className)}
-	o.FieldTable["methName"] = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(methodName)}
-	o.FieldTable["signature"] = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(sig)}
+	o.FieldTable["clName"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(className)}
+	o.FieldTable["methName"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(methodName)}
+	o.FieldTable["signature"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(sig)}
 	return o
 }
 
@@ -647,7 +647,7 @@ func TestThreadToString_AllPaths(t *testing.T) {
 	th := ThreadCreateNoarg(nil).(*object.Object)
 	th.KlassName = types.StringPoolThreadIndex
 	th.FieldTable["ID"] = object.Field{Ftype: types.Int, Fvalue: int64(10)}
-	th.FieldTable["name"] = object.Field{Ftype: types.ByteArray, Fvalue: object.StringObjectFromGoString("Thread-10")}
+	th.FieldTable["name"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.StringObjectFromGoString("Thread-10")}
 	th.FieldTable["priority"] = object.Field{Ftype: types.Int, Fvalue: int64(5)}
 	th.FieldTable["state"] = object.Field{Ftype: types.Int, Fvalue: RUNNABLE}
 

--- a/src/gfunction/javaNio/javaNioFileFiles.go
+++ b/src/gfunction/javaNio/javaNioFileFiles.go
@@ -194,7 +194,7 @@ func boolToJava(b bool) types.JavaBool {
 func newFileInputStreamObj(path string, fh *os.File) *object.Object {
 	className := "java/io/FileInputStream"
 	obj := object.MakeEmptyObjectWithClassName(&className)
-	obj.FieldTable[ghelpers.FilePath] = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(path)}
+	obj.FieldTable[ghelpers.FilePath] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(path)}
 	obj.FieldTable[ghelpers.FileHandle] = object.Field{Ftype: ghelpers.FileHandle, Fvalue: fh}
 	return obj
 }
@@ -203,7 +203,7 @@ func newFileInputStreamObj(path string, fh *os.File) *object.Object {
 func newFileOutputStreamObj(path string, fh *os.File) *object.Object {
 	className := "java/io/FileOutputStream"
 	obj := object.MakeEmptyObjectWithClassName(&className)
-	obj.FieldTable[ghelpers.FilePath] = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(path)}
+	obj.FieldTable[ghelpers.FilePath] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(path)}
 	obj.FieldTable[ghelpers.FileHandle] = object.Field{Ftype: ghelpers.FileHandle, Fvalue: fh}
 	return obj
 }

--- a/src/gfunction/javaUtil/javaUtilArrays_test.go
+++ b/src/gfunction/javaUtil/javaUtilArrays_test.go
@@ -117,8 +117,8 @@ func TestCopyOfPrimitive_Byte(t *testing.T) {
 	}
 
 	// Verify type preservation
-	if resObj.FieldTable["value"].Ftype != types.ByteArray {
-		t.Errorf("Expected type %s, got %s", types.ByteArray, resObj.FieldTable["value"].Ftype)
+	if resObj.FieldTable["value"].Ftype != types.JavaByteArray {
+		t.Errorf("Expected type %s, got %s", types.JavaByteArray, resObj.FieldTable["value"].Ftype)
 	}
 }
 

--- a/src/gfunction/javaUtil/javaUtilBase64.go
+++ b/src/gfunction/javaUtil/javaUtilBase64.go
@@ -249,7 +249,7 @@ func base64EncodeBsrc(params []interface{}) interface{} {
 	}
 
 	// Return the result array in an object.
-	return object.MakePrimitiveObject("[B", types.ByteArray, jba)
+	return object.MakePrimitiveObject("[B", types.JavaByteArray, jba)
 }
 
 // Base 64 encode all bytes from the specified byte array using the Base64 encoding scheme specified in params[0].
@@ -276,7 +276,7 @@ func base64EncodeBsrcBdst(params []interface{}) interface{} {
 	}
 
 	// Put the encoded array in the destination object.
-	fld.Ftype = types.ByteArray
+	fld.Ftype = types.JavaByteArray
 	fld.Fvalue = jba.([]types.JavaByte)
 	dstObject.FieldTable[fieldNameValue] = fld
 
@@ -308,7 +308,7 @@ func base64Decode(params []interface{}) interface{} {
 	}
 
 	// Return the result array in an object.
-	return object.MakePrimitiveObject("[B", types.ByteArray, jba)
+	return object.MakePrimitiveObject("[B", types.JavaByteArray, jba)
 }
 
 // Base 64 decode all bytes from the specified byte array using the Base64 encoding scheme specified in params[0].
@@ -335,7 +335,7 @@ func base64DecodeBsrcBdst(params []interface{}) interface{} {
 	}
 
 	// Put the encoded array in the destination object.
-	fld.Ftype = types.ByteArray
+	fld.Ftype = types.JavaByteArray
 	fld.Fvalue = jba.([]types.JavaByte)
 	dstObject.FieldTable[fieldNameValue] = fld
 

--- a/src/gfunction/javaUtil/javaUtilBitSet_test.go
+++ b/src/gfunction/javaUtil/javaUtilBitSet_test.go
@@ -215,7 +215,7 @@ func TestBitSet_ValueOf(t *testing.T) {
 	// Test valueOf(byte[])
 	initialBytes := []int8{0b1011} // bits 0, 1, 3 are set. value 11.
 	byteArray := object.MakeEmptyObjectWithClassName(new("byte[]"))
-	byteArray.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: initialBytes}
+	byteArray.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: initialBytes}
 
 	resBytes := bitsetValueOfBytes([]interface{}{byteArray})
 	bsBytes := resBytes.(*object.Object)

--- a/src/gfunction/javaUtil/javaUtilHexFormat.go
+++ b/src/gfunction/javaUtil/javaUtilHexFormat.go
@@ -233,28 +233,28 @@ func hexFormatClinit(params []interface{}) interface{} {
 		-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 		-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 	}
-	sDigits := statics.Static{Type: types.ByteArray, Value: DIGITS}
+	sDigits := statics.Static{Type: types.JavaByteArray, Value: DIGITS}
 	statics.AddStatic("java/util/HexFormat.DIGITS", sDigits)
 
 	UPPERCASE_DIGITS := []types.JavaByte{
 		'0', '1', '2', '3', '4', '5', '6', '7',
 		'8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
 	}
-	sUppercaseDigits := statics.Static{Type: types.ByteArray, Value: UPPERCASE_DIGITS}
+	sUppercaseDigits := statics.Static{Type: types.JavaByteArray, Value: UPPERCASE_DIGITS}
 	statics.AddStatic("java/util/HexFormat.UPPERCASE_DIGITS", sUppercaseDigits)
 
 	LOWERCASE_DIGITS := []types.JavaByte{
 		'0', '1', '2', '3', '4', '5', '6', '7',
 		'8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
 	}
-	sLowercaseDigits := statics.Static{Type: types.ByteArray, Value: LOWERCASE_DIGITS}
+	sLowercaseDigits := statics.Static{Type: types.JavaByteArray, Value: LOWERCASE_DIGITS}
 	statics.AddStatic("java/util/HexFormat.LOWERCASE_DIGITS", sLowercaseDigits)
 
 	obj := mkHexFormatObject([]types.JavaByte{}, []types.JavaByte{}, []types.JavaByte{}, LOWERCASE_DIGITS)
 	sHexFormat := statics.Static{Type: "Ljava/util/HexFormat;", Value: obj}
 	statics.AddStatic("java/util/HexFormat.HEX_FORMAT", sHexFormat)
 
-	sEmptyBytes := statics.Static{Type: types.ByteArray, Value: []types.JavaByte{}}
+	sEmptyBytes := statics.Static{Type: types.JavaByteArray, Value: []types.JavaByte{}}
 	statics.AddStatic("java/util/HexFormat.EMPTY_BYTES", sEmptyBytes)
 
 	sJavaLangAccess := statics.Static{Type: types.Int, Value: 42}
@@ -269,16 +269,16 @@ func mkHexFormatObject(delimiter, prefix, suffix, digits []types.JavaByte) *obje
 	className := "java/util/HexFormat"
 	obj := object.MakeEmptyObjectWithClassName(&className)
 
-	fld = object.Field{Ftype: types.ByteArray, Fvalue: delimiter}
+	fld = object.Field{Ftype: types.JavaByteArray, Fvalue: delimiter}
 	obj.FieldTable["delimiter"] = fld
 
-	fld = object.Field{Ftype: types.ByteArray, Fvalue: prefix}
+	fld = object.Field{Ftype: types.JavaByteArray, Fvalue: prefix}
 	obj.FieldTable["prefix"] = fld
 
-	fld = object.Field{Ftype: types.ByteArray, Fvalue: suffix}
+	fld = object.Field{Ftype: types.JavaByteArray, Fvalue: suffix}
 	obj.FieldTable["suffix"] = fld
 
-	fld = object.Field{Ftype: types.ByteArray, Fvalue: digits}
+	fld = object.Field{Ftype: types.JavaByteArray, Fvalue: digits}
 	obj.FieldTable["digits"] = fld
 
 	return obj

--- a/src/gfunction/javaUtil/javaUtilLocale.go
+++ b/src/gfunction/javaUtil/javaUtilLocale.go
@@ -82,7 +82,7 @@ func getDefaultLocale([]interface{}) interface{} {
 	langStr := os.Getenv("LANGUAGE")
 	classStr := "java/lang/Locale"
 	obj := object.MakeEmptyObjectWithClassName(&classStr)
-	fld := object.Field{Ftype: types.ByteArray, Fvalue: []byte(langStr)}
+	fld := object.Field{Ftype: types.JavaByteArray, Fvalue: []byte(langStr)}
 	obj.FieldTable["value"] = fld
 	return obj
 }

--- a/src/gfunction/javaUtil/javaUtilRandom.go
+++ b/src/gfunction/javaUtil/javaUtilRandom.go
@@ -293,7 +293,7 @@ func randomNextBytes(params []interface{}) interface{} {
 		object.GoByteArrayFromJavaByteArray(bobj.FieldTable["value"].Fvalue.([]types.JavaByte))
 	r.rand.Read(bytes)
 	randBytes := object.JavaByteArrayFromGoByteArray(bytes) // convert back to Java bytes
-	bobj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: randBytes}
+	bobj.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: randBytes}
 	return nil
 }
 

--- a/src/gfunction/javaUtil/javaUtilZipCheckedInputStream.go
+++ b/src/gfunction/javaUtil/javaUtilZipCheckedInputStream.go
@@ -151,7 +151,7 @@ func CheckedInputStreamSkip(params []interface{}) interface{} {
 
 	// Create a byte array object for reading
 	javaBytes := make([]types.JavaByte, bufSize)
-	bufObj := object.MakePrimitiveObject("[B", types.ByteArray, javaBytes) // Using "[B" for byte array class name
+	bufObj := object.MakePrimitiveObject("[B", types.JavaByteArray, javaBytes) // Using "[B" for byte array class name
 
 	totalSkipped := int64(0)
 	for totalSkipped < n {

--- a/src/gfunction/javaUtil/javaUtilZipCheckedInputStream_test.go
+++ b/src/gfunction/javaUtil/javaUtilZipCheckedInputStream_test.go
@@ -71,7 +71,7 @@ func TestCheckedInputStream_Read(t *testing.T) {
 
 	// Test read(byte[], off, len)
 	buf := make([]types.JavaByte, 5)
-	bufObj := object.MakePrimitiveObject("java/util/ArrayList", types.ByteArray, buf)
+	bufObj := object.MakePrimitiveObject("java/util/ArrayList", types.JavaByteArray, buf)
 	n := javaUtil.CheckedInputStreamReadArray([]interface{}{cis, bufObj, int64(0), int64(5)})
 	if nr, ok := n.(int64); !ok || nr != 5 {
 		t.Errorf("Expected 5 bytes read, got %v", n)

--- a/src/gfunction/misc/jdkInternalMiscUnsafe_test.go
+++ b/src/gfunction/misc/jdkInternalMiscUnsafe_test.go
@@ -39,7 +39,7 @@ func TestUnsafe_ArrayBaseOffset_And_IndexScale(t *testing.T) {
 
 	// arrayIndexScale0: build a faux "array class" object whose value field type encodes the array kind
 	// byte[] => 1
-	arrClassB := object.MakePrimitiveObject("java/lang/Class", types.ByteArray, nil) // Ftype == "[B"
+	arrClassB := object.MakePrimitiveObject("java/lang/Class", types.JavaByteArray, nil) // Ftype == "[B"
 	if v := unsafeArrayIndexScale0([]interface{}{arrClassB}).(int64); v != 1 {
 		t.Fatalf("indexScale0 for [B expected 1, got %d", v)
 	}

--- a/src/gfunction/misc/jj.go
+++ b/src/gfunction/misc/jj.go
@@ -122,7 +122,7 @@ func jjStringifyScalar(ftype string, fvalue any) *object.Object {
 		str = object.GoStringFromStringObject(fvalue.(*object.Object))
 	case types.Short:
 		str = fmt.Sprintf("%d", fvalue.(int64))
-	case types.Ref, types.ByteArray:
+	case types.Ref, types.JavaByteArray:
 		if object.IsNull(fvalue.(*object.Object)) {
 			str = types.NullString
 		} else {
@@ -379,8 +379,8 @@ func jjSubProcess(params []interface{}) interface{} {
 	// Collect output from pipes.
 	stdout := stdoutBuf.String()
 	stderr := stderrBuf.String()
-	subpObj.FieldTable["stdout"] = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(stdout)}
-	subpObj.FieldTable["stderr"] = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(stderr)}
+	subpObj.FieldTable["stdout"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(stdout)}
+	subpObj.FieldTable["stderr"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(stderr)}
 
 	// Handle exit code or POSIX signal.
 	exitCode := int64(0)
@@ -391,7 +391,7 @@ func jjSubProcess(params []interface{}) interface{} {
 		stderrLines := strings.Split(stderr, "\n")
 		stderr = fmt.Sprintf("jjSubProcess: Process %s failed, err: %s\nstderr: %s", cmdString, err.Error(), stderrLines[0])
 		trace.Error(stderr)
-		subpObj.FieldTable["stderr"] = object.Field{Ftype: types.ByteArray, Fvalue: object.JavaByteArrayFromGoString(stderr)}
+		subpObj.FieldTable["stderr"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.JavaByteArrayFromGoString(stderr)}
 
 		// Is err of type *exec.ExitError?
 		if exitErr, ok := err.(*exec.ExitError); ok {

--- a/src/gfunction/misc/jj_test.go
+++ b/src/gfunction/misc/jj_test.go
@@ -374,7 +374,7 @@ func TestJjStringifyScalar_JavaString(t *testing.T) {
 }
 
 func TestJjStringifyScalar_ByteArrayNull(t *testing.T) {
-	result := jjStringifyScalar(types.ByteArray, object.Null)
+	result := jjStringifyScalar(types.JavaByteArray, object.Null)
 	expected := types.NullString
 	if object.GoStringFromStringObject(result) != expected {
 		t.Errorf("Expected %s, got %s", expected, object.GoStringFromStringObject(result))
@@ -549,8 +549,8 @@ func TestJjSubProcess_Success(t *testing.T) {
 		FieldTable: map[string]object.Field{
 			"commandLine": {Fvalue: cmdLine},
 			"classpath":   {Fvalue: []*object.Object{}},
-			"stdout":      {Ftype: types.ByteArray, Fvalue: []types.JavaByte{}},
-			"stderr":      {Ftype: types.ByteArray, Fvalue: []types.JavaByte{}},
+			"stdout":      {Ftype: types.JavaByteArray, Fvalue: []types.JavaByte{}},
+			"stderr":      {Ftype: types.JavaByteArray, Fvalue: []types.JavaByte{}},
 		},
 	}
 	params := []interface{}{subpObj}
@@ -572,8 +572,8 @@ func TestJjSubProcess_Failure(t *testing.T) {
 		FieldTable: map[string]object.Field{
 			"commandLine": {Fvalue: []*object.Object{object.StringObjectFromGoString("nonexistentcommand")}},
 			"classpath":   {Fvalue: []*object.Object{}},
-			"stdout":      {Ftype: types.ByteArray, Fvalue: []types.JavaByte{}},
-			"stderr":      {Ftype: types.ByteArray, Fvalue: []types.JavaByte{}},
+			"stdout":      {Ftype: types.JavaByteArray, Fvalue: []types.JavaByte{}},
+			"stderr":      {Ftype: types.JavaByteArray, Fvalue: []types.JavaByte{}},
 		},
 	}
 	params := []interface{}{subpObj}
@@ -613,8 +613,8 @@ func TestJjSubProcess_ExitError(t *testing.T) {
 		FieldTable: map[string]object.Field{
 			"commandLine": {Fvalue: cmdLine},
 			"classpath":   {Fvalue: []*object.Object{}},
-			"stdout":      {Ftype: types.ByteArray, Fvalue: []types.JavaByte{}},
-			"stderr":      {Ftype: types.ByteArray, Fvalue: []types.JavaByte{}},
+			"stdout":      {Ftype: types.JavaByteArray, Fvalue: []types.JavaByte{}},
+			"stderr":      {Ftype: types.JavaByteArray, Fvalue: []types.JavaByte{}},
 		},
 	}
 	params := []interface{}{subpObj}
@@ -647,8 +647,8 @@ func TestJjSubProcess_Classpath(t *testing.T) {
 		FieldTable: map[string]object.Field{
 			"commandLine": {Fvalue: cmdLine},
 			"classpath":   {Fvalue: []*object.Object{object.StringObjectFromGoString("test_cp")}},
-			"stdout":      {Ftype: types.ByteArray, Fvalue: []types.JavaByte{}},
-			"stderr":      {Ftype: types.ByteArray, Fvalue: []types.JavaByte{}},
+			"stdout":      {Ftype: types.JavaByteArray, Fvalue: []types.JavaByte{}},
+			"stderr":      {Ftype: types.JavaByteArray, Fvalue: []types.JavaByte{}},
 		},
 	}
 	params := []interface{}{subpObj}

--- a/src/gfunction/misc/stringFormatter.go
+++ b/src/gfunction/misc/stringFormatter.go
@@ -64,7 +64,7 @@ func StringFormatter(params []interface{}) interface{} {
 				object.GoStringFromJavaByteArray(formatStringObj.FieldTable["value"].Fvalue.([]types.JavaByte))
 		default:
 			errMsg := fmt.Sprintf("StringFormatter: In the format string object, expected Ftype=%s but observed: %s",
-				types.ByteArray, formatStringObj.FieldTable["value"].Ftype)
+				types.JavaByteArray, formatStringObj.FieldTable["value"].Ftype)
 			return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, errMsg)
 		}
 	default:
@@ -106,7 +106,7 @@ func StringFormatter(params []interface{}) interface{} {
 		}
 		if hasValue {
 			switch fld.Ftype {
-			case types.ByteArray:
+			case types.JavaByteArray:
 				var str string
 				switch fld.Fvalue.(type) {
 				case []byte:

--- a/src/jvm/instantiate_test.go
+++ b/src/jvm/instantiate_test.go
@@ -26,7 +26,7 @@ func TestInstantiateArray(t *testing.T) {
 	trace.Init()
 	classloader.InitMethodArea()
 
-	anything, err := InstantiateClass(types.ByteArray, nil)
+	anything, err := InstantiateClass(types.JavaByteArray, nil)
 	if err != nil {
 		t.Errorf("Got unexpected error from instantiating array: %s", err.Error())
 	}

--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -1066,7 +1066,7 @@ func doBastore(fr *frames.Frame, _ int64) int {
 		fld := arrayRef.FieldTable["value"]
 		arrayRef.ThMutex.RUnlock()
 
-		if fld.Ftype != types.ByteArray && fld.Ftype != types.BoolArray {
+		if fld.Ftype != types.JavaByteArray && fld.Ftype != types.BoolArray {
 			globals.GetGlobalRef().ErrorGoStack = string(debug.Stack())
 			errMsg := fmt.Sprintf("in %s.%s, BASTORE: field type expected boolean or byte, observed=%s",
 				util.ConvertInternalClassNameToUserFormat(fr.ClName), fr.MethName, fld.Ftype)
@@ -2495,7 +2495,7 @@ func doGetfield(fr *frames.Frame, _ int64) int {
 			elemType := w.Elem()
 			switch elemType.Kind() {
 			case reflect.Int8:
-				newFieldType = types.ByteArray
+				newFieldType = types.JavaByteArray
 			case reflect.Int64:
 				newFieldType = types.IntArray
 			case reflect.Float64:

--- a/src/jvm/interpreter_A-E_test.go
+++ b/src/jvm/interpreter_A-E_test.go
@@ -432,7 +432,7 @@ func TestAthrow_Uncaught_WithStringObjectMessageBytes(t *testing.T) {
 
 	// detailMessage = object with field "value" = []byte("hello")
 	msgObj := object.MakeEmptyObject()
-	msgObj.FieldTable["value"] = object.Field{Ftype: types.ByteArray, Fvalue: []byte("hello")}
+	msgObj.FieldTable["value"] = object.Field{Ftype: types.JavaByteArray, Fvalue: []byte("hello")}
 	ex.FieldTable["detailMessage"] = object.Field{Ftype: types.StringClassName, Fvalue: msgObj}
 
 	// stackTrace

--- a/src/jvm/interpreter_F-IF_test.go
+++ b/src/jvm/interpreter_F-IF_test.go
@@ -620,7 +620,7 @@ func TestNewGetField(t *testing.T) {
 	// push the string whose field[0] we'll be getting
 	str := object.NewStringObject()
 	str.FieldTable["value"] = object.Field{
-		Ftype:  types.ByteArray,
+		Ftype:  types.JavaByteArray,
 		Fvalue: "hello",
 	}
 

--- a/src/object/arrays.go
+++ b/src/object/arrays.go
@@ -135,7 +135,7 @@ func Make1DimArray(arrType uint8, size int64) *Object {
 		of = Field{Ftype: types.BoolArray, Fvalue: barArr}
 	case T_BYTE:
 		barArr := make([]types.JavaByte, size)
-		of = Field{Ftype: types.ByteArray, Fvalue: barArr}
+		of = Field{Ftype: types.JavaByteArray, Fvalue: barArr}
 	case T_CHAR: // integer arrays
 		farArr := make([]int64, size)
 		of = Field{Ftype: types.CharArray, Fvalue: farArr}
@@ -204,7 +204,7 @@ func MakeArrayFromRawArray(rawArray interface{}) *Object {
 		return obj
 	case *[]types.JavaByte: // an array of bytes
 		objPtr :=
-			MakePrimitiveObject(types.ByteArray, types.ByteArray, *rawArray.(*[]types.JavaByte))
+			MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, *rawArray.(*[]types.JavaByte))
 		return objPtr
 	}
 
@@ -212,11 +212,11 @@ func MakeArrayFromRawArray(rawArray interface{}) *Object {
 	if arrType.Kind() == reflect.Slice {
 		switch arrType.Elem().Kind() {
 		case reflect.Int8:
-			return MakePrimitiveObject(types.ByteArray, types.ByteArray, rawArray.([]int8))
+			return MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, rawArray.([]int8))
 		case reflect.Uint8:
 			// convert array of bytes into JavaBytes
 			jba := JavaByteArrayFromGoByteArray(rawArray.([]uint8))
-			return MakePrimitiveObject(types.ByteArray, types.ByteArray, jba)
+			return MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, jba)
 		case reflect.Int64:
 			return MakePrimitiveObject(types.IntArray, types.IntArray, rawArray.([]int64))
 		}
@@ -233,9 +233,9 @@ func MakeArrayFromRawArray(rawArray interface{}) *Object {
 
 		switch arrType.Elem().Kind() {
 		case reflect.Int8:
-			return MakePrimitiveObject(types.ByteArray, types.ByteArray, slice)
+			return MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, slice)
 		case reflect.Uint8:
-			return MakePrimitiveObject(types.ByteArray, types.ByteArray, slice)
+			return MakePrimitiveObject(types.JavaByteArray, types.JavaByteArray, slice)
 		case reflect.Int64:
 			return MakePrimitiveObject(types.IntArray, types.IntArray, slice)
 		}
@@ -254,7 +254,7 @@ func ArrayLength(arrayRef *Object) int64 {
 	arrayType := fld.Ftype
 
 	switch arrayType {
-	case types.ByteArray, types.BoolArray:
+	case types.JavaByteArray, types.BoolArray:
 		if array, ok := fld.Fvalue.([]types.JavaByte); ok {
 			return int64(len(array))
 		} else {

--- a/src/object/format.go
+++ b/src/object/format.go
@@ -111,7 +111,7 @@ func fmtHelper(field Field, className string, fieldName string) string {
 				return fmt.Sprintf("<ERROR Ftype=bool but unexpected Fvalue variable type: %T >", field.Fvalue)
 			}
 		}
-	case types.ByteArray:
+	case types.JavaByteArray:
 		// Special handling for non-String byte array.
 		var bytes []byte
 		if flagStatic {

--- a/src/object/format_test.go
+++ b/src/object/format_test.go
@@ -247,7 +247,7 @@ func TestFmtHelper(t *testing.T) {
 
 	// Primitive byte array.
 	bites = []byte{'A', 'B', 'C'}
-	fld = Field{types.ByteArray, bites}
+	fld = Field{types.JavaByteArray, bites}
 	str = fmtHelper(fld, className, fieldName)
 	if str != "41 42 43" {
 		t.Errorf("TestFmtHelper: expected fmtHelper to return \"41 42 43\", got \"%v\"", str)
@@ -255,7 +255,7 @@ func TestFmtHelper(t *testing.T) {
 
 	// Primitive byte array pointer.
 	bites = []byte{'A', 'B', 'C'}
-	fld = Field{types.ByteArray, &bites}
+	fld = Field{types.JavaByteArray, &bites}
 	str = fmtHelper(fld, className, fieldName)
 	if str != "41 42 43" {
 		t.Errorf("TestFmtHelper: expected fmtHelper to return \"41 42 43\", got \"%v\"", str)
@@ -263,7 +263,7 @@ func TestFmtHelper(t *testing.T) {
 
 	// Primitive byte array, wrong format.
 	jb := []types.JavaByte{1, 2, 3}
-	fld = Field{types.ByteArray, jb}
+	fld = Field{types.JavaByteArray, jb}
 	str = fmtHelper(fld, className, fieldName)
 	if !strings.Contains(str, "but value is of type") {
 		t.Errorf("TestFmtHelper: expected fmtHelper to return \"but value is of type\", got \"%v\"", str)
@@ -271,7 +271,7 @@ func TestFmtHelper(t *testing.T) {
 
 	// Primitive byte array, length=0.
 	bites = []byte{}
-	fld = Field{types.ByteArray, bites}
+	fld = Field{types.JavaByteArray, bites}
 	str = fmtHelper(fld, className, fieldName)
 	if !strings.Contains(str, "array of zero") {
 		t.Errorf("TestFmtHelper: expected fmtHelper to return \"array of zero\", got \"%v\"", str)
@@ -433,7 +433,7 @@ func TestFmtHelperStaticByteArray(t *testing.T) {
 	globals.GetGlobalRef().FuncThrowException = _formatCycleKiller
 	globals.GetGlobalRef().FuncGetStaticValue = statics.GetStaticValue
 
-	field := Field{Ftype: types.Static + types.ByteArray, Fvalue: []byte{1, 2, 3}}
+	field := Field{Ftype: types.Static + types.JavaByteArray, Fvalue: []byte{1, 2, 3}}
 	result := fmtHelper(field, "TestClass", "testField")
 
 	// Should contain "static" in the result
@@ -446,7 +446,7 @@ func TestFmtHelperStaticByteArray(t *testing.T) {
 func TestFmtHelperByteArrayNilValue(t *testing.T) {
 	globals.InitGlobals("test")
 
-	field := Field{Ftype: types.ByteArray, Fvalue: nil}
+	field := Field{Ftype: types.JavaByteArray, Fvalue: nil}
 	result := fmtHelper(field, "TestClass", "testField")
 	expected := "<ERROR nil Fvalue>"
 	if result != expected {
@@ -459,7 +459,7 @@ func TestFmtHelperByteArrayWithEmbeddedObject(t *testing.T) {
 	globals.InitGlobals("test")
 
 	embeddedObj := MakeEmptyObject()
-	field := Field{Ftype: types.ByteArray, Fvalue: embeddedObj}
+	field := Field{Ftype: types.JavaByteArray, Fvalue: embeddedObj}
 	result := fmtHelper(field, "TestClass", "testField")
 	expected := "*** embedded object ***"
 	if result != expected {

--- a/src/object/object_test.go
+++ b/src/object/object_test.go
@@ -223,7 +223,7 @@ func TestMakeOneFieldObject(t *testing.T) {
 	globals.InitGlobals("test")
 
 	// Test with string field
-	stringObj := MakeOneFieldObject("java/lang/String", "data", types.ByteArray, "hello")
+	stringObj := MakeOneFieldObject("java/lang/String", "data", types.JavaByteArray, "hello")
 	if stringObj == nil {
 		t.Errorf("MakeOneFieldObject() should not return nil")
 	}
@@ -239,8 +239,8 @@ func TestMakeOneFieldObject(t *testing.T) {
 	if !exists {
 		t.Errorf("Expected field 'data' to exist")
 	}
-	if field.Ftype != types.ByteArray {
-		t.Errorf("Expected field type '%s', got '%s'", types.ByteArray, field.Ftype)
+	if field.Ftype != types.JavaByteArray {
+		t.Errorf("Expected field type '%s', got '%s'", types.JavaByteArray, field.Ftype)
 	}
 	if field.Fvalue.(string) != "hello" {
 		t.Errorf("Expected field value 'hello', got '%s'", field.Fvalue.(string))
@@ -296,7 +296,7 @@ func TestMakeOneFieldObject(t *testing.T) {
 	}
 
 	// Test with empty field name
-	emptyFieldObj := MakeOneFieldObject("TestClass", "", types.ByteArray, "test")
+	emptyFieldObj := MakeOneFieldObject("TestClass", "", types.JavaByteArray, "test")
 	_, exists = emptyFieldObj.FieldTable[""]
 	if !exists {
 		t.Errorf("Expected empty string field name to be valid")
@@ -385,7 +385,7 @@ func TestClearFieldTable(t *testing.T) {
 	}
 
 	// Test clearing field table with one field
-	singleFieldObj := MakeOneFieldObject("TestClass", "field1", types.ByteArray, "value1")
+	singleFieldObj := MakeOneFieldObject("TestClass", "field1", types.JavaByteArray, "value1")
 	if len(singleFieldObj.FieldTable) != 1 {
 		t.Errorf("Expected 1 field before clearing, got %d", len(singleFieldObj.FieldTable))
 	}
@@ -396,7 +396,7 @@ func TestClearFieldTable(t *testing.T) {
 
 	// Test clearing field table with multiple fields
 	multiFieldObj := MakeEmptyObject()
-	multiFieldObj.FieldTable["field1"] = Field{Ftype: types.ByteArray, Fvalue: "value1"}
+	multiFieldObj.FieldTable["field1"] = Field{Ftype: types.JavaByteArray, Fvalue: "value1"}
 	multiFieldObj.FieldTable["field2"] = Field{Ftype: types.Int, Fvalue: 42}
 	multiFieldObj.FieldTable["field3"] = Field{Ftype: types.Double, Fvalue: 3.14}
 

--- a/src/object/string.go
+++ b/src/object/string.go
@@ -301,7 +301,7 @@ func ObjectFieldToString(obj *Object, fieldName string) string {
 		return str
 	case types.Byte, types.Char, types.Int, types.Long, types.Rune, types.Short:
 		return fmt.Sprintf("%d", fld.Fvalue.(int64))
-	case types.ByteArray, "Ljava/lang/String;":
+	case types.JavaByteArray, "Ljava/lang/String;":
 		switch fld.Fvalue.(type) {
 		case []byte:
 			return fmt.Sprintf("%x", fld.Fvalue.([]byte))

--- a/src/object/string_test.go
+++ b/src/object/string_test.go
@@ -740,9 +740,9 @@ func TestObjectFieldToStringAdditionalCases(t *testing.T) {
 		t.Errorf("Expected empty string, got '%s'", result)
 	}
 
-	// Test ByteArray with []byte
+	// Test JavaByteArray with []byte
 	obj.FieldTable["byteArrayField"] = Field{
-		Ftype:  types.ByteArray,
+		Ftype:  types.JavaByteArray,
 		Fvalue: []byte{0x41, 0x42, 0x43}, // ABC
 	}
 	result = ObjectFieldToString(obj, "byteArrayField")

--- a/src/object/stringifyAnything.go
+++ b/src/object/stringifyAnything.go
@@ -113,7 +113,7 @@ func StringifyAnythingGo(arg interface{}) string {
 				return GoStringFromJavaCharArray(charArr)
 			}
 			return fmt.Sprintf("*** ERROR, StringifyAnythingGo: corrupted char array \"value\" field, type %T", fld.Fvalue)
-		case types.ByteArray:
+		case types.JavaByteArray:
 			fld, ok := obj.FieldTable["value"]
 			if !ok {
 				return "*** ERROR, StringifyAnythingGo: corrupted byte array, missing \"value\" field"
@@ -243,7 +243,7 @@ func StringifyAnythingGo(arg interface{}) string {
 				return "*** ERROR, StringifyAnythingGo Field types.Byte: corrupted byte \"value\" field"
 			}
 			return "0x" + hex.EncodeToString(ba1)
-		case types.ByteArray:
+		case types.JavaByteArray:
 			var bytes []byte
 			switch fld.Fvalue.(type) {
 			case []types.JavaByte:
@@ -251,7 +251,7 @@ func StringifyAnythingGo(arg interface{}) string {
 			case []byte:
 				bytes = fld.Fvalue.([]byte)
 			default:
-				return "*** ERROR, StringifyAnythingGo Field types.ByteArray: corrupted byte array \"value\" field"
+				return "*** ERROR, StringifyAnythingGo Field types.JavaByteArray: corrupted byte array \"value\" field"
 			}
 			return "0x" + hex.EncodeToString(bytes)
 		case types.Bool:

--- a/src/object/stringifyAnything_test.go
+++ b/src/object/stringifyAnything_test.go
@@ -55,7 +55,7 @@ func TestStringifyAnythingGo_StringObject(t *testing.T) {
 	// Create a String object with value field
 	obj := MakeEmptyObjectWithClassName(&stringName)
 	javaBytes := JavaByteArrayFromGoString("hello")
-	obj.FieldTable["value"] = Field{Ftype: types.ByteArray, Fvalue: javaBytes}
+	obj.FieldTable["value"] = Field{Ftype: types.JavaByteArray, Fvalue: javaBytes}
 
 	result := StringifyAnythingGo(obj)
 	if result != "hello" {
@@ -264,7 +264,7 @@ func TestStringifyAnythingGo_ByteArray(t *testing.T) {
 	globals.InitGlobals("test")
 	obj := MakeEmptyObjectWithClassName(&ba)
 	bytes := []byte{0x48, 0x65, 0x6c, 0x6c, 0x6f} // "Hello"
-	obj.FieldTable["value"] = Field{Ftype: types.ByteArray, Fvalue: bytes}
+	obj.FieldTable["value"] = Field{Ftype: types.JavaByteArray, Fvalue: bytes}
 
 	result := StringifyAnythingGo(obj)
 	if result != "0x48656c6c6f" {
@@ -276,7 +276,7 @@ func TestStringifyAnythingGo_ByteArray_JavaBytes(t *testing.T) {
 	globals.InitGlobals("test")
 	obj := MakeEmptyObjectWithClassName(&ba)
 	javaBytes := []types.JavaByte{0x48, 0x65, 0x6c, 0x6c, 0x6f}
-	obj.FieldTable["value"] = Field{Ftype: types.ByteArray, Fvalue: javaBytes}
+	obj.FieldTable["value"] = Field{Ftype: types.JavaByteArray, Fvalue: javaBytes}
 
 	result := StringifyAnythingGo(obj)
 	if result != "0x48656c6c6f" {
@@ -298,7 +298,7 @@ func TestStringifyAnythingGo_ByteArray_MissingValue(t *testing.T) {
 func TestStringifyAnythingGo_ByteArray_CorruptedValue(t *testing.T) {
 	globals.InitGlobals("test")
 	obj := MakeEmptyObjectWithClassName(&ba)
-	obj.FieldTable["value"] = Field{Ftype: types.ByteArray, Fvalue: "invalid"} // Wrong type
+	obj.FieldTable["value"] = Field{Ftype: types.JavaByteArray, Fvalue: "invalid"} // Wrong type
 
 	result := StringifyAnythingGo(obj)
 	expected := "corrupted byte array"
@@ -492,7 +492,7 @@ func TestStringifyAnythingGo_Field_Byte_CorruptedValue(t *testing.T) {
 
 func TestStringifyAnythingGo_Field_ByteArray_JavaBytes(t *testing.T) {
 	javaBytes := []types.JavaByte{0x48, 0x65}
-	field := Field{Ftype: types.ByteArray, Fvalue: javaBytes}
+	field := Field{Ftype: types.JavaByteArray, Fvalue: javaBytes}
 
 	result := StringifyAnythingGo(field)
 	if result != "0x4865" {
@@ -502,7 +502,7 @@ func TestStringifyAnythingGo_Field_ByteArray_JavaBytes(t *testing.T) {
 
 func TestStringifyAnythingGo_Field_ByteArray_GoBytes(t *testing.T) {
 	bytes := []byte{0x48, 0x65}
-	field := Field{Ftype: types.ByteArray, Fvalue: bytes}
+	field := Field{Ftype: types.JavaByteArray, Fvalue: bytes}
 
 	result := StringifyAnythingGo(field)
 	if result != "0x4865" {
@@ -511,7 +511,7 @@ func TestStringifyAnythingGo_Field_ByteArray_GoBytes(t *testing.T) {
 }
 
 func TestStringifyAnythingGo_Field_ByteArray_CorruptedValue(t *testing.T) {
-	field := Field{Ftype: types.ByteArray, Fvalue: "invalid"}
+	field := Field{Ftype: types.JavaByteArray, Fvalue: "invalid"}
 
 	result := StringifyAnythingGo(field)
 	expected := "corrupted byte array"

--- a/src/object/toString_test.go
+++ b/src/object/toString_test.go
@@ -133,7 +133,7 @@ func TestObjectFieldToStringPos(t *testing.T) {
 
 	// Byte array
 	var byteAry = []byte{65, 66, 67}
-	setField(obj, fieldName, types.ByteArray, byteAry)
+	setField(obj, fieldName, types.JavaByteArray, byteAry)
 	observed = ObjectFieldToString(obj, fieldName)
 	expected = "414243"
 	if observed != expected {
@@ -142,7 +142,7 @@ func TestObjectFieldToStringPos(t *testing.T) {
 
 	// Java byte array
 	var jbAry = []types.JavaByte{65, 66, 67}
-	setField(obj, fieldName, types.ByteArray, jbAry)
+	setField(obj, fieldName, types.JavaByteArray, jbAry)
 	observed = ObjectFieldToString(obj, fieldName)
 	expected = "ABC"
 	if observed != expected {

--- a/src/stringPool/StringPool.go
+++ b/src/stringPool/StringPool.go
@@ -115,7 +115,7 @@ func GetStringPoolSize() uint32 {
 func PreloadArrayClassesToStringPool() {
 	arrayClassesToPreload := []string{
 		types.BoolArray,
-		types.ByteArray,
+		types.JavaByteArray,
 		types.DoubleArray,
 		types.FloatArray,
 		types.IntArray,

--- a/src/types/javaTypes.go
+++ b/src/types/javaTypes.go
@@ -28,12 +28,11 @@ const U16 = "U" // uint16
 
 const Array = "["
 const BoolArray = "[Z"
-const ByteArray = "[B" // a Java byte array (i.e., int8). See GoByteArray for uint8.
-const CharArray = "[R" // char array is = rune array
+const CharArray = "[R"     // char array is = rune array
 const DoubleArray = "[D"
 const GoByteArray = "[GB" // array of golang bytes (i.e., uint8)
 const IntArray = "[I"
-const JavaByteArray = "[B"       // same as ByteArray above. This type is preferred due to its unambiguity
+const JavaByteArray = "[B" // Java byte array (i.e., int8). See GoByteArray for uint8.
 const JavaStringObjectRef = "JS" // type for an *object.Object that points to a java/lang/String object
 const FloatArray = "[F"
 const LongArray = "[J"

--- a/src/types/javaTypes_test.go
+++ b/src/types/javaTypes_test.go
@@ -22,7 +22,7 @@ func TestTheIsFunctionsValidate(t *testing.T) {
 		t.Errorf("IsIntegral() returned false for short, should be true")
 	}
 
-	if !IsAddress(ByteArray) {
+	if !IsAddress(JavaByteArray) {
 		t.Errorf("IsAddress() returned false for byte array, should be true")
 	}
 
@@ -57,8 +57,8 @@ func TestTheIsFunctionsNegatively(t *testing.T) {
 		t.Errorf("Error: Int incorrectly is true in IsAddress()")
 	}
 
-	if IsStatic(ByteArray) {
-		t.Errorf("Error: ByteArray incorrectly is true in IsStatic()")
+	if IsStatic(JavaByteArray) {
+		t.Errorf("Error: JavaByteArray incorrectly is true in IsStatic()")
 	}
 
 	if IsError(Short) {
@@ -162,8 +162,8 @@ func TestIsArray(t *testing.T) {
 		t.Errorf("IsArray() returned false for BoolArray, should be true")
 	}
 
-	if !IsArray(ByteArray) {
-		t.Errorf("IsArray() returned false for ByteArray, should be true")
+	if !IsArray(JavaByteArray) {
+		t.Errorf("IsArray() returned false for JavaByteArray, should be true")
 	}
 
 	if !IsArray(CharArray) {


### PR DESCRIPTION
See JACOBIN-934 for details.

Sole edit:
* src/types/javaTypes.go

Files refactored by GoLand:
* notes/Initialisation.txt
* src/classloader/classloader_test.go
* src/classloader/methArea.go
* src/debug/debug.go
* src/debug/debug_test.go
* src/gfunction/javaIo/javaIoBufferedWriter_test.go
* src/gfunction/javaIo/javaIoByteArrayOutputStream.go
* src/gfunction/javaIo/javaIoByteArrayOutputStream_test.go
* src/gfunction/javaIo/javaIoFile.go
* src/gfunction/javaIo/javaIoFileInputStream.go
* src/gfunction/javaIo/javaIoFileInputStream_test.go
* src/gfunction/javaIo/javaIoFileOutputStream.go
* src/gfunction/javaIo/javaIoFileOutputStream_test.go
* src/gfunction/javaIo/javaIoFileReader.go
* src/gfunction/javaIo/javaIoFileReader_test.go
* src/gfunction/javaIo/javaIoFilterInputStream_test.go
* src/gfunction/javaIo/javaIoFilterOutputStream_test.go
* src/gfunction/javaIo/javaIoInputStreamReader_test.go
* src/gfunction/javaIo/javaIoOutputStreamWriter_test.go
* src/gfunction/javaIo/javaIoRandomAccessFile.go
* src/gfunction/javaIo/javaIoRandomAccessFile_test.go
* src/gfunction/javaLang/javaLangCharSequence_test.go
* src/gfunction/javaLang/javaLangRunnable.go
* src/gfunction/javaLang/javaLangRunnable_test.go
* src/gfunction/javaLang/javaLangRuntime.go
* src/gfunction/javaLang/javaLangString.go
* src/gfunction/javaLang/javaLangStringBuffer.go
* src/gfunction/javaLang/javaLangStringBuilder.go
* src/gfunction/javaLang/javaLangStringBuilder_test.go
* src/gfunction/javaLang/javaLangString_boundary_test.go
* src/gfunction/javaLang/javaLangString_test.go
* src/gfunction/javaLang/javaLangSystem.go
* src/gfunction/javaLang/javaLangThread.go
* src/gfunction/javaLang/javaLangThreadGroup_test.go
* src/gfunction/javaLang/javaLangThread_helpers.go
* src/gfunction/javaLang/javaLangThread_members.go
* src/gfunction/javaLang/javaLangThread_test.go
* src/gfunction/javaNio/javaNioFileFiles.go
* src/gfunction/javaUtil/javaUtilArrays_test.go
* src/gfunction/javaUtil/javaUtilBase64.go
* src/gfunction/javaUtil/javaUtilBitSet_test.go
* src/gfunction/javaUtil/javaUtilHexFormat.go
* src/gfunction/javaUtil/javaUtilLocale.go
* src/gfunction/javaUtil/javaUtilRandom.go
* src/gfunction/javaUtil/javaUtilZipCheckedInputStream.go
* src/gfunction/javaUtil/javaUtilZipCheckedInputStream_test.go
* src/gfunction/misc/jdkInternalMiscUnsafe_test.go
* src/gfunction/misc/jj.go
* src/gfunction/misc/jj_test.go
* src/gfunction/misc/stringFormatter.go
* src/jvm/instantiate_test.go
* src/jvm/interpreter.go
* src/jvm/interpreter_A-E_test.go
* src/jvm/interpreter_F-IF_test.go
* src/object/arrays.go
* src/object/format.go
* src/object/format_test.go
* src/object/object_test.go
* src/object/string.go
* src/object/string_test.go
* src/object/stringifyAnything.go
* src/object/stringifyAnything_test.go
* src/object/toString_test.go
* src/stringPool/StringPool.go
* src/types/javaTypes_test.go
