### PR TITLE
JACOBIN-742: Make the bytecode verifier recognize Jacobin's internal CachedMeth constant pool entry type

### DIFF
--- a/src/classloader/codeCheck.go
+++ b/src/classloader/codeCheck.go
@@ -1067,7 +1067,7 @@ func checkInvokespecial() int {
 	}
 
 	CPentry := CP.CpIndex[CPslot]
-	if CPentry.Type != MethodRef && CPentry.Type != Interface {
+	if CPentry.Type != MethodRef && CPentry.Type != Interface && CPentry.Type != CachedMeth {
 		// because this is not a ClassFormatError, we output a trace error message here
 		errMsg := fmt.Sprintf("%s:\n INVOKESPECIAL at %d: CP entry (%d) is not a method or interface reference",
 			excNames.JVMexceptionNames[excNames.VerifyError], PC, CPentry.Type)
@@ -1086,7 +1086,7 @@ func checkInvokestatic() int {
 	}
 
 	CPentry := CP.CpIndex[CPslot]
-	if CPentry.Type != MethodRef && CPentry.Type != Interface {
+	if CPentry.Type != MethodRef && CPentry.Type != Interface && CPentry.Type != CachedMeth {
 		// because this is not a ClassFormatError, we output a trace message here
 		errMsg := fmt.Sprintf("%s:\n INVOKESTATIC at %d: CP entry (%d) is not a method or interface reference",
 			excNames.JVMexceptionNames[excNames.VerifyError], PC, CPentry.Type)
@@ -1105,7 +1105,7 @@ func CheckInvokevirtual() int {
 	}
 
 	CPentry := CP.CpIndex[CPslot]
-	if CPentry.Type != MethodRef {
+	if CPentry.Type != MethodRef && CPentry.Type != CachedMeth {
 		// because this is not a ClassFormatError, we emit a trace message here
 		errMsg := fmt.Sprintf("%s:\n INVOKEVIRTUAL at %d: CP entry (%d) is not a method reference",
 			excNames.JVMexceptionNames[excNames.VerifyError], PC, CPentry.Type)

--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -3144,18 +3144,20 @@ processMTentry: // at this point, we have the mtEntry
 
 	// if this is the first time calling this method and we're using cached methods,
 	// then cache this mtEntry
-	if globals.CacheMeths && shouldCacheMeth {
+	if (globals.CacheMeths && shouldCacheMeth) || !globals.CacheMeths {
 		mtEntry.MethClass = stringPool.GetStringIndex(&className)
 		mtEntry.MethName = stringPool.GetStringIndex(&methodName)
 		mtEntry.MethType = stringPool.GetStringIndex(&methodType)
 		mtEntry.MethFQN = stringPool.GetStringIndex(&fqn)
-		CP.Mutex.Lock() // update the CP with the cached method
-		CP.CachedMethods = append(CP.CachedMethods, mtEntry)
-		CP.CpIndex[CPslot] = classloader.CpEntry{
-			Type: classloader.CachedMeth,
-			Slot: uint16(len(CP.CachedMethods) - 1)}
-		CP.Mutex.Unlock()
-		shouldCacheMeth = false
+		if globals.CacheMeths && shouldCacheMeth {
+			CP.Mutex.Lock() // update the CP with the cached method
+			CP.CachedMethods = append(CP.CachedMethods, mtEntry)
+			CP.CpIndex[CPslot] = classloader.CpEntry{
+				Type: classloader.CachedMeth,
+				Slot: uint16(len(CP.CachedMethods) - 1)}
+			CP.Mutex.Unlock()
+			shouldCacheMeth = false
+		}
 	}
 
 	if mtEntry.MType == 'G' {


### PR DESCRIPTION
modified:   src/classloader/codeCheck.go

Also fixed JACOBIN-937 Stop Jacobin -XX:-cacheMethods crashes
modified: src/jvm/interpreter.go (doInvokestatic)