### PR TITLE
JACOBIN-945 dont call testing.Fatalf inside a go threaded function

### DIFF
--- a/src/classloader/classes_test.go
+++ b/src/classloader/classes_test.go
@@ -239,11 +239,10 @@ func TestFetchMethodAndCP_FoundInClassMethodTable(t *testing.T) {
 
 	klassName := "com/example/Owner"
 	// Build a class whose MethodTable contains the method
-	cp := CPool{}
 	kData := &ClData{
 		Name:        klassName,
 		MethodTable: make(map[string]*Method),
-		CP:          cp,
+		CP:          CPool{},
 	}
 	meth := &Method{AccessFlags: 0x1, CodeAttr: CodeAttrib{MaxStack: 2, MaxLocals: 1, Code: []byte{0xb1}}}
 	kData.MethodTable["doIt()V"] = meth

--- a/src/classloader/cpUtils_test.go
+++ b/src/classloader/cpUtils_test.go
@@ -251,7 +251,7 @@ func TestFetchCPentriesThatAreStructAddresses(t *testing.T) {
 		t.Errorf("Expected IS_STRUCT_ADDR, got %d", cp.RetType)
 	}
 
-	struc := *cp.AddrVal
+	struc := cp.AddrVal
 	if struc.entry1 != uint16(4) || struc.entry2 != 2 {
 		t.Errorf("Expected returned struc to contain 4 and 2, got %d and %d",
 			struc.entry1, struc.entry2)
@@ -269,7 +269,7 @@ func TestFetchCPentriesThatAreStructAddresses(t *testing.T) {
 		t.Errorf("Expected IS_STRUCT_ADDR, got %d", cp.RetType)
 	}
 
-	struc = *cp.AddrVal
+	struc = cp.AddrVal
 	if struc.entry1 != uint16(5) || struc.entry2 != uint16(3) {
 		t.Errorf("Expected returned struc to contain 5 and 3, got %d and %d",
 			struc.entry1, struc.entry2)
@@ -287,7 +287,7 @@ func TestFetchCPentriesThatAreStructAddresses(t *testing.T) {
 		t.Errorf("Expected IS_STRUCT_ADDR, got %d", cp.RetType)
 	}
 
-	struc = *cp.AddrVal
+	struc = cp.AddrVal
 	if struc.entry1 != uint16(20) || struc.entry2 != uint16(21) {
 		t.Errorf("Expected returned struc to contain 20 and 21, got %d and %d",
 			struc.entry1, struc.entry2)
@@ -305,7 +305,7 @@ func TestFetchCPentriesThatAreStructAddresses(t *testing.T) {
 		t.Errorf("Expected IS_STRUCT_ADDR, got %d", cp.RetType)
 	}
 
-	struc = *cp.AddrVal
+	struc = cp.AddrVal
 	if struc.entry1 != uint16(8) || struc.entry2 != uint16(9) {
 		t.Errorf("Expected returned struc to contain 8 and 9, got %d and %d",
 			struc.entry1, struc.entry2)
@@ -323,7 +323,7 @@ func TestFetchCPentriesThatAreStructAddresses(t *testing.T) {
 		t.Errorf("Expected IS_STRUCT_ADDR, got %d", cp.RetType)
 	}
 
-	struc = *cp.AddrVal
+	struc = cp.AddrVal
 	if struc.entry1 != uint16(10) || struc.entry2 != uint16(11) {
 		t.Errorf("Expected returned struc to contain 10 and 11, got %d and %d",
 			struc.entry1, struc.entry2)
@@ -341,7 +341,7 @@ func TestFetchCPentriesThatAreStructAddresses(t *testing.T) {
 		t.Errorf("Expected IS_STRUCT_ADDR, got %d", cp.RetType)
 	}
 
-	struc = *cp.AddrVal
+	struc = cp.AddrVal
 	if struc.entry1 != uint16(12) || struc.entry2 != uint16(13) {
 		t.Errorf("Expected returned struc to contain 12 and 13, got %d and %d",
 			struc.entry1, struc.entry2)

--- a/src/gfunction/javaLang/javaLangString_test.go
+++ b/src/gfunction/javaLang/javaLangString_test.go
@@ -164,7 +164,7 @@ func TestSprintf_2(t *testing.T) {
 
 	switch result.(type) {
 	case *ghelpers.GErrBlk:
-		geptr := *(result.(*ghelpers.GErrBlk))
+		geptr := result.(*ghelpers.GErrBlk)
 		errMsg := geptr.ErrMsg
 		t.Errorf("TestSprintf_2: %s\n", errMsg)
 	case *object.Object:
@@ -213,7 +213,7 @@ func TestSprintf_3(t *testing.T) {
 
 	switch result.(type) {
 	case *ghelpers.GErrBlk:
-		geptr := *(result.(*ghelpers.GErrBlk))
+		geptr := result.(*ghelpers.GErrBlk)
 		errMsg := geptr.ErrMsg
 		t.Errorf("TestSprintf_2: %s\n", errMsg)
 	case *object.Object:
@@ -791,7 +791,7 @@ func TestStringStripTrailing(t *testing.T) {
 
 	outputRaw := stringStripTrailing([]interface{}{input})
 
-	output := *outputRaw.(*object.Object)
+	output := outputRaw.(*object.Object)
 	strippedString :=
 		object.GoStringFromJavaByteArray(output.FieldTable["value"].Fvalue.([]types.JavaByte))
 	// strippedString := string(output.FieldTable["value"].Fvalue.([]byte))

--- a/src/gfunction/javaUtil/javaUtilArrays_test.go
+++ b/src/gfunction/javaUtil/javaUtilArrays_test.go
@@ -17,14 +17,14 @@ import (
 )
 
 func TestCopyOfObjectPointers_TooFewArguments(t *testing.T) {
-	result := *(utilArraysCopyOf([]interface{}{}).(*ghelpers.GErrBlk))
+	result := utilArraysCopyOf([]interface{}{}).(*ghelpers.GErrBlk)
 	if result.ExceptionType != excNames.IllegalArgumentException || result.ErrMsg != "utilArraysCopyOf: too few arguments" {
 		t.Errorf("Expected IllegalArgumentException for too few arguments")
 	}
 }
 
 func TestCopyOfObjectPointers_NullArray(t *testing.T) {
-	result := *(utilArraysCopyOf([]interface{}{nil, int64(5)}).(*ghelpers.GErrBlk))
+	result := utilArraysCopyOf([]interface{}{nil, int64(5)}).(*ghelpers.GErrBlk)
 	if result.ExceptionType != excNames.NullPointerException || result.ErrMsg != "utilArraysCopyOf: null array argument" {
 		t.Errorf("Expected NullPointerException for null array argument")
 	}
@@ -32,7 +32,7 @@ func TestCopyOfObjectPointers_NullArray(t *testing.T) {
 
 func TestCopyOfObjectPointers_NegativeLength(t *testing.T) {
 	obj := object.MakeEmptyObject()
-	result := *(utilArraysCopyOf([]interface{}{obj, int64(-1)}).(*ghelpers.GErrBlk))
+	result := utilArraysCopyOf([]interface{}{obj, int64(-1)}).(*ghelpers.GErrBlk)
 	if result.ExceptionType != excNames.NegativeArraySizeException || result.ErrMsg != "utilArraysCopyOf: negative array length" {
 		// if result != ghelpers.GetGErrBlk(excNames.NegativeArraySizeException, "copyOf: negative array length") {
 		t.Errorf("Expected NegativeArraySizeException for negative array length")

--- a/src/gfunction/javaUtil/javaUtilLinkedListFuncAtoQ_test.go
+++ b/src/gfunction/javaUtil/javaUtilLinkedListFuncAtoQ_test.go
@@ -27,7 +27,7 @@ func assertJavaBoolLL(t *testing.T, got interface{}, want int64, msg string) {
 	if !ok {
 		switch got.(type) {
 		case *ghelpers.GErrBlk:
-			errBlk := *got.(*ghelpers.GErrBlk)
+			errBlk := got.(*ghelpers.GErrBlk)
 			t.Fatalf("%s: expected Java boolean (int64), got ghelpers.GErrBlk %d (%s)", msg, errBlk.ExceptionType, errBlk.ErrMsg)
 		}
 		t.Fatalf("%s: expected Java boolean (int64), got %T", msg, got)

--- a/src/jvm/double_precision_repro_test.go
+++ b/src/jvm/double_precision_repro_test.go
@@ -13,14 +13,14 @@ func TestDoublePrecision(t *testing.T) {
 	f := newFrame(opcodes.DADD)
 	v1 := 1.0
 	v2 := 1e-15
-	push(&f, v1)
-	push(&f, v2)
+	push(f, v1)
+	push(f, v2)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	res := pop(&f).(float64)
+	res := pop(f).(float64)
 	fmt.Printf("DADD result: %v\n", res)
 	if res == 1.0 {
 		t.Errorf("DADD: lost precision, 1.0 + 1e-15 resulted in 1.0")
@@ -28,12 +28,12 @@ func TestDoublePrecision(t *testing.T) {
 
 	// DREM precision test
 	f = newFrame(opcodes.DREM)
-	push(&f, 1.0)
-	push(&f, 0.3)
+	push(f, 1.0)
+	push(f, 0.3)
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
-	res = pop(&f).(float64)
+	res = pop(f).(float64)
 	fmt.Printf("DREM result: %v\n", res)
 	// 1.0 % 0.3 should be 0.1 (roughly)
 	if float32(res) != float32(1.0-0.9) {
@@ -45,13 +45,13 @@ func TestD2fConversion(t *testing.T) {
 	f := newFrame(opcodes.D2F)
 	// A value that changes when converted to float32
 	v := 1.0000000000000002
-	push(&f, v)
+	push(f, v)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	res := pop(&f).(float64)
+	res := pop(f).(float64)
 	fmt.Printf("D2F result: %v\n", res)
 	if res == v {
 		t.Errorf("D2F: failed to round to float32 precision")
@@ -70,14 +70,14 @@ func TestF2dConversion(t *testing.T) {
 	f := newFrame(opcodes.FADD)
 	v1 := float64(float32(1.0))
 	v2 := float64(float32(1e-16))
-	push(&f, v1)
-	push(&f, v2)
+	push(f, v1)
+	push(f, v2)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	res := pop(&f).(float64)
+	res := pop(f).(float64)
 	if res != 1.0 {
 		t.Errorf("FADD: expected 1.0 due to float32 precision limits, got %v", res)
 	}

--- a/src/jvm/gfunctionExec_test.go
+++ b/src/jvm/gfunctionExec_test.go
@@ -86,7 +86,7 @@ func TestGfunctionExecValid(t *testing.T) {
 	f.TOS = 0
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -193,7 +193,7 @@ func TestGfuncINVOKEVIRTUALwith1stringArgtemplate(t *testing.T) {
 	f.TOS = 0
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// get contents written by stderr and stdout, then

--- a/src/jvm/interpreter_A-E_test.go
+++ b/src/jvm/interpreter_A-E_test.go
@@ -31,11 +31,11 @@ import (
 
 // set up function to create a frame with a method with the single instruction
 // that's being tested
-func newFrame(code byte) frames.Frame {
+func newFrame(code byte) *frames.Frame {
 	f := frames.CreateFrame(6)
 	f.Ftype = 'J'
 	f.Meth = append(f.Meth, code)
-	return *f
+	return f
 }
 
 var zero = int64(0)
@@ -55,9 +55,9 @@ func validateFloatingPoint(t *testing.T, op string, expected float64, actual flo
 func TestNewAconstNull(t *testing.T) {
 	f := newFrame(opcodes.ACONST_NULL)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	x := peek(&f)
+	x := peek(f)
 	if x != object.Null {
 		t.Errorf("ACONST_NULL: Expecting nil on stack, got: %d", x)
 	}
@@ -77,9 +77,9 @@ func TestNewAload(t *testing.T) {
 	f.Locals = append(f.Locals, int64(0x1234562)) // put value in locals[4]
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	x := pop(&f).(int64)
+	x := pop(f).(int64)
 	if x != 0x1234562 {
 		t.Errorf("ALOAD: Expecting 0x1234562 on stack, got: 0x%x", x)
 	}
@@ -97,9 +97,9 @@ func TestNewAload0(t *testing.T) {
 	f.Locals = append(f.Locals, int64(0x1234560)) // put value in locals[0]
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	x := pop(&f).(int64)
+	x := pop(f).(int64)
 	if x != 0x1234560 {
 		t.Errorf("ALOAD_0: Expecting 0x1234560 on stack, got: 0x%x", x)
 	}
@@ -115,9 +115,9 @@ func TestNewAload1(t *testing.T) {
 	f.Locals = append(f.Locals, int64(0x1234561)) // put value in locals[1]
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	x := pop(&f).(int64)
+	x := pop(f).(int64)
 	if x != 0x1234561 {
 		t.Errorf("ALOAD_1: Expecting 0x1234561 on stack, got: 0x%x", x)
 	}
@@ -134,9 +134,9 @@ func TestNewAload2(t *testing.T) {
 	f.Locals = append(f.Locals, int64(0x1234562)) // put value in locals[2]
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	x := pop(&f).(int64)
+	x := pop(f).(int64)
 	if x != 0x1234562 {
 		t.Errorf("ALOAD_2: Expecting 0x1234562 on stack, got: 0x%x", x)
 	}
@@ -154,9 +154,9 @@ func TestNewAload3(t *testing.T) {
 	f.Locals = append(f.Locals, int64(0x1234563)) // put value in locals[3]
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	x := pop(&f).(int64)
+	x := pop(f).(int64)
 	if x != 0x1234563 {
 		t.Errorf("ALOAD_3: Expecting 0x1234563 on stack, got: 0x%x", x)
 	}
@@ -168,15 +168,15 @@ func TestNewAload3(t *testing.T) {
 // ARETURN: Return a long from a function
 func TestNewAreturn(t *testing.T) {
 	f0 := newFrame(0)
-	push(&f0, unsafe.Pointer(&f0))
+	push(f0, unsafe.Pointer(f0))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f0)
+	fs.PushFront(f0)
 
 	// create a new frame which does an ARETURN of pointer to f1
 	f1 := newFrame(opcodes.ARETURN)
-	push(&f1, unsafe.Pointer(&f1))
-	fs.PushFront(&f1)
+	push(f1, unsafe.Pointer(f1))
+	fs.PushFront(f1)
 	interpret(fs)
 
 	// now that the ARETURN has completed, pop that frame (the one that did the ARETURN)
@@ -185,7 +185,7 @@ func TestNewAreturn(t *testing.T) {
 	// and see whether the pointer at the frame's top of stack points to f1
 	f2 := fs.Front().Value.(*frames.Frame)
 	newVal := pop(f2).(unsafe.Pointer)
-	if newVal != unsafe.Pointer(&f1) {
+	if newVal != unsafe.Pointer(f1) {
 		t.Error("ARETURN: did not get expected value of reference")
 	}
 }
@@ -199,10 +199,10 @@ func TestNewAstore(t *testing.T) {
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
-	push(&f, int64(0x22223))
+	push(f, int64(0x22223))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.Locals[3] != int64(0x22223) {
@@ -222,9 +222,9 @@ func TestAstoreWide(t *testing.T) {
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
 	f.WideInEffect = true
-	push(&f, int64(0x1111))
+	push(f, int64(0x1111))
 
-	ret := doAstore(&f, int64(0))
+	ret := doAstore(f, int64(0))
 	if ret != 3 {
 		t.Errorf("ASTORE: Expecting f.PC increment of 3, got: %d", ret)
 	}
@@ -238,10 +238,10 @@ func TestAstoreWide(t *testing.T) {
 func TestNewAstore0(t *testing.T) {
 	f := newFrame(opcodes.ASTORE_0)
 	f.Locals = append(f.Locals, zero)
-	push(&f, int64(0x22220))
+	push(f, int64(0x22220))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.Locals[0] != int64(0x22220) {
@@ -257,10 +257,10 @@ func TestAstore1(t *testing.T) {
 	f := newFrame(opcodes.ASTORE_1)
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
-	push(&f, int64(0x22221))
+	push(f, int64(0x22221))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.Locals[1] != int64(0x22221) {
@@ -277,10 +277,10 @@ func TestAstore2(t *testing.T) {
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
-	push(&f, int64(0x22222))
+	push(f, int64(0x22222))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.Locals[2] != int64(0x22222) {
@@ -298,10 +298,10 @@ func TestAstore3(t *testing.T) {
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
-	push(&f, int64(0x22223))
+	push(f, int64(0x22223))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.Locals[3] != int64(0x22223) {
@@ -323,10 +323,10 @@ func TestAthrow_NullRef(t *testing.T) {
 
 	f := newFrame(opcodes.ATHROW)
 	// Push a typed null *object.Object
-	push(&f, object.Null)
+	push(f, object.Null)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -386,10 +386,10 @@ func TestAthrow_Uncaught_WithJavaByteMessage(t *testing.T) {
 		Fvalue: makeStackTraceArray([]*object.Object{ste1, steFiltered, ste2}),
 	}
 
-	push(&f, ex)
+	push(f, ex)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -439,10 +439,10 @@ func TestAthrow_Uncaught_WithStringObjectMessageBytes(t *testing.T) {
 	ste := makeSTE("pkg/Clazz", "run", "Main.java", "42")
 	ex.FieldTable["stackTrace"] = object.Field{Ftype: "[Ljava/lang/Object;", Fvalue: makeStackTraceArray([]*object.Object{ste})}
 
-	push(&f, ex)
+	push(f, ex)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -465,12 +465,12 @@ func TestNewBipush(t *testing.T) {
 	f := newFrame(opcodes.BIPUSH)
 	f.Meth = append(f.Meth, 0x05)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("BIPUSH: Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 5 {
 		t.Errorf("BIPUSH: Expected popped value to be 5, got: %d", value)
 	}
@@ -482,12 +482,12 @@ func TestNewBipushNeg(t *testing.T) {
 	val := -5
 	f.Meth = append(f.Meth, byte(val))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("BIPUSH: Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != -5 {
 		t.Errorf("BIPUSH: Expected popped value to be -5, got: %d", value)
 	}
@@ -525,13 +525,13 @@ func TestNewCheckcastOfString(t *testing.T) {
 	CP.ClassRefs = append(CP.ClassRefs, types.StringPoolStringIndex) // point to string pool entry
 	f.CP = &CP
 
-	push(&f, s)
+	push(f, s)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(*object.Object)
+	value := pop(f).(*object.Object)
 	if value != s { // if the stack is unchanged, we got a match
 		t.Errorf(" CHECKCAST: Expected stack not found on successful check")
 	}
@@ -554,10 +554,10 @@ func TestNewCheckcastOfNil(t *testing.T) {
 		}))
 
 	f := newFrame(opcodes.CHECKCAST)
-	push(&f, nil) // this should cause the error
+	push(f, nil) // this should cause the error
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != 0 {
@@ -577,10 +577,10 @@ func TestNewCheckcastOfNull(t *testing.T) {
 	trace.Init()
 
 	f := newFrame(opcodes.CHECKCAST)
-	push(&f, object.Null) // this should cause the error
+	push(f, object.Null) // this should cause the error
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != 0 {
@@ -605,10 +605,10 @@ func TestNewCheckcastOfInvalidReference(t *testing.T) {
 	os.Stderr = w
 
 	f := newFrame(opcodes.CHECKCAST)
-	push(&f, float64(42.0)) // this should cause the error
+	push(f, float64(42.0)) // this should cause the error
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -633,13 +633,13 @@ func TestNewCheckcastOfInvalidReference(t *testing.T) {
 // D2F: test convert double to float
 func TestNewD2f(t *testing.T) {
 	f := newFrame(opcodes.D2F)
-	push(&f, 2.9)
+	push(f, 2.9)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	val := pop(&f).(float64)
+	val := pop(f).(float64)
 	if math.Abs(val-2.9) > maxFloatDiff {
 		t.Errorf("D2F: expected a result of 2.9, but got: %f", val)
 	}
@@ -651,13 +651,13 @@ func TestNewD2f(t *testing.T) {
 // D2I: test convert double to int, positive
 func TestNewD2iPositive(t *testing.T) {
 	f := newFrame(opcodes.D2I)
-	push(&f, 2.9)
+	push(f, 2.9)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	val := pop(&f).(int64)
+	val := pop(f).(int64)
 	if val != 2 {
 		t.Errorf("D2I: expected a result of 2, but got: %d", val)
 	}
@@ -669,13 +669,13 @@ func TestNewD2iPositive(t *testing.T) {
 // D2I: test convert double to int, negative
 func TestNewD2iNegative(t *testing.T) {
 	f := newFrame(opcodes.D2I)
-	push(&f, -2.9)
+	push(f, -2.9)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	val := pop(&f).(int64)
+	val := pop(f).(int64)
 	if val != -2 {
 		t.Errorf("D2I: expected a result of -2, but got: %d", val)
 	}
@@ -687,13 +687,13 @@ func TestNewD2iNegative(t *testing.T) {
 // D2L: test convert double to long, positive
 func TestNewD2lPositive(t *testing.T) {
 	f := newFrame(opcodes.D2L)
-	push(&f, 2.9)
+	push(f, 2.9)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	val := pop(&f).(int64)
+	val := pop(f).(int64)
 	if val != 2 {
 		t.Errorf("D2L: expected a result of 2, but got: %d", val)
 	}
@@ -705,13 +705,13 @@ func TestNewD2lPositive(t *testing.T) {
 // D2L: test convert double to long, negative
 func TestNewD2lNegative(t *testing.T) {
 	f := newFrame(opcodes.D2L)
-	push(&f, -2.9)
+	push(f, -2.9)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	val := pop(&f).(int64)
+	val := pop(f).(int64)
 	if val != -2 {
 		t.Errorf("D2L: expected a result of -2, but got: %d", val)
 	}
@@ -723,14 +723,14 @@ func TestNewD2lNegative(t *testing.T) {
 // DADD: test add two doubles
 func TestNewDadd(t *testing.T) {
 	f := newFrame(opcodes.DADD)
-	push(&f, 15.3)
-	push(&f, 22.1)
+	push(f, 15.3)
+	push(f, 22.1)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	val := pop(&f).(float64)
+	val := pop(f).(float64)
 	validateFloatingPoint(t, "DADD", 37.4, val)
 	if f.TOS != -1 {
 		t.Errorf("DADD: Expected stack with 0 items, but got a TOS of: %d", f.TOS)
@@ -740,14 +740,14 @@ func TestNewDadd(t *testing.T) {
 // DADD: test add two doubles, one is NaN
 func TestNewDaddNan(t *testing.T) {
 	f := newFrame(opcodes.DADD)
-	push(&f, 15.3)
-	push(&f, math.NaN())
+	push(f, 15.3)
+	push(f, math.NaN())
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	val := pop(&f).(float64)
+	val := pop(f).(float64)
 
 	if !math.IsNaN(val) {
 		t.Errorf("DADD: Expected NaN, got: %f", val)
@@ -761,14 +761,14 @@ func TestNewDaddNan(t *testing.T) {
 // DADD: test add two doubles, one is Inf
 func TestNewDaddInf(t *testing.T) {
 	f := newFrame(opcodes.DADD)
-	push(&f, 15.3)
-	push(&f, math.Inf(1))
+	push(f, 15.3)
+	push(f, math.Inf(1))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	val := pop(&f).(float64)
+	val := pop(f).(float64)
 
 	if !math.IsInf(val, 1) {
 		t.Errorf("DADD: Expected Inf, got: %f", val)
@@ -782,14 +782,14 @@ func TestNewDaddInf(t *testing.T) {
 // DCMP0: compare two doubles, 1 on NaN
 func TestNewDcmpg1(t *testing.T) {
 	f := newFrame(opcodes.DCMPG)
-	push(&f, 3.0)
-	push(&f, 2.0)
+	push(f, 3.0)
+	push(f, 2.0)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 
 	if value != 1 {
 		t.Errorf("DCMPG: Expected value to be 1, got: %d", value)
@@ -803,14 +803,14 @@ func TestNewDcmpg1(t *testing.T) {
 // DCMPG: compare two doubles
 func TestNewDcmpgMinus1(t *testing.T) {
 	f := newFrame(opcodes.DCMPG)
-	push(&f, 2.0)
-	push(&f, 3.0)
+	push(f, 2.0)
+	push(f, 3.0)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 
 	if value != -1 {
 		t.Errorf("DCMPG: Expected value to be -1, got: %d", value)
@@ -824,14 +824,14 @@ func TestNewDcmpgMinus1(t *testing.T) {
 // DCMP0: compare two doubles
 func TestNewDcmpg0(t *testing.T) {
 	f := newFrame(opcodes.DCMPG)
-	push(&f, 3.0)
-	push(&f, 3.0)
+	push(f, 3.0)
+	push(f, 3.0)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 
 	if value != 0 {
 		t.Errorf("DCMPG: Expected value to be 0, got: %d", value)
@@ -844,14 +844,14 @@ func TestNewDcmpg0(t *testing.T) {
 
 func TestNewDcmpgNan(t *testing.T) {
 	f := newFrame(opcodes.DCMPG)
-	push(&f, math.NaN())
-	push(&f, 3.0)
+	push(f, math.NaN())
+	push(f, 3.0)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 
 	if value != 1 {
 		t.Errorf("DCMPG: Expected value to be 1, got: %d", value)
@@ -865,14 +865,14 @@ func TestNewDcmpgNan(t *testing.T) {
 // DCMPL
 func TestNewDcmplNan(t *testing.T) {
 	f := newFrame(opcodes.DCMPL)
-	push(&f, math.NaN())
-	push(&f, 3.0)
+	push(f, math.NaN())
+	push(f, 3.0)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 
 	if value != -1 {
 		t.Errorf("DCMPL: Expected value to be -1, got: %d", value)
@@ -887,10 +887,10 @@ func TestNewDcmplNan(t *testing.T) {
 func TestNewDconst0(t *testing.T) {
 	f := newFrame(opcodes.DCONST_0)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 
 	if value != 0.0 {
 		t.Errorf("DCONST_0: Expected popped value to be 0.0, got: %f", value)
@@ -905,10 +905,10 @@ func TestNewDconst0(t *testing.T) {
 func TestNewDconst1(t *testing.T) {
 	f := newFrame(opcodes.DCONST_1)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	if value != 1.0 {
 		t.Errorf("DCONST_1: Expected popped value to be 1.0, got: %f", value)
 	}
@@ -921,14 +921,14 @@ func TestNewDconst1(t *testing.T) {
 // DDIV: double divide of.TOS-1 by tos, push result
 func TestNewDdiv(t *testing.T) {
 	f := newFrame(opcodes.DDIV)
-	push(&f, 3.0)
-	push(&f, 2.0)
+	push(f, 3.0)
+	push(f, 2.0)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	validateFloatingPoint(t, "DDIV", 1.5, value)
 	if f.TOS != -1 {
 		t.Errorf("DDIV: Expected stack with 0 items, but got a TOS of: %d", f.TOS)
@@ -938,13 +938,13 @@ func TestNewDdiv(t *testing.T) {
 // DDIV: with divide zero by zero, should = NaN
 func TestNewDdivDivideZeroByZero(t *testing.T) {
 	f := newFrame(opcodes.DDIV)
-	push(&f, float64(0))
-	push(&f, float64(0))
+	push(f, float64(0))
+	push(f, float64(0))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	ret := pop(&f)
+	ret := pop(f)
 
 	if !math.IsNaN(ret.(float64)) {
 		t.Errorf("DDIV: Did not get an expected NaN")
@@ -954,13 +954,13 @@ func TestNewDdivDivideZeroByZero(t *testing.T) {
 // DDIV: with divide positive number by zero, should = +Inf
 func TestNewDdivDividePosNumberByZero(t *testing.T) {
 	f := newFrame(opcodes.DDIV)
-	push(&f, float64(10))
-	push(&f, float64(0))
+	push(f, float64(10))
+	push(f, float64(0))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	ret := pop(&f)
+	ret := pop(f)
 
 	if !math.IsInf(ret.(float64), 1) {
 		t.Errorf("DDIV: Did not get an expected +Infinity")
@@ -978,9 +978,9 @@ func TestNewDload(t *testing.T) {
 	f.Locals = append(f.Locals, float64(0x1234562)) // put value in locals[4]
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	x := pop(&f).(float64)
+	x := pop(f).(float64)
 	if x != float64(0x1234562) {
 		t.Errorf("DLOAD: Expecting 0x1234562 on stack, got: 0x%x", x)
 	}
@@ -998,10 +998,10 @@ func TestNewDload0(t *testing.T) {
 	f.Locals = append(f.Locals, 1.2)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	validateFloatingPoint(t, "DLOAD_0", 1.2, value)
 
 	if f.TOS != -1 {
@@ -1016,10 +1016,10 @@ func TestNewDload1(t *testing.T) {
 	f.Locals = append(f.Locals, 1.2)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	validateFloatingPoint(t, "DLOAD_1", 1.2, value)
 
 	if f.TOS != -1 {
@@ -1035,10 +1035,10 @@ func TestNewDload2(t *testing.T) {
 	f.Locals = append(f.Locals, 1.2)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	validateFloatingPoint(t, "DLOAD_2", 1.2, value)
 
 	if f.TOS != -1 {
@@ -1055,10 +1055,10 @@ func TestNewDload3(t *testing.T) {
 	f.Locals = append(f.Locals, 1.2)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	validateFloatingPoint(t, "DLOAD_3", 1.2, value)
 
 	if f.TOS != -1 {
@@ -1069,14 +1069,14 @@ func TestNewDload3(t *testing.T) {
 // DMUL (pop 2 doubles, multiply them, push result)
 func TestNewDmul(t *testing.T) {
 	f := newFrame(opcodes.DMUL)
-	push(&f, 1.5)
-	push(&f, 2.0)
+	push(f, 1.5)
+	push(f, 2.0)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	validateFloatingPoint(t, "DMUL", 3.0, pop(&f).(float64))
+	validateFloatingPoint(t, "DMUL", 3.0, pop(f).(float64))
 
 	if f.TOS != -1 {
 		t.Errorf("DMUL, Top of stack, expected 0, got: %d", f.TOS)
@@ -1086,13 +1086,13 @@ func TestNewDmul(t *testing.T) {
 // DNEG Negate a double
 func TestNewDneg(t *testing.T) {
 	f := newFrame(opcodes.DNEG)
-	push(&f, 1.5)
+	push(f, 1.5)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	validateFloatingPoint(t, "DNEG", -1.5, pop(&f).(float64))
+	validateFloatingPoint(t, "DNEG", -1.5, pop(f).(float64))
 
 	if f.TOS != -1 {
 		t.Errorf("DNEG, Top of stack, expected 0, got: %d", f.TOS)
@@ -1102,13 +1102,13 @@ func TestNewDneg(t *testing.T) {
 // DNEG Negate a double - infinity
 func TestNewDnegInf(t *testing.T) {
 	f := newFrame(opcodes.DNEG)
-	push(&f, math.Inf(1))
+	push(f, math.Inf(1))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	val := pop(&f).(float64)
+	val := pop(f).(float64)
 
 	if math.Inf(-1) != val {
 		t.Errorf("Expected negative infinity, got %f", val)
@@ -1122,18 +1122,18 @@ func TestNewDnegInf(t *testing.T) {
 // DREM: remainder of float division (the % operator)
 func TestNewDrem(t *testing.T) {
 	f := newFrame(opcodes.DREM)
-	push(&f, 23.5)
-	push(&f, 3.3)
+	push(f, 23.5)
+	push(f, 3.3)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != 0 {
 		t.Errorf("DREM, Top of stack, expected 0, got: %d", f.TOS)
 	}
 
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	if math.Abs(value-0.40000033) > maxFloatDiff {
 		t.Errorf("DREM: Expected popped value to be 0.40000033, got: %f", value)
 	}
@@ -1142,12 +1142,12 @@ func TestNewDrem(t *testing.T) {
 // DRETURN: Return a long from a function
 func TestNewDreturn(t *testing.T) {
 	f0 := newFrame(0)
-	push(&f0, float64(20))
+	push(f0, float64(20))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f0)
+	fs.PushFront(f0)
 	f1 := newFrame(opcodes.DRETURN)
-	push(&f1, float64(21))
-	fs.PushFront(&f1)
+	push(f1, float64(21))
+	fs.PushFront(f1)
 	interpret(fs)
 
 	f3 := fs.Front().Value.(*frames.Frame)
@@ -1171,9 +1171,9 @@ func TestNewDstore(t *testing.T) {
 	f.Locals = append(f.Locals, zerof)
 	f.Locals = append(f.Locals, zerof)
 
-	push(&f, float64(0x22223))
+	push(f, float64(0x22223))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.Locals[2] != float64(0x22223) {
@@ -1190,10 +1190,10 @@ func TestNewDstore0(t *testing.T) {
 	f := newFrame(opcodes.DSTORE_0)
 	f.Locals = append(f.Locals, 0.0)
 	f.Locals = append(f.Locals, 0.0)
-	push(&f, 1.0)
+	push(f, 1.0)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.Locals[0].(float64) != 1.0 {
@@ -1211,10 +1211,10 @@ func TestNewDstore1(t *testing.T) {
 	f.Locals = append(f.Locals, 0.0)
 	f.Locals = append(f.Locals, 0.0)
 	f.Locals = append(f.Locals, 0.0)
-	push(&f, 1.0)
+	push(f, 1.0)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.Locals[1].(float64) != 1.0 {
@@ -1233,10 +1233,10 @@ func TestNewDstore2(t *testing.T) {
 	f.Locals = append(f.Locals, 0.0)
 	f.Locals = append(f.Locals, 0.0)
 	f.Locals = append(f.Locals, 0.0)
-	push(&f, 1.0)
+	push(f, 1.0)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.Locals[2].(float64) != 1.0 {
@@ -1256,10 +1256,10 @@ func TestNewDstore3(t *testing.T) {
 	f.Locals = append(f.Locals, 0.0)
 	f.Locals = append(f.Locals, 0.0)
 	f.Locals = append(f.Locals, 0.0)
-	push(&f, 1.0)
+	push(f, 1.0)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.Locals[3].(float64) != 1.0 {
@@ -1274,14 +1274,14 @@ func TestNewDstore3(t *testing.T) {
 // DSUB: double subtraction
 func TestNewDsub(t *testing.T) {
 	f := newFrame(opcodes.DSUB)
-	push(&f, 1.0)
-	push(&f, 0.7)
+	push(f, 1.0)
+	push(f, 0.7)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 
 	if math.Abs(value-0.3) > maxFloatDiff {
 		t.Errorf("DSUB: Expected popped value to be 0.3, got: %f", value)
@@ -1295,17 +1295,17 @@ func TestNewDsub(t *testing.T) {
 // DUP: Push a duplicate of the top item on the stack
 func TestNewDup(t *testing.T) {
 	f := newFrame(opcodes.DUP)
-	push(&f, int64(0x22223))
+	push(f, int64(0x22223))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS < 1 {
 		t.Errorf("DUP: stack should have two elements with tos > 0, tos was: %d", f.TOS)
 	}
 
-	a := pop(&f).(int64)
-	b := pop(&f).(int64)
+	a := pop(f).(int64)
+	b := pop(f).(int64)
 	if a != 0x22223 || b != 0x22223 {
 		t.Errorf(
 			"DUP: popped values are incorrect. Expecting 0x22223, got: %X and %X", a, b)
@@ -1315,21 +1315,21 @@ func TestNewDup(t *testing.T) {
 // DUP2: Push duplicate of the top two items on the stack
 func TestNewDup2(t *testing.T) {
 	f := newFrame(opcodes.DUP2)
-	push(&f, int64(0x22))
-	push(&f, int64(0x11)) // this is TOS
+	push(f, int64(0x22))
+	push(f, int64(0x11)) // this is TOS
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != 3 {
 		t.Errorf("DUP2: stack should have four elements, got tos was: %d", f.TOS)
 	}
 
-	a := pop(&f).(int64)
-	b := pop(&f).(int64)
-	c := pop(&f).(int64)
-	d := pop(&f).(int64)
+	a := pop(f).(int64)
+	b := pop(f).(int64)
+	c := pop(f).(int64)
+	d := pop(f).(int64)
 	if a != 0x11 || c != 0x11 {
 		t.Errorf(
 			"DUP2: popped values are incorrect. Expecting 0x11, got: %X and %X", a, c)
@@ -1343,20 +1343,20 @@ func TestNewDup2(t *testing.T) {
 // DUP_X1: Duplicate the top stack value and insert it two slots down
 func TestNewDupX1(t *testing.T) {
 	f := newFrame(opcodes.DUP_X1)
-	push(&f, int64(0x3))
-	push(&f, int64(0x2))
-	push(&f, int64(0x1))
+	push(f, int64(0x3))
+	push(f, int64(0x2))
+	push(f, int64(0x1))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != 3 {
 		t.Errorf("DUP_X1: Expecting a top of stack = 3 (so stack size 4), got: %d", f.TOS)
 	}
 
-	a := pop(&f).(int64)
-	b := pop(&f).(int64)
-	c := pop(&f).(int64)
+	a := pop(f).(int64)
+	b := pop(f).(int64)
+	c := pop(f).(int64)
 	if a != 1 || c != 1 {
 		t.Errorf(
 			"DUP_X1: popped values are incorrect. Expecting value of 1, got: %X and %X", a, b)
@@ -1366,21 +1366,21 @@ func TestNewDupX1(t *testing.T) {
 // DUP_X2: Duplicate the top stack value and insert it three slots down
 func TestNewDupX2(t *testing.T) {
 	f := newFrame(opcodes.DUP_X2)
-	push(&f, int64(0x3))
-	push(&f, int64(0x2))
-	push(&f, int64(0x1)) // this will be the dup'ed value
+	push(f, int64(0x3))
+	push(f, int64(0x2))
+	push(f, int64(0x1)) // this will be the dup'ed value
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != 3 {
 		t.Errorf("DUP_X2: Expecting a top of stack = 3 (so stack size 4), got: %d", f.TOS)
 	}
 
-	a := pop(&f).(int64)
-	pop(&f)
-	pop(&f)
-	d := pop(&f).(int64)
+	a := pop(f).(int64)
+	pop(f)
+	pop(f)
+	d := pop(f).(int64)
 	if a != 1 || d != 1 {
 		t.Errorf(
 			"DUP_X2: popped values are incorrect. Expecting value of 1, got: %X and %X", a, d)
@@ -1390,21 +1390,21 @@ func TestNewDupX2(t *testing.T) {
 // DUP2_X1: Duplicate the top 2 stack values and insert them 3 slots down
 func TestNewDup2X1(t *testing.T) {
 	f := newFrame(opcodes.DUP2_X1)
-	push(&f, int64(0x3))
-	push(&f, int64(0x2))
-	push(&f, int64(0x1)) // this is nowdir TOS
+	push(f, int64(0x3))
+	push(f, int64(0x2))
+	push(f, int64(0x1)) // this is nowdir TOS
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != 4 {
 		t.Errorf("DUP2_X1: Expecting a top of stack = 4 (so stack size 5), got: %d", f.TOS)
 	}
 
-	a := pop(&f).(int64)
-	pop(&f)
-	pop(&f)
-	d := pop(&f).(int64)
+	a := pop(f).(int64)
+	pop(f)
+	pop(f)
+	d := pop(f).(int64)
 	if a != 1 || d != 1 {
 		t.Errorf(
 			"DUP2_X1: popped values are incorrect. Expecting value of 1, got: %X and %X", a, d)
@@ -1414,23 +1414,23 @@ func TestNewDup2X1(t *testing.T) {
 // DUP2_X1: Duplicate the top 2 stack values and insert them 4 slots down
 func TestNewDup2X2(t *testing.T) {
 	f := newFrame(opcodes.DUP2_X2)
-	push(&f, int64(0x4))
-	push(&f, int64(0x3))
-	push(&f, int64(0x2))
-	push(&f, int64(0x1)) // this is now TOS
+	push(f, int64(0x4))
+	push(f, int64(0x3))
+	push(f, int64(0x2))
+	push(f, int64(0x1)) // this is now TOS
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != 5 {
 		t.Errorf("DUP2_X2: Expecting a top of stack = 5 (so stack size 6), got: %d", f.TOS)
 	}
 
-	a := pop(&f).(int64)
-	pop(&f)
-	pop(&f)
-	pop(&f)
-	e := pop(&f).(int64)
+	a := pop(f).(int64)
+	pop(f)
+	pop(f)
+	pop(f)
+	e := pop(f).(int64)
 	if a != 1 || e != 1 {
 		t.Errorf(
 			"DUP2_X2: popped values are incorrect. Expecting value of 1, got: %X and %X", a, e)

--- a/src/jvm/interpreter_F-IF_test.go
+++ b/src/jvm/interpreter_F-IF_test.go
@@ -33,13 +33,13 @@ import (
 // F2D: test convert float to double
 func TestNewF2d(t *testing.T) {
 	f := newFrame(opcodes.F2D)
-	push(&f, 2.0)
+	push(f, 2.0)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	val := pop(&f).(float64)
+	val := pop(f).(float64)
 	if val != 2.0 {
 		t.Errorf("F2D: expected a result of 2.0, but got: %f", val)
 	}
@@ -51,13 +51,13 @@ func TestNewF2d(t *testing.T) {
 // F2I: test convert float to int
 func TestNewF2iPositive(t *testing.T) {
 	f := newFrame(opcodes.F2I)
-	push(&f, 2.9)
+	push(f, 2.9)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	val := pop(&f).(int64)
+	val := pop(f).(int64)
 	if val != 2 {
 		t.Errorf("F2I: expected a result of 2, but got: %d", val)
 	}
@@ -68,13 +68,13 @@ func TestNewF2iPositive(t *testing.T) {
 
 func TestNewF2iNegative(t *testing.T) {
 	f := newFrame(opcodes.F2I)
-	push(&f, -2.9)
+	push(f, -2.9)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	val := pop(&f).(int64)
+	val := pop(f).(int64)
 	if val != -2 {
 		t.Errorf("F2I: expected a result of 2, but got: %d", val)
 	}
@@ -86,13 +86,13 @@ func TestNewF2iNegative(t *testing.T) {
 // F2L: test convert float to long
 func TestNewF2l(t *testing.T) {
 	f := newFrame(opcodes.F2L)
-	push(&f, 2.0)
+	push(f, 2.0)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	val := pop(&f).(int64)
+	val := pop(f).(int64)
 	if val != 2 {
 		t.Errorf("F2L: expected a result of 2.0, but got: %d", val)
 	}
@@ -104,12 +104,12 @@ func TestNewF2l(t *testing.T) {
 // FADD: Add two floats
 func TestNewFadd(t *testing.T) {
 	f := newFrame(opcodes.FADD)
-	push(&f, 2.1)
-	push(&f, 3.1)
+	push(f, 2.1)
+	push(f, 3.1)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	if math.Abs(value-5.2) > maxFloatDiff {
 		t.Errorf("FADD: expected a result of 5.2, but got: %f", value)
 	}
@@ -121,14 +121,14 @@ func TestNewFadd(t *testing.T) {
 // FCMPG: compare two floats
 func TestNewFcmpg1(t *testing.T) {
 	f := newFrame(opcodes.FCMPG)
-	push(&f, 3.0)
-	push(&f, 2.0)
+	push(f, 3.0)
+	push(f, 2.0)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 
 	if value != 1 {
 		t.Errorf("FCMPG: Expected value to be 1, got: %d", value)
@@ -142,14 +142,14 @@ func TestNewFcmpg1(t *testing.T) {
 // FCMPG: compare two floats
 func TestNewFcmpgMinus1(t *testing.T) {
 	f := newFrame(opcodes.FCMPG)
-	push(&f, 2.0)
-	push(&f, 3.0)
+	push(f, 2.0)
+	push(f, 3.0)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 
 	if value != -1 {
 		t.Errorf("FCMPG: Expected value to be -1, got: %d", value)
@@ -163,14 +163,14 @@ func TestNewFcmpgMinus1(t *testing.T) {
 // FCMPG: compare two floats
 func TestNewFcmpg0(t *testing.T) {
 	f := newFrame(opcodes.FCMPG)
-	push(&f, 3.0)
-	push(&f, 3.0)
+	push(f, 3.0)
+	push(f, 3.0)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 
 	if value != 0 {
 		t.Errorf("FCMPG: Expected value to be 0, got: %d", value)
@@ -184,14 +184,14 @@ func TestNewFcmpg0(t *testing.T) {
 // FCMPG
 func TestNewFcmpgNan(t *testing.T) {
 	f := newFrame(opcodes.FCMPG)
-	push(&f, math.NaN())
-	push(&f, 3.0)
+	push(f, math.NaN())
+	push(f, 3.0)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 
 	if value != 1 {
 		t.Errorf("FCMPG: Expected value to be 1, got: %d", value)
@@ -205,14 +205,14 @@ func TestNewFcmpgNan(t *testing.T) {
 // FCMPL
 func TestNewFcmplNan(t *testing.T) {
 	f := newFrame(opcodes.FCMPL)
-	push(&f, math.NaN())
-	push(&f, 3.0)
+	push(f, math.NaN())
+	push(f, 3.0)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 
 	if value != -1 {
 		t.Errorf("FCMPL: Expected value to be -1, got: %d", value)
@@ -227,12 +227,12 @@ func TestNewFcmplNan(t *testing.T) {
 func TestNewFconst0(t *testing.T) {
 	f := newFrame(opcodes.FCONST_0)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	if value != 0.0 {
 		t.Errorf("FCONST_0: Expected popped value to be 0.0, got: %f", value)
 	}
@@ -242,12 +242,12 @@ func TestNewFconst0(t *testing.T) {
 func TestNewFconst1(t *testing.T) {
 	f := newFrame(opcodes.FCONST_1)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	if value != 1.0 {
 		t.Errorf("FCONST_1: Expected popped value to be 1.0, got: %f", value)
 	}
@@ -257,12 +257,12 @@ func TestNewFconst1(t *testing.T) {
 func TestNewFconst2(t *testing.T) {
 	f := newFrame(opcodes.FCONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	if value != 2.0 {
 		t.Errorf("FCONST_2: Expected popped value to be 2.0, got: %f", value)
 	}
@@ -271,12 +271,12 @@ func TestNewFconst2(t *testing.T) {
 // FDIV: float divide of.TOS-1 by tos, push result
 func TestNewFdiv(t *testing.T) {
 	f := newFrame(opcodes.FDIV)
-	push(&f, 3.0)
-	push(&f, 2.0)
+	push(f, 3.0)
+	push(f, 2.0)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	if value != 1.5 {
 		t.Errorf("FDIV: expected a result of 1.5, but got: %f", value)
 	}
@@ -285,13 +285,13 @@ func TestNewFdiv(t *testing.T) {
 // FDIV: with divide zero by zero, should = NaN
 func TestNewFdivDivideZeroByZero(t *testing.T) {
 	f := newFrame(opcodes.FDIV)
-	push(&f, float64(0))
-	push(&f, float64(0))
+	push(f, float64(0))
+	push(f, float64(0))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	ret := pop(&f)
+	ret := pop(f)
 
 	if !math.IsNaN(ret.(float64)) {
 		t.Errorf("FDIV: Did not get an expected NaN")
@@ -301,13 +301,13 @@ func TestNewFdivDivideZeroByZero(t *testing.T) {
 // FDIV: with divide positive number by zero, should = +Inf
 func TestNewFdivDividePosNumberByZero(t *testing.T) {
 	f := newFrame(opcodes.FDIV)
-	push(&f, float64(10))
-	push(&f, float64(0))
+	push(f, float64(10))
+	push(f, float64(0))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	ret := pop(&f)
+	ret := pop(f)
 
 	if !math.IsInf(ret.(float64), 1) {
 		t.Errorf("FDIV: Did not get an expected +Infinity")
@@ -325,9 +325,9 @@ func TestNewFload(t *testing.T) {
 	f.Locals = append(f.Locals, float64(0x1234562)) // put value in locals[4]
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	x := pop(&f).(float64)
+	x := pop(f).(float64)
 	if x != float64(0x1234562) {
 		t.Errorf("FLOAD: Expecting 0x1234562 on stack, got: 0x%x", x)
 	}
@@ -344,12 +344,12 @@ func TestNewFload0(t *testing.T) {
 	f := newFrame(opcodes.FLOAD_0)
 	f.Locals = append(f.Locals, 1.2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	if value != 1.2 {
 		t.Errorf("FLOAD_0: Expected popped value to be 1.2, got: %f", value)
 	}
@@ -361,12 +361,12 @@ func TestNewFload1(t *testing.T) {
 	f.Locals = append(f.Locals, 1.1)
 	f.Locals = append(f.Locals, 1.2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	if value != 1.2 {
 		t.Errorf("FLOAD_1: Expected popped value to be 1.2, got: %f", value)
 	}
@@ -379,12 +379,12 @@ func TestNewFload2(t *testing.T) {
 	f.Locals = append(f.Locals, 1.1)
 	f.Locals = append(f.Locals, 1.2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	if value != 1.2 {
 		t.Errorf("FLOAD_2: Expected popped value to be 1.2, got: %f", value)
 	}
@@ -398,12 +398,12 @@ func TestNewFload3(t *testing.T) {
 	f.Locals = append(f.Locals, 1.1)
 	f.Locals = append(f.Locals, 1.2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	if value != 1.2 {
 		t.Errorf("FLOAD_3: Expected popped value to be 1.2, got: %f", value)
 	}
@@ -412,15 +412,15 @@ func TestNewFload3(t *testing.T) {
 // FMUL (pop 2 floats, multiply them, push result)
 func TestNewFmul(t *testing.T) {
 	f := newFrame(opcodes.FMUL)
-	push(&f, 1.5)
-	push(&f, 2.0)
+	push(f, 1.5)
+	push(f, 2.0)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("FMUL, Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	if value != 3.0 {
 		t.Errorf("FMUL: Expected popped value to be 3.0, got: %f", value)
 	}
@@ -429,17 +429,17 @@ func TestNewFmul(t *testing.T) {
 // FNEG: negate a float
 func TestNewFneg(t *testing.T) {
 	f := newFrame(opcodes.FNEG)
-	push(&f, 10.0)
+	push(f, 10.0)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != 0 {
 		t.Errorf("FNEG, Top of stack, expected 0, got: %d", f.TOS)
 	}
 
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	if value != -10.0 {
 		t.Errorf("FNEG: Expected popped value to be -10.0, got: %f", value)
 	}
@@ -448,19 +448,19 @@ func TestNewFneg(t *testing.T) {
 // FREM: remainder of float division (the % operator)
 func TestNewFrem(t *testing.T) {
 	f := newFrame(opcodes.FREM)
-	push(&f, 23.5)
+	push(f, 23.5)
 
-	push(&f, 3.3)
+	push(f, 3.3)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != 0 {
 		t.Errorf("FREM, Top of stack, expected 0, got: %d", f.TOS)
 	}
 
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	if math.Abs(value-0.40000033) > maxFloatDiff {
 		t.Errorf("FREM: Expected popped value to be 0.40000033, got: %f", value)
 	}
@@ -474,10 +474,10 @@ func TestNewFstore(t *testing.T) {
 	f.Locals = append(f.Locals, zerof)
 	f.Locals = append(f.Locals, zerof)
 	f.Locals = append(f.Locals, zerof)
-	push(&f, float64(0x22223))
+	push(f, float64(0x22223))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.Locals[2] != float64(0x22223) {
@@ -493,9 +493,9 @@ func TestNewFstore(t *testing.T) {
 func TestNewFstore0(t *testing.T) {
 	f := newFrame(opcodes.FSTORE_0)
 	f.Locals = append(f.Locals, 0.0)
-	push(&f, 1.0)
+	push(f, 1.0)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Locals[0].(float64) != 1.0 {
 		t.Errorf("FSTORE_0: expected lcoals[0] to be 1.0, got: %f", f.Locals[0].(float64))
@@ -510,9 +510,9 @@ func TestNewFstore1(t *testing.T) {
 	f := newFrame(opcodes.FSTORE_1)
 	f.Locals = append(f.Locals, 0.0)
 	f.Locals = append(f.Locals, 0.0)
-	push(&f, 1.0)
+	push(f, 1.0)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Locals[1].(float64) != 1.0 {
 		t.Errorf("FSTORE_1: expected lcoals[1] to be 1.0, got: %f", f.Locals[1].(float64))
@@ -528,9 +528,9 @@ func TestNewFstore2(t *testing.T) {
 	f.Locals = append(f.Locals, 0.0)
 	f.Locals = append(f.Locals, 0.0)
 	f.Locals = append(f.Locals, 0.0)
-	push(&f, 1.0)
+	push(f, 1.0)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Locals[2].(float64) != 1.0 {
 		t.Errorf("FSTORE_2: expected lcoals[2] to be 1.0, got: %f", f.Locals[2].(float64))
@@ -548,9 +548,9 @@ func TestNewFstore3(t *testing.T) {
 	f.Locals = append(f.Locals, 0.0)
 	f.Locals = append(f.Locals, 0.0)
 	f.Locals = append(f.Locals, 0.0)
-	push(&f, 1.0)
+	push(f, 1.0)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Locals[3].(float64) != 1.0 {
 		t.Errorf("FSTORE_3: expected lcoals[3] to be 1.0, got: %f", f.Locals[3].(float64))
@@ -563,14 +563,14 @@ func TestNewFstore3(t *testing.T) {
 // FSUB:float subtraction
 func TestNewFsub(t *testing.T) {
 	f := newFrame(opcodes.FSUB)
-	push(&f, 1.0)
-	push(&f, 0.7)
+	push(f, 1.0)
+	push(f, 0.7)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 
 	if math.Abs(value-0.3) > maxFloatDiff {
 		t.Errorf("FSUB: Expected popped value to be 0.3, got: %f", value)
@@ -624,14 +624,14 @@ func TestNewGetField(t *testing.T) {
 		Fvalue: "hello",
 	}
 
-	push(&f, str)
+	push(f, str)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// preceding should mean that the field value is on the stack
-	ret := pop(&f)
+	ret := pop(f)
 	s := object.GoStringFromStringObject(ret.(*object.Object))
 	if s != "hello" {
 		t.Errorf("GETFIELD: did not get expected pointer to a string 'hello'")
@@ -669,14 +669,14 @@ func TestNewGetFieldWithLong(t *testing.T) {
 
 	// push the string whose field[0] we'll be getting
 	obj := object.MakePrimitiveObject("java/lang/Long", types.Long, int64(222))
-	push(&f, obj)
+	push(f, obj)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// preceding should mean that the field value is on the stack
-	ret := pop(&f).(int64)
+	ret := pop(f).(int64)
 	if ret != 222 {
 		t.Errorf("GETFIELD: expected popped value of 222, got: %d", ret)
 	}
@@ -706,10 +706,10 @@ func TestGetFieldInvalidRefType(t *testing.T) {
 	f.CP = &CP
 
 	// push an invalid ref type (string instead of *object.Object)
-	push(&f, "not an object")
+	push(f, "not an object")
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	// restore stderr
@@ -741,10 +741,10 @@ func TestGetFieldNullRef(t *testing.T) {
 	CP.FieldRefs[0] = classloader.ResolvedFieldEntry{FldName: "value"}
 	f.CP = &CP
 
-	push(&f, object.Null)
+	push(f, object.Null)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -777,10 +777,10 @@ func TestGetFieldMissingField(t *testing.T) {
 
 	// object without the requested field
 	obj := object.MakeEmptyObject()
-	push(&f, obj)
+	push(f, obj)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -812,13 +812,13 @@ func TestGetFieldStringIndex(t *testing.T) {
 
 	obj := object.MakeEmptyObject()
 	obj.FieldTable["value"] = object.Field{Ftype: types.StringIndex, Fvalue: idx}
-	push(&f, obj)
+	push(f, obj)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	ret := pop(&f).(*string)
+	ret := pop(f).(*string)
 	if ret == nil || *ret != s {
 		t.Errorf("GETFIELD StringIndex: expected %q, got %#v", s, ret)
 	}
@@ -844,13 +844,13 @@ func TestGetFieldStringClassRefBytes(t *testing.T) {
 	// StringClassRef with []byte payload
 	obj := object.MakeEmptyObject()
 	obj.FieldTable["value"] = object.Field{Ftype: types.StringClassRef, Fvalue: []byte{'h', 'i'}}
-	push(&f, obj)
+	push(f, obj)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	ret := pop(&f).(*object.Object)
+	ret := pop(f).(*object.Object)
 	if object.GoStringFromStringObject(ret) != "hi" {
 		t.Errorf("GETFIELD StringClassRef([]byte): expected 'hi', got %q", object.GoStringFromStringObject(ret))
 	}
@@ -876,13 +876,13 @@ func TestGetFieldStringClassRefJavaBytes(t *testing.T) {
 	jb := []types.JavaByte{types.JavaByte('b'), types.JavaByte('y'), types.JavaByte('e')}
 	obj := object.MakeEmptyObject()
 	obj.FieldTable["value"] = object.Field{Ftype: types.StringClassRef, Fvalue: jb}
-	push(&f, obj)
+	push(f, obj)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	ret := pop(&f).(*object.Object)
+	ret := pop(f).(*object.Object)
 	if object.GoStringFromStringObject(ret) != "bye" {
 		t.Errorf("GETFIELD StringClassRef(JavaByte[]): expected 'bye', got %q", object.GoStringFromStringObject(ret))
 	}
@@ -908,13 +908,13 @@ func TestGetFieldArrayWrap(t *testing.T) {
 	arr := []int64{10, 20, 30}
 	obj := object.MakeEmptyObject()
 	obj.FieldTable["value"] = object.Field{Ftype: types.IntArray, Fvalue: arr}
-	push(&f, obj)
+	push(f, obj)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	ret := pop(&f).(*object.Object)
+	ret := pop(f).(*object.Object)
 	fv, ok := ret.FieldTable["value"]
 	if !ok || fv.Ftype != types.IntArray {
 		t.Fatalf("GETFIELD array wrap: expected wrapped array field type %q, got %#v", types.IntArray, fv)
@@ -946,13 +946,13 @@ func TestGetFieldObjectWrapsArray(t *testing.T) {
 	// Field type is Object, but value is an int64 slice. doGetfield should wrap this
 	// into an Object whose field("value").Ftype is inferred to an array descriptor
 	obj.FieldTable["value"] = object.Field{Ftype: "Ljava/lang/Object;", Fvalue: payload}
-	push(&f, obj)
+	push(f, obj)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	ret := pop(&f).(*object.Object)
+	ret := pop(f).(*object.Object)
 	fv, ok := ret.FieldTable["value"]
 	if !ok || fv.Ftype != types.IntArray {
 		t.Fatalf("GETFIELD Object-wrap: expected inferred array type %q, got %#v", types.IntArray, fv)
@@ -1013,12 +1013,12 @@ func TestGetStaticInt(t *testing.T) {
 	// Push the frame onto the frame stack
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 
 	interpret(fs)
 
 	// Verify the result
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 42 {
 		t.Errorf("doGetstatic: expected value 42, got %d", value)
 	}
@@ -1051,10 +1051,10 @@ func TestGetStaticBoolNormalization(t *testing.T) {
 	_ = statics.AddStatic("TestClass.boolField", statics.Static{Type: types.Bool, Value: true})
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	v := pop(&f).(int64)
+	v := pop(f).(int64)
 	if v != 1 {
 		t.Fatalf("GETSTATIC bool normalization: expected 1, got %d", v)
 	}
@@ -1085,10 +1085,10 @@ func TestGetStaticBytePromotion(t *testing.T) {
 	_ = statics.AddStatic("TestClass.byteField", statics.Static{Type: types.Byte, Value: byte(7)})
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	v := pop(&f).(int64)
+	v := pop(f).(int64)
 	if v != 7 {
 		t.Fatalf("GETSTATIC byte promotion: expected 7, got %d", v)
 	}
@@ -1119,10 +1119,10 @@ func TestGetStaticDefaultPathInt64(t *testing.T) {
 	_ = statics.AddStatic("TestClass.i64Field", statics.Static{Type: types.Long, Value: int64(99)})
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
-	v := pop(&f).(int64)
+	v := pop(f).(int64)
 	if v != 99 {
 		t.Fatalf("GETSTATIC default path (int64): expected 99, got %d", v)
 	}
@@ -1165,7 +1165,7 @@ func TestGetStaticClassNotFound(t *testing.T) {
 	f.CP = &CP
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -1212,7 +1212,7 @@ func TestGetStaticMissingFieldAfterInstantiate(t *testing.T) {
 	f.CP = &CP
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -1234,7 +1234,7 @@ func TestNewGotoForward(t *testing.T) {
 	f.Meth = append(f.Meth, opcodes.NOP)
 	f.Meth = append(f.Meth, opcodes.NOP)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC] != opcodes.RETURN {
 		t.Errorf("GOTO forward: Expected PC to point to RETURN, but instead it points to : %s", opcodes.BytecodeNames[f.Meth[f.PC]])
@@ -1250,7 +1250,7 @@ func TestNewGotoBackward(t *testing.T) {
 	f.Meth = append(f.Meth, opcodes.BIPUSH)
 	f.PC = 1 // skip over the return instruction to start, catch it on the backward goto
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC] != opcodes.RETURN {
 		t.Errorf("GOTO backward: Expected PC to point to RETURN, but instead it points to : %s", opcodes.BytecodeNames[f.Meth[f.PC]])
@@ -1268,7 +1268,7 @@ func TestNewGotowForward(t *testing.T) {
 	f.Meth = append(f.Meth, opcodes.NOP)
 	f.Meth = append(f.Meth, opcodes.NOP)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC] != opcodes.RETURN {
 		t.Errorf("GOTO_W forward: Expected PC to point to RETURN, but instead it points to : %s", opcodes.BytecodeNames[f.Meth[f.PC]])
@@ -1286,7 +1286,7 @@ func TestNewGotowBackward(t *testing.T) {
 	f.Meth = append(f.Meth, opcodes.BIPUSH)
 	f.PC = 1 // skip over the return instruction to start, catch it on the backward goto
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC] != opcodes.RETURN {
 		t.Errorf("GOTO_W backward: Expected PC to point to RETURN, but instead it points to : %s", opcodes.BytecodeNames[f.Meth[f.PC]])
@@ -1296,12 +1296,12 @@ func TestNewGotowBackward(t *testing.T) {
 // I2B: convert int to Java char (16-bit value)
 func TestNewI2B(t *testing.T) {
 	f := newFrame(opcodes.I2B)
-	push(&f, int64(2100))
+	push(f, int64(2100))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 52 {
 		t.Errorf("I2B: expected a result of 52, but got: %d", value)
 	}
@@ -1313,12 +1313,12 @@ func TestNewI2B(t *testing.T) {
 // I2B: convert int to Java char (16-bit value) using a negative value
 func TestNewI2Bneg(t *testing.T) { // TODO: check that this matches Java result
 	f := newFrame(opcodes.I2B)
-	push(&f, int64(-2100))
+	push(f, int64(-2100))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != -52 {
 		t.Errorf("I2B: expected a result of -52, but got: %d", value)
 	}
@@ -1330,12 +1330,12 @@ func TestNewI2Bneg(t *testing.T) { // TODO: check that this matches Java result
 // I2C: convert int to Java char (16-bit value)
 func TestNewI2C(t *testing.T) {
 	f := newFrame(opcodes.I2C)
-	push(&f, int64(21))
+	push(f, int64(21))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 21 {
 		t.Errorf("I2C: expected a result of 21, but got: %d", value)
 	}
@@ -1349,12 +1349,12 @@ func TestNewI2C(t *testing.T) {
 // doubles use two slots.
 func TestNewI2D(t *testing.T) {
 	f := newFrame(opcodes.I2D)
-	push(&f, int64(21))
+	push(f, int64(21))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	if value != 21.0 {
 		t.Errorf("I2D: expected a result of 21.0, but got: %f", value)
 	}
@@ -1366,12 +1366,12 @@ func TestNewI2D(t *testing.T) {
 // I2F: convert int to short
 func TestNewI2f(t *testing.T) {
 	f := newFrame(opcodes.I2F)
-	push(&f, int64(21))
+	push(f, int64(21))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	if value != 21.0 {
 		t.Errorf("I2F: expected a result of 21.0, but got: %f", value)
 	}
@@ -1386,12 +1386,12 @@ func TestNewI2f(t *testing.T) {
 // slot, longs use two slots. So this is the primary test here.
 func TestNewI2l(t *testing.T) {
 	f := newFrame(opcodes.I2L)
-	push(&f, int64(21))
+	push(f, int64(21))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 21 {
 		t.Errorf("I2L: expected a result of 21, but got: %d", value)
 	}
@@ -1403,12 +1403,12 @@ func TestNewI2l(t *testing.T) {
 // I2S: convert int to short
 func TestNewI2s(t *testing.T) {
 	f := newFrame(opcodes.I2S)
-	push(&f, int64(21))
+	push(f, int64(21))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 21 {
 		t.Errorf("I2S: expected a result of 21, but got: %d", value)
 	}
@@ -1420,12 +1420,12 @@ func TestNewI2s(t *testing.T) {
 // IADD: Add two integers
 func TestNewIadd(t *testing.T) {
 	f := newFrame(opcodes.IADD)
-	push(&f, int64(21))
-	push(&f, int64(22))
+	push(f, int64(21))
+	push(f, int64(22))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 43 {
 		t.Errorf("IADD: expected a result of 43, but got: %d", value)
 	}
@@ -1437,14 +1437,14 @@ func TestNewIadd(t *testing.T) {
 // IAND: Logical and of two ints, push result
 func TestNewIand(t *testing.T) {
 	f := newFrame(opcodes.IAND)
-	push(&f, int64(21))
-	push(&f, int64(22))
+	push(f, int64(21))
+	push(f, int64(22))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(int64) // longs require two slots, so popped twice
+	value := pop(f).(int64) // longs require two slots, so popped twice
 
 	if value != 20 { // 21 & 22 = 20
 		t.Errorf("IAND: expected a result of 20, but got: %d", value)
@@ -1458,12 +1458,12 @@ func TestNewIand(t *testing.T) {
 func TestNewIconstN1(t *testing.T) {
 	f := newFrame(opcodes.ICONST_M1)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	var value = pop(&f).(int64)
+	var value = pop(f).(int64)
 	if value != -1 {
 		t.Errorf("ICONST_M1: Expected popped value to be -1, got: %d", value)
 	}
@@ -1473,12 +1473,12 @@ func TestNewIconstN1(t *testing.T) {
 func TestNewIconst0(t *testing.T) {
 	f := newFrame(opcodes.ICONST_0)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 0 {
 		t.Errorf("ICONST_0: Expected popped value to be 0, got: %d", value)
 	}
@@ -1488,12 +1488,12 @@ func TestNewIconst0(t *testing.T) {
 func TestNewIconst1(t *testing.T) {
 	f := newFrame(opcodes.ICONST_1)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 1 {
 		t.Errorf("ICONST_1: Expected popped value to be 1, got: %d", value)
 	}
@@ -1503,12 +1503,12 @@ func TestNewIconst1(t *testing.T) {
 func TestNewIconst2(t *testing.T) {
 	f := newFrame(opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 2 {
 		t.Errorf("ICONST_2: Expected popped value to be 2, got: %d", value)
 	}
@@ -1518,12 +1518,12 @@ func TestNewIconst2(t *testing.T) {
 func TestNewIconst3(t *testing.T) {
 	f := newFrame(opcodes.ICONST_3)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 3 {
 		t.Errorf("ICONST_3: Expected popped value to be 3, got: %d", value)
 	}
@@ -1533,12 +1533,12 @@ func TestNewIconst3(t *testing.T) {
 func TestNewIconst4(t *testing.T) {
 	f := newFrame(opcodes.ICONST_4)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 4 {
 		t.Errorf("ICONST_4: Expected popped value to be 4, got: %d", value)
 	}
@@ -1548,12 +1548,12 @@ func TestNewIconst4(t *testing.T) {
 func TestNewIconst5(t *testing.T) {
 	f := newFrame(opcodes.ICONST_5)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 5 {
 		t.Errorf("ICONST_5: Expected popped value to be 5, got: %d", value)
 	}
@@ -1562,12 +1562,12 @@ func TestNewIconst5(t *testing.T) {
 // IDIV: integer divide of.TOS-1 by tos, push result
 func TestNewIdiv(t *testing.T) {
 	f := newFrame(opcodes.IDIV)
-	push(&f, int64(220))
-	push(&f, int64(22))
+	push(f, int64(220))
+	push(f, int64(22))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 10 {
 		t.Errorf("IDIV: expected a result of 10, but got: %d", value)
 	}
@@ -1578,15 +1578,15 @@ func TestNewIdiv(t *testing.T) {
 // IF_ACMPEQ: jump if two addresses are equal
 func TestNewIfAcmpEq(t *testing.T) {
 	f := newFrame(opcodes.IF_ACMPEQ)
-	push(&f, int64(0xFF8899))
-	push(&f, int64(0xFF8899))
+	push(f, int64(0xFF8899))
+	push(f, int64(0xFF8899))
 	// note that the byte passed in newframe() is at f.Meth[0]
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.ICONST_1)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] != opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IF_ACMPEQ: expecting a jump to ICONST_2 instuction, got: %s",
@@ -1597,15 +1597,15 @@ func TestNewIfAcmpEq(t *testing.T) {
 // IF_ACMPEQ: jump if two addresses are equal (this tests addresses being unequal)
 func TestNewIfAcmpeqFail(t *testing.T) {
 	f := newFrame(opcodes.IF_ACMPEQ)
-	push(&f, int64(0xFF8899))
-	push(&f, int64(0xFF889A))
+	push(f, int64(0xFF8899))
+	push(f, int64(0xFF889A))
 	// note that the byte passed in newframe() is at f.Meth[0]
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST_2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.RETURN) // the failed test should drop to this
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC] != opcodes.RETURN { // b/c we return directly, we don't subtract 1 from pc
 		t.Errorf("IF_ICMPEQ: expecting fall-through to RETURN instuction, got: %s",
@@ -1616,15 +1616,15 @@ func TestNewIfAcmpeqFail(t *testing.T) {
 // IF_ACMPNE: jump if two addresses are not equal
 func TestNewIfAcmpNe(t *testing.T) {
 	f := newFrame(opcodes.IF_ACMPNE)
-	push(&f, int64(0xFF8899))
-	push(&f, int64(0xFF889A))
+	push(f, int64(0xFF8899))
+	push(f, int64(0xFF889A))
 	// note that the byte passed in newframe() is at f.Meth[0]
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.ICONST_1)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] != opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IF_ACMPNE: expecting a jump to ICONST_2 instuction, got: %s",
@@ -1635,15 +1635,15 @@ func TestNewIfAcmpNe(t *testing.T) {
 // IF_ACMPNE: jump if two addresses are equal (this tests addresses being equal)
 func TestNewIfAcmpneFail(t *testing.T) {
 	f := newFrame(opcodes.IF_ACMPNE)
-	push(&f, int64(0xFF8899))
-	push(&f, int64(0xFF8899))
+	push(f, int64(0xFF8899))
+	push(f, int64(0xFF8899))
 	// note that the byte passed in newframe() is at f.Meth[0]
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST_2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.RETURN) // the failed test should drop to this
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC] != opcodes.RETURN { // b/c we return directly, we don't subtract 1 from pc
 		t.Errorf("IF_ICMPNE: expecting fall-through to RETURN instuction, got: %s",
@@ -1654,15 +1654,15 @@ func TestNewIfAcmpneFail(t *testing.T) {
 // IF_ICMPEQ: jump if val1 == val2 (both ints, both popped off stack)
 func TestNewIfIcmpeq(t *testing.T) {
 	f := newFrame(opcodes.IF_ICMPEQ)
-	push(&f, int64(9)) // pushed two equal values, so jump should be made.
-	push(&f, int64(9))
+	push(f, int64(9)) // pushed two equal values, so jump should be made.
+	push(f, int64(9))
 
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.NOP)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] != opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("ICMPEQ: expecting a jump to ICONST_2 instuction, got: %s",
@@ -1673,11 +1673,11 @@ func TestNewIfIcmpeq(t *testing.T) {
 // IF_ICMPEQ: jump if val1 == val2; here test with unequal value
 func TestNewIfIcmpeqUnequal(t *testing.T) {
 	f := newFrame(opcodes.IF_ICMPEQ)
-	push(&f, int64(9)) // pushed two unequal values, so no jump should be made.
-	push(&f, int64(-9))
+	push(f, int64(9)) // pushed two unequal values, so no jump should be made.
+	push(f, int64(-9))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.PC != 3 { // 2 for the jump due to inequality above, +1 for fetch of next bytecode
@@ -1692,15 +1692,15 @@ func TestNewIfIcmpeqUnequal(t *testing.T) {
 // IF_CMPGE: if integer compare val 1 >= val 2. Here test for = (next test for >)
 func TestNewIfIcmpge1(t *testing.T) {
 	f := newFrame(opcodes.IF_ICMPGE)
-	push(&f, int64(9))
-	push(&f, int64(9))
+	push(f, int64(9))
+	push(f, int64(9))
 	// note that the byte passed in newframe() is at f.Meth[0]
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.ICONST_1)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] != opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("ICMPGE: expecting a jump to ICONST_2 instuction, got: %s",
@@ -1711,15 +1711,15 @@ func TestNewIfIcmpge1(t *testing.T) {
 // IF_ICMPGE: if integer compare val 1 >= val 2. Here test for > (previous test for =)
 func TestNewIfIcmpge2(t *testing.T) {
 	f := newFrame(opcodes.IF_ICMPGE)
-	push(&f, int64(9))
-	push(&f, int64(8))
+	push(f, int64(9))
+	push(f, int64(8))
 	// note that the byte passed in newframe() is at f.Meth[0]
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.ICONST_1)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] != opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("ICMPGE: expecting a jump to ICONST_2 instuction, got: %s",
@@ -1730,15 +1730,15 @@ func TestNewIfIcmpge2(t *testing.T) {
 // IF_ICMPGE: if integer compare val 1 >= val 2 //test when condition fails
 func TestNewIfIcmgetFail(t *testing.T) {
 	f := newFrame(opcodes.IF_ICMPGE)
-	push(&f, int64(8))
-	push(&f, int64(9))
+	push(f, int64(8))
+	push(f, int64(9))
 	// note that the byte passed in newframe() is at f.Meth[0]
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.RETURN) // the failed test should drop to this
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC] != opcodes.RETURN { // b/c we return directly, we don't subtract 1 from pc
 		t.Errorf("ICMPGE: expecting fall-through to RETURN instuction, got: %s",
@@ -1749,15 +1749,15 @@ func TestNewIfIcmgetFail(t *testing.T) {
 // IF_ICMPGT: jump if val1 > val2 (both ints, both popped off stack)
 func TestIfIcmpgt(t *testing.T) {
 	f := newFrame(opcodes.IF_ICMPGT)
-	push(&f, int64(9)) // val1 > val2, so jump should be made.
-	push(&f, int64(8))
+	push(f, int64(9)) // val1 > val2, so jump should be made.
+	push(f, int64(8))
 
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.NOP)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] != opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IF_ICMPGT: expecting a jump to ICONST_2 instuction, got: %s",
@@ -1768,9 +1768,9 @@ func TestIfIcmpgt(t *testing.T) {
 // IF_ICMPGT: jump if val1 > val2 (both ints, both popped off stack)
 func TestIfIcmpgtWithLessThan(t *testing.T) {
 	f := newFrame(opcodes.IF_ICMPGT)
-	push(&f, int64(8)) // val1 > val2, so jump should be made.
-	push(&f, int64(9))
-	ret := doIficmpgt(&f, 0)
+	push(f, int64(8)) // val1 > val2, so jump should be made.
+	push(f, int64(9))
+	ret := doIficmpgt(f, 0)
 
 	if ret != 3 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IF_ICMPGT: expecting to jump over opcode (so, PC +3), got: %d", ret)
@@ -1780,15 +1780,15 @@ func TestIfIcmpgtWithLessThan(t *testing.T) {
 // IF_ICMPLE: if integer compare val 1 ! <= val 2 //test when condition fails
 func TestNewIfIcmpletFail(t *testing.T) {
 	f := newFrame(opcodes.IF_ICMPLE)
-	push(&f, int64(9))
-	push(&f, int64(8))
+	push(f, int64(9))
+	push(f, int64(8))
 	// note that the byte passed in newframe() is at f.Meth[0]
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.RETURN) // the failed test should drop to this
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC] != opcodes.RETURN { // b/c we return directly, we don't subtract 1 from pc
 		t.Errorf("IF_ICMPLE: expecting fall-through to RETURN instuction, got: %s",
@@ -1799,15 +1799,15 @@ func TestNewIfIcmpletFail(t *testing.T) {
 // IF_ICMPLE: if integer compare val 1 <= val 2. Here testing for =
 func TestNewIfIcmple1(t *testing.T) {
 	f := newFrame(opcodes.IF_ICMPLE)
-	push(&f, int64(9))
-	push(&f, int64(9))
+	push(f, int64(9))
+	push(f, int64(9))
 	// note that the byte passed in newframe() is at f.Meth[0]
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.ICONST_1)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] != opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IF_CMPLE: expecting a jump to ICONST_2 instuction, got: %s",
@@ -1818,15 +1818,15 @@ func TestNewIfIcmple1(t *testing.T) {
 // IF_ICMPLT: if integer compare val 1 < val 2
 func TestNewIfIcmplt(t *testing.T) {
 	f := newFrame(opcodes.IF_ICMPLT)
-	push(&f, int64(8))
-	push(&f, int64(9))
+	push(f, int64(8))
+	push(f, int64(9))
 	// note that the byte passed in newframe() is at f.Meth[0]
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.ICONST_1)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] != opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IF_ICMPLT: expecting a jump to ICONST_2 instuction, got: %s",
@@ -1837,15 +1837,15 @@ func TestNewIfIcmplt(t *testing.T) {
 // IF_ICMPLT: if integer compare val 1 < val 2 //test when condition fails
 func TestNewIfIcmpltFail(t *testing.T) {
 	f := newFrame(opcodes.IF_ICMPLT)
-	push(&f, int64(9))
-	push(&f, int64(9))
+	push(f, int64(9))
+	push(f, int64(9))
 	// note that the byte passed in newframe() is at f.Meth[0]
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.RETURN) // the failed test should drop to this
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC] != opcodes.RETURN { // b/c we return directly, we don't subtract 1 from pc
 		t.Errorf("IF_ICMPLT: expecting fall-through to RETURN instuction, got: %s",
@@ -1856,15 +1856,15 @@ func TestNewIfIcmpltFail(t *testing.T) {
 // IF_ICMPNE: jump if val1 != val2 (both ints, both popped off stack)
 func TestNewIfIcmpne(t *testing.T) {
 	f := newFrame(opcodes.IF_ICMPNE)
-	push(&f, int64(9)) // pushed two unequal values, so jump should be made.
-	push(&f, int64(8))
+	push(f, int64(9)) // pushed two unequal values, so jump should be made.
+	push(f, int64(8))
 
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.NOP)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] != opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IF_ICMPNE: expecting a jump to ICONST_2 instuction, got: %s",
@@ -1875,11 +1875,11 @@ func TestNewIfIcmpne(t *testing.T) {
 // IF_ICMPNE: jump if val1 != val2 Here tests when they are equal
 func TestNewIfIcmpneAreEqual(t *testing.T) {
 	f := newFrame(opcodes.IF_ICMPNE)
-	push(&f, int64(9)) // pushed two equal values, so jump should not be made.
-	push(&f, int64(9))
+	push(f, int64(9)) // pushed two equal values, so jump should not be made.
+	push(f, int64(9))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.PC != 3 { // PC+= 2 when test fails, +1 for the next bytecode
@@ -1893,14 +1893,14 @@ func TestNewIfIcmpneAreEqual(t *testing.T) {
 // IFEQ: jump if int popped off TOS is = 0
 func TestNewIfeq(t *testing.T) {
 	f := newFrame(opcodes.IFEQ)
-	push(&f, int64(0)) // pushed 0, so jump should be made.
+	push(f, int64(0)) // pushed 0, so jump should be made.
 
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.NOP)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] != opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IFEQ: expecting a jump to ICONST_2 instuction, got: %s",
@@ -1911,14 +1911,14 @@ func TestNewIfeq(t *testing.T) {
 // IFEQ: jump if int popped off TOS is = 0; here != 0
 func TestNewIfeqFallThrough(t *testing.T) {
 	f := newFrame(opcodes.IFEQ)
-	push(&f, int64(23)) // pushed 23, so jump should not be made.
+	push(f, int64(23)) // pushed 23, so jump should not be made.
 
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.RETURN)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] == opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IFEQ: Invalid fall-through, got: %s",
@@ -1929,14 +1929,14 @@ func TestNewIfeqFallThrough(t *testing.T) {
 // IFGE: jump if int popped off TOS is >= 0
 func TestNewIfge(t *testing.T) {
 	f := newFrame(opcodes.IFGE)
-	push(&f, int64(66)) // pushed 66, so jump should be made.
+	push(f, int64(66)) // pushed 66, so jump should be made.
 
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.NOP)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] != opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IFGE: expecting a jump to ICONST_2 instuction, got: %s",
@@ -1947,14 +1947,14 @@ func TestNewIfge(t *testing.T) {
 // IFGE: jump if int popped off TOS is >= 0, here = 0
 func TestNewIfgeEqual0(t *testing.T) {
 	f := newFrame(opcodes.IFGE)
-	push(&f, int64(0)) // pushed 0, so jump should be made.
+	push(f, int64(0)) // pushed 0, so jump should be made.
 
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.NOP)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] != opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IFGE: expecting a jump to ICONST_2 instuction, got: %s",
@@ -1965,14 +1965,14 @@ func TestNewIfgeEqual0(t *testing.T) {
 // IFGE: jump if int popped off TOS is >= 0; here < 0
 func TestNewIfgeFallThrough(t *testing.T) {
 	f := newFrame(opcodes.IFGE)
-	push(&f, int64(-1)) // pushed -1, so jump should not be made.
+	push(f, int64(-1)) // pushed -1, so jump should not be made.
 
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.RETURN)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] == opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IFGE: Invalid fall-through, got: %s",
@@ -1983,14 +1983,14 @@ func TestNewIfgeFallThrough(t *testing.T) {
 // IFGT: jump if int popped off TOS is > 0
 func TestNewIfgt(t *testing.T) {
 	f := newFrame(opcodes.IFGT)
-	push(&f, int64(66)) // pushed 66, so jump should be made.
+	push(f, int64(66)) // pushed 66, so jump should be made.
 
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.NOP)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] != opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IFGT: expecting a jump to ICONST_2 instuction, got: %s",
@@ -2001,14 +2001,14 @@ func TestNewIfgt(t *testing.T) {
 // IFGT: jump if int popped off TOS is > 0; here = 0
 func TestNewIfgtFallThrough(t *testing.T) {
 	f := newFrame(opcodes.IFGT)
-	push(&f, int64(0)) // pushed 0, so jump should not be made.
+	push(f, int64(0)) // pushed 0, so jump should not be made.
 
 	f.Meth = append(f.Meth, 0)
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.RETURN)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] == opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IFGT: Invalid fall-through, got: %s",
@@ -2019,14 +2019,14 @@ func TestNewIfgtFallThrough(t *testing.T) {
 // IFLE: jump if int popped off TOS is <= 0
 func TestNewIfle(t *testing.T) {
 	f := newFrame(opcodes.IFLE)
-	push(&f, int64(-66)) // pushed -66, so jump should be made.
+	push(f, int64(-66)) // pushed -66, so jump should be made.
 
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.NOP)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] != opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IFLE: expecting a jump to ICONST_2 instuction, got: %s",
@@ -2037,14 +2037,14 @@ func TestNewIfle(t *testing.T) {
 // IFLE: jump if int popped off TOS is <= 0; here = 0
 func TestNewIfleTest0(t *testing.T) {
 	f := newFrame(opcodes.IFLE)
-	push(&f, int64(0)) // pushed 0, so jump should be made.
+	push(f, int64(0)) // pushed 0, so jump should be made.
 
 	f.Meth = append(f.Meth, 0)
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.RETURN)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] != opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IFLE: expecting a jump to ICONST_2 instuction, got: %s",
@@ -2055,14 +2055,14 @@ func TestNewIfleTest0(t *testing.T) {
 // IFLE: jump if int popped off TOS is <= 0; here > 0, so no jump
 func TestNewIfleFallThrough(t *testing.T) {
 	f := newFrame(opcodes.IFLE)
-	push(&f, int64(66)) // pushed 66, so jump should not be made.
+	push(f, int64(66)) // pushed 66, so jump should not be made.
 
 	f.Meth = append(f.Meth, 0)
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.RETURN)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] == opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IFLE: Invalid jump when expecting fall-through, got: %s",
@@ -2073,14 +2073,14 @@ func TestNewIfleFallThrough(t *testing.T) {
 // IFLT: jump if int popped off TOS is < 0
 func TestNewIflt(t *testing.T) {
 	f := newFrame(opcodes.IFLT)
-	push(&f, int64(-66)) // pushed -66, so jump should be made.
+	push(f, int64(-66)) // pushed -66, so jump should be made.
 
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.NOP)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] != opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IFLT: expecting a jump to ICONST_2 instuction, got: %s",
@@ -2091,14 +2091,14 @@ func TestNewIflt(t *testing.T) {
 // IFLT: jump if int popped off TOS is < 0; here = 0
 func TestNewIfltFallThrough(t *testing.T) {
 	f := newFrame(opcodes.IFLT)
-	push(&f, int64(0)) // pushed 0, so jump should not be made.
+	push(f, int64(0)) // pushed 0, so jump should not be made.
 
 	f.Meth = append(f.Meth, 0)
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.RETURN)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] == opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IFLT: Invalid fall-through, got: %s",
@@ -2109,14 +2109,14 @@ func TestNewIfltFallThrough(t *testing.T) {
 // IFNE: jump if int popped off TOS is != 0
 func TestNewIfne(t *testing.T) {
 	f := newFrame(opcodes.IFNE)
-	push(&f, int64(1)) // pushed 1, so jump should be made.
+	push(f, int64(1)) // pushed 1, so jump should be made.
 
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.NOP)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] != opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IFNE: expecting a jump to ICONST_2 instuction, got: %s",
@@ -2127,14 +2127,14 @@ func TestNewIfne(t *testing.T) {
 // IFNE: jump if int popped off TOS is != 0; here it is = 0
 func TestNewIfneFallThrough(t *testing.T) {
 	f := newFrame(opcodes.IFNE)
-	push(&f, int64(0)) // pushed 0, so jump should not be made.
+	push(f, int64(0)) // pushed 0, so jump should not be made.
 
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.RETURN)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] == opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IFNE: Invalid fall-through, got: %s",
@@ -2146,14 +2146,14 @@ func TestNewIfneFallThrough(t *testing.T) {
 func TestNewIfnonnull(t *testing.T) {
 	f := newFrame(opcodes.IFNONNULL)
 	o := object.NewStringObject()
-	push(&f, o) // pushed a valid address, so jump should be made.
+	push(f, o) // pushed a valid address, so jump should be made.
 
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.NOP)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] != opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IFNONNULL: expecting a jump to ICONST_2 instuction, got: %s",
@@ -2166,13 +2166,13 @@ func TestNewIfnonnullFallThrough(t *testing.T) {
 	f := newFrame(opcodes.IFNONNULL)
 	var oAddr *object.Object
 	oAddr = object.Null
-	push(&f, oAddr)
+	push(f, oAddr)
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.RETURN)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] == opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Logf("IFNONNULL: Invalid fall-through, got: %s", opcodes.BytecodeNames[f.PC])
@@ -2185,14 +2185,14 @@ func TestNewIfnull(t *testing.T) {
 	f := newFrame(opcodes.IFNULL)
 	var oAddr *object.Object
 	oAddr = nil     // note either nil or object.Null will give same result
-	push(&f, oAddr) // pushed null, so jump should be made.
+	push(f, oAddr) // pushed null, so jump should be made.
 
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.NOP)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] != opcodes.ICONST_2 { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IFNULL: expecting a jump to ICONST_2 instuction, got: %s",
@@ -2204,14 +2204,14 @@ func TestNewIfnull(t *testing.T) {
 func TestNewIfnullFallThrough(t *testing.T) {
 	f := newFrame(opcodes.IFNULL)
 	o := object.MakeEmptyObject()
-	push(&f, o) // pushed non-null address, so jump should not be made.
+	push(f, o) // pushed non-null address, so jump should not be made.
 
 	f.Meth = append(f.Meth, 0) // where we are jumping to, byte 4 = ICONST2
 	f.Meth = append(f.Meth, 4)
 	f.Meth = append(f.Meth, opcodes.RETURN)
 	f.Meth = append(f.Meth, opcodes.ICONST_2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Meth[f.PC-1] == opcodes.IFNULL { // -1 b/c the run loop adds 1 before exiting
 		t.Errorf("IFNULL: Invalid fall-through, got: %s",

--- a/src/jvm/interpreter_II-LD_test.go
+++ b/src/jvm/interpreter_II-LD_test.go
@@ -36,7 +36,7 @@ func TestIinc(t *testing.T) {
 	f.Meth = append(f.Meth, 1)             // increment local variable[1]
 	f.Meth = append(f.Meth, 27)            // increment it by 27
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != -1 {
 		t.Errorf("Top of stack, expected -1, got: %d", f.TOS)
@@ -56,7 +56,7 @@ func TestIincNeg(t *testing.T) {
 	val := -27
 	f.Meth = append(f.Meth, byte(val)) // "increment" it by -27
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != -1 {
 		t.Errorf("Top of stack, expected -1, got: %d", f.TOS)
@@ -74,7 +74,7 @@ func TestIincOverflow(t *testing.T) {
 	f.Meth = append(f.Meth, 1)                     // increment local variable[1]
 	f.Meth = append(f.Meth, 1)                     // increment it by 1
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != -1 {
 		t.Errorf("Top of stack, expected -1, got: %d", f.TOS)
@@ -96,9 +96,9 @@ func TestNewIload(t *testing.T) {
 	f.Locals = append(f.Locals, int64(0x1234562)) // put value in locals[4]
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	x := pop(&f).(int64)
+	x := pop(f).(int64)
 	if x != 0x1234562 {
 		t.Errorf("ILOAD: Expecting 0x1234562 on stack, got: 0x%x", x)
 	}
@@ -115,12 +115,12 @@ func TestNewIload0(t *testing.T) {
 	f := newFrame(opcodes.ILOAD_0)
 	f.Locals = append(f.Locals, int64(27))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != int64(27) {
 		t.Errorf("ILOAD_0: Expected popped value to be 27, got: %d", value)
 	}
@@ -132,12 +132,12 @@ func TestNewIload1(t *testing.T) {
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, int64(27))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 27 {
 		t.Errorf("ILOAD_1: Expected popped value to be 27, got: %d", value)
 	}
@@ -150,12 +150,12 @@ func TestNewIload2(t *testing.T) {
 	f.Locals = append(f.Locals, int64(1))
 	f.Locals = append(f.Locals, int64(27))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != int64(27) {
 		t.Errorf("ILOAD_2: Expected popped value to be 27, got: %d", value)
 	}
@@ -169,12 +169,12 @@ func TestNewIload3(t *testing.T) {
 	f.Locals = append(f.Locals, int64(2))
 	f.Locals = append(f.Locals, int64(27))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 27 {
 		t.Errorf("ILOAD_3: Expected popped value to be 27, got: %d", value)
 	}
@@ -183,15 +183,15 @@ func TestNewIload3(t *testing.T) {
 // Test IMUL (pop 2 values, multiply them, push result)
 func TestNewImul(t *testing.T) {
 	f := newFrame(opcodes.IMUL)
-	push(&f, int64(10))
-	push(&f, int64(7))
+	push(f, int64(10))
+	push(f, int64(7))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("IMUL, Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 70 {
 		t.Errorf("IMUL: Expected popped value to be 70, got: %d", value)
 	}
@@ -200,15 +200,15 @@ func TestNewImul(t *testing.T) {
 // Test IMUL (pop 2 values, multiply them, push result) -- here test for overflow of int32 (aka Java int)
 func TestImulOverflow(t *testing.T) {
 	f := newFrame(opcodes.IMUL)
-	push(&f, int64(11))
-	push(&f, int64(math.MaxInt32))
+	push(f, int64(11))
+	push(f, int64(math.MaxInt32))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("IMUL, Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 2147483637 {
 		t.Errorf("IMUL: Expected popped value to be 2147483637, got: %d", value)
 	}
@@ -217,17 +217,17 @@ func TestImulOverflow(t *testing.T) {
 // INEG: negate an int
 func TestNewIneg(t *testing.T) {
 	f := newFrame(opcodes.INEG)
-	push(&f, int64(10))
+	push(f, int64(10))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != 0 {
 		t.Errorf("INEG, Top of stack, expected 0, got: %d", f.TOS)
 	}
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != -10 {
 		t.Errorf("INEG: Expected popped value to be -10, got: %d", value)
 	}
@@ -236,12 +236,12 @@ func TestNewIneg(t *testing.T) {
 // runInstanceof runs doInstanceof on obj against targetName and returns a result pushed on the stack.
 func runInstanceof(t *testing.T, obj interface{}, targetName string) int64 {
 	fr := newFrame(opcodes.INSTANCEOF)
-	setCPClassRefFor(&fr, targetName)
-	push(&fr, obj)
+	setCPClassRefFor(fr, targetName)
+	push(fr, obj)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&fr)
+	fs.PushFront(fr)
 	interpret(fs)
-	val, _ := pop(&fr).(int64)
+	val, _ := pop(fr).(int64)
 	return val
 }
 
@@ -303,25 +303,25 @@ func TestInstanceofMisc(t *testing.T) {
 // INSTANCEOF: Is the TOS item an instance of a particular class?
 func TestNewInstanceofNilAndNull(t *testing.T) {
 	f := newFrame(opcodes.INSTANCEOF)
-	push(&f, nil)
+	push(f, nil)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 0 {
 		t.Errorf("INSTANCEOF: Expected nil to return a 0, got %d", value)
 	}
 
 	f = newFrame(opcodes.INSTANCEOF)
-	push(&f, object.Null)
+	push(f, object.Null)
 
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value = pop(&f).(int64)
+	value = pop(f).(int64)
 	if value != 0 {
 		t.Errorf("INSTANCEOF: Expected null to return a 0, got %d", value)
 	}
@@ -358,13 +358,13 @@ func TestNewInstanceofString(t *testing.T) {
 	CP.ClassRefs = append(CP.ClassRefs, types.StringPoolStringIndex) // point to string pool entry for java/lang/String
 	f.CP = &CP
 
-	push(&f, s)
+	push(f, s)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 1 { // a 1 = it's a match between class and object
 		t.Errorf("INSTANCEOF: Expected string to return a 1, got %d", value)
 	}
@@ -373,14 +373,14 @@ func TestNewInstanceofString(t *testing.T) {
 // IOR: Logical OR of two ints
 func TestNewIor(t *testing.T) {
 	f := newFrame(opcodes.IOR)
-	push(&f, int64(21))
-	push(&f, int64(22))
+	push(f, int64(21))
+	push(f, int64(22))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 
 	if value != 23 { // 21 | 22 = 23
 		t.Errorf("IOR: expected a result of 23, but got: %d", value)
@@ -393,18 +393,18 @@ func TestNewIor(t *testing.T) {
 // IREM: int modulo
 func TestNewIrem(t *testing.T) {
 	f := newFrame(opcodes.IREM)
-	push(&f, int64(74))
-	push(&f, int64(6))
+	push(f, int64(74))
+	push(f, int64(6))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != 0 { // product is pushed twice b/c it's a long, which occupies 2 slots
 		t.Errorf("IREM, Top of stack, expected 1, got: %d", f.TOS)
 	}
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 2 {
 		t.Errorf("IREM: Expected result to be 2, got: %d", value)
 	}
@@ -417,12 +417,12 @@ func TestNewIrem(t *testing.T) {
 // IRETURN: push an int on to the op stack of the calling method and exit the present method/frame
 func TestNewIreturn(t *testing.T) {
 	f0 := newFrame(0)
-	push(&f0, int64(20))
+	push(f0, int64(20))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f0)
+	fs.PushFront(f0)
 	f1 := newFrame(opcodes.IRETURN)
-	push(&f1, int64(21))
-	fs.PushFront(&f1)
+	push(f1, int64(21))
+	fs.PushFront(f1)
 	interpret(fs)
 
 	f3 := fs.Front().Value.(*frames.Frame)
@@ -449,11 +449,11 @@ func TestIrem_DivideByZero_DefaultMessage(t *testing.T) {
 
 	f := newFrame(opcodes.IREM)
 	// dividend % divisor; here divisor = 0 to trigger error
-	push(&f, int64(10)) // dividend
-	push(&f, int64(0))  // divisor
+	push(f, int64(10)) // dividend
+	push(f, int64(0))  // divisor
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -478,11 +478,11 @@ func TestIrem_DivideByZero_StrictJDK(t *testing.T) {
 	os.Stderr = w
 
 	f := newFrame(opcodes.IREM)
-	push(&f, int64(5)) // dividend
-	push(&f, int64(0)) // divisor
+	push(f, int64(5)) // dividend
+	push(f, int64(0)) // divisor
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -500,15 +500,15 @@ func TestIrem_NegativeDividend(t *testing.T) {
 	globals.InitGlobals("test")
 
 	f := newFrame(opcodes.IREM)
-	push(&f, int64(-7)) // dividend
-	push(&f, int64(3))  // divisor
+	push(f, int64(-7)) // dividend
+	push(f, int64(3))  // divisor
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	// result should be -1 per Java semantics (and the implementation casts to int32 before %)
-	got := pop(&f).(int64)
+	got := pop(f).(int64)
 	if got != -1 {
 		t.Fatalf("IREM negative dividend: want -1, got %d", got)
 	}
@@ -520,14 +520,14 @@ func TestIrem_NegativeDividend(t *testing.T) {
 // ISHL: Left shift of long
 func TestNewIshl(t *testing.T) {
 	f := newFrame(opcodes.ISHL)
-	push(&f, int64(22)) // longs require two slots, so pushed twice
-	push(&f, int64(3))  // shift left 3 bits
+	push(f, int64(22)) // longs require two slots, so pushed twice
+	push(f, int64(3))  // shift left 3 bits
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(int64) // longs require two slots, so popped twice
+	value := pop(f).(int64) // longs require two slots, so popped twice
 
 	if value != 176 { // 22 << 3 = 176
 		t.Errorf("ISHL: expected a result of 176, but got: %d", value)
@@ -540,14 +540,14 @@ func TestNewIshl(t *testing.T) {
 // ISHR: Right shift of int
 func TestNewIshr(t *testing.T) {
 	f := newFrame(opcodes.ISHR)
-	push(&f, int64(200))
-	push(&f, int64(3)) // shift right 3 bits
+	push(f, int64(200))
+	push(f, int64(3)) // shift right 3 bits
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(int64) // longs require two slots, so popped twice
+	value := pop(f).(int64) // longs require two slots, so popped twice
 
 	if value != 25 { // 200 >> 3 = 25
 		t.Errorf("ISHR: expected a result of 25, but got: %d", value)
@@ -560,14 +560,14 @@ func TestNewIshr(t *testing.T) {
 // ISHR: Right shift of negative int
 func TestNewIshrNeg(t *testing.T) {
 	f := newFrame(opcodes.ISHR)
-	push(&f, int64(-200))
-	push(&f, int64(3)) // shift right 3 bits
+	push(f, int64(-200))
+	push(f, int64(3)) // shift right 3 bits
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(int64) // longs require two slots, so popped twice
+	value := pop(f).(int64) // longs require two slots, so popped twice
 
 	if value != -25 { // 200 >> 3 = -25
 		t.Errorf("ISHR: expected a result of -25, but got: %d", value)
@@ -585,10 +585,10 @@ func TestNewIstore(t *testing.T) {
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
-	push(&f, int64(0x22223))
+	push(f, int64(0x22223))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.Locals[2] != int64(0x22223) {
@@ -608,10 +608,10 @@ func TestNewIstoreByte(t *testing.T) {
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
-	push(&f, uint8(0x22))
+	push(f, uint8(0x22))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.Locals[2] != int64(0x22) {
@@ -627,9 +627,9 @@ func TestNewIstoreByte(t *testing.T) {
 func TestNewIstore0(t *testing.T) {
 	f := newFrame(opcodes.ISTORE_0)
 	f.Locals = append(f.Locals, zero)
-	push(&f, int64(220))
+	push(f, int64(220))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Locals[0] != int64(220) {
 		t.Errorf("ISTORE_0: expected locals[0] to be 220, got: %d", f.Locals[0])
@@ -645,9 +645,9 @@ func TestNewIstore0(t *testing.T) {
 func TestNewIstore0Byte(t *testing.T) {
 	f := newFrame(opcodes.ISTORE_0)
 	f.Locals = append(f.Locals, zero)
-	push(&f, byte(220))
+	push(f, byte(220))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Locals[0] != int64(220) {
 		t.Errorf("ISTORE_0: expected locals[0] to be int64 of value 220, got value of: %d", f.Locals[0])
@@ -663,9 +663,9 @@ func TestNewIstore0Byte(t *testing.T) {
 func TestNewIstore0Uint32(t *testing.T) {
 	f := newFrame(opcodes.ISTORE_0)
 	f.Locals = append(f.Locals, zero)
-	push(&f, uint32(220))
+	push(f, uint32(220))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Locals[0] != int64(220) {
 		t.Errorf("ISTORE_0: expected locals[0] to be int64 of value 220, got value of: %d", f.Locals[0])
@@ -678,9 +678,9 @@ func TestNewIstore0Uint32(t *testing.T) {
 func TestNewIstore0BooleanTrue(t *testing.T) {
 	f := newFrame(opcodes.ISTORE_0)
 	f.Locals = append(f.Locals, zero)
-	push(&f, true)
+	push(f, true)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Locals[0] != types.JavaBoolTrue {
 		t.Errorf("ISTORE_0: expected locals[0] to be int64 of value 1, got value of: %d", f.Locals[0])
@@ -693,9 +693,9 @@ func TestNewIstore0BooleanTrue(t *testing.T) {
 func TestNewIstore0BooleanFalse(t *testing.T) {
 	f := newFrame(opcodes.ISTORE_0)
 	f.Locals = append(f.Locals, zero)
-	push(&f, false)
+	push(f, false)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Locals[0] != types.JavaBoolFalse {
 		t.Errorf("ISTORE_0: expected locals[0] to be int64 of value 0, got value of: %d", f.Locals[0])
@@ -710,9 +710,9 @@ func TestNewIstore1(t *testing.T) {
 	f := newFrame(opcodes.ISTORE_1)
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
-	push(&f, int64(221))
+	push(f, int64(221))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Locals[1] != int64(221) {
 		t.Errorf("ISTORE_1: expected locals[1] to be 221, got: %d", f.Locals[1])
@@ -728,9 +728,9 @@ func TestNewIstore2(t *testing.T) {
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
-	push(&f, int64(222))
+	push(f, int64(222))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Locals[2] != int64(222) {
 		t.Errorf("ISTORE_2: expected locals[2] to be 222, got: %d", f.Locals[2])
@@ -747,9 +747,9 @@ func TestNewIstore3(t *testing.T) {
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
-	push(&f, int64(223))
+	push(f, int64(223))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.Locals[3] != int64(223) {
 		t.Errorf("ISTORE_3: expected locals[3] to be 223, got: %d", f.Locals[3])
@@ -762,15 +762,15 @@ func TestNewIstore3(t *testing.T) {
 // ISUB: integer subtraction
 func TestNewIsub(t *testing.T) {
 	f := newFrame(opcodes.ISUB)
-	push(&f, int64(10))
-	push(&f, int64(7))
+	push(f, int64(10))
+	push(f, int64(7))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("ISUB, Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 3 {
 		t.Errorf("ISUB: Expected popped value to be 3, got: %d", value)
 	}
@@ -778,10 +778,10 @@ func TestNewIsub(t *testing.T) {
 
 func TestIsubUnderflow(t *testing.T) {
 	f := newFrame(opcodes.ISUB)
-	push(&f, int64(math.MinInt32))
-	push(&f, int64(1))
+	push(f, int64(math.MinInt32))
+	push(f, int64(1))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -796,15 +796,15 @@ func TestIsubUnderflow(t *testing.T) {
 // IUSHR: unsigned right shift of int
 func TestNewIushr(t *testing.T) {
 	f := newFrame(opcodes.IUSHR)
-	push(&f, int64(-200))
-	push(&f, int64(3)) // shift right 3 bits
+	push(f, int64(-200))
+	push(f, int64(3)) // shift right 3 bits
 	expected := int64(536870887)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 
 	if value != expected {
 		t.Errorf("IUSHR: expected a result of %d, but got: %d", expected, value)
@@ -818,14 +818,14 @@ func TestNewIushr(t *testing.T) {
 // IXOR: Logical XOR of two ints
 func TestNewIxor(t *testing.T) {
 	f := newFrame(opcodes.IXOR)
-	push(&f, int64(21))
-	push(&f, int64(22))
+	push(f, int64(21))
+	push(f, int64(22))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 3 { // 21 ^ 22 = 3
 		t.Errorf("IXOR: expected a result of 3, but got: %d", value)
 	}
@@ -844,7 +844,7 @@ func TestJSR(t *testing.T) {
 	f.Meth = append(f.Meth, 0x00)
 	f.Meth = append(f.Meth, 0xFF)
 
-	ret := int64(doJsr(&f, 0))
+	ret := int64(doJsr(f, 0))
 
 	if ret != int64(4) {
 		t.Errorf("JSR: expected jump of 4, got: %d", ret)
@@ -859,7 +859,7 @@ func TestWideJsr(t *testing.T) {
 	f.Meth = append(f.Meth, 0x00)
 	f.Meth = append(f.Meth, 0x04)
 
-	ret := int64(doJsrw(&f, 0))
+	ret := int64(doJsrw(f, 0))
 
 	if ret != int64(4) {
 		t.Errorf("JSR_W: expected jump of 4, got: %d", ret)
@@ -869,14 +869,14 @@ func TestWideJsr(t *testing.T) {
 // L2D: Convert long to double
 func TestNewL2d(t *testing.T) {
 	f := newFrame(opcodes.L2D)
-	push(&f, int64(21)) // longs require two slots, so pushed twice
-	push(&f, int64(21))
+	push(f, int64(21)) // longs require two slots, so pushed twice
+	push(f, int64(21))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	val := pop(&f).(float64)
+	val := pop(f).(float64)
 	if val != 21.0 {
 		t.Errorf("L2D: expected a result of 21.0, but got: %f", val)
 	}
@@ -888,13 +888,13 @@ func TestNewL2d(t *testing.T) {
 // L2F: Convert long to float
 func TestNewL2f(t *testing.T) {
 	f := newFrame(opcodes.L2F)
-	push(&f, int64(21))
+	push(f, int64(21))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	val := pop(&f).(float64)
+	val := pop(f).(float64)
 	if val != 21.0 {
 		t.Errorf("L2D: expected a result of 21.0, but got: %f", val)
 	}
@@ -907,13 +907,13 @@ func TestNewL2f(t *testing.T) {
 // L2I: Convert long to int
 func TestNewL2i(t *testing.T) {
 	f := newFrame(opcodes.L2I)
-	push(&f, int64(21))
+	push(f, int64(21))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	val := pop(&f).(int64)
+	val := pop(f).(int64)
 	if val != 21 {
 		t.Errorf("L2I: expected a result of 21, but got: %d", val)
 	}
@@ -926,13 +926,13 @@ func TestNewL2i(t *testing.T) {
 // L2I: Convert long to int (test with negative value)
 func TestNewL2ineg(t *testing.T) {
 	f := newFrame(opcodes.L2I)
-	push(&f, int64(-21))
+	push(f, int64(-21))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	val := pop(&f).(int64)
+	val := pop(f).(int64)
 	if val != -21 {
 		t.Errorf("L2I: expected a result of -21, but got: %d", val)
 	}
@@ -945,14 +945,14 @@ func TestNewL2ineg(t *testing.T) {
 // LADD: Add two longs
 func TestNewLadd(t *testing.T) {
 	f := newFrame(opcodes.LADD)
-	push(&f, int64(21))
-	push(&f, int64(22))
+	push(f, int64(21))
+	push(f, int64(22))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(int64) // longs require two slots, so popped twice
+	value := pop(f).(int64) // longs require two slots, so popped twice
 
 	if value != 43 {
 		t.Errorf("LADD: expected a result of 43, but got: %d", value)
@@ -965,14 +965,14 @@ func TestNewLadd(t *testing.T) {
 // LAND: Logical and of two longs, push result
 func TestNewLand(t *testing.T) {
 	f := newFrame(opcodes.LAND)
-	push(&f, int64(21))
-	push(&f, int64(22))
+	push(f, int64(21))
+	push(f, int64(22))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 
 	if value != 20 { // 21 & 22 = 20
 		t.Errorf("LAND: expected a result of 20, but got: %d", value)
@@ -985,14 +985,14 @@ func TestNewLand(t *testing.T) {
 // LCMP: compare two longs (using two equal values)
 func TestNewLcmpEQ(t *testing.T) {
 	f := newFrame(opcodes.LCMP)
-	push(&f, int64(21))
-	push(&f, int64(21))
+	push(f, int64(21))
+	push(f, int64(21))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 0 {
 		t.Errorf("LCMP: Expected comparison to result in 0, got: %d", value)
 	}
@@ -1004,14 +1004,14 @@ func TestNewLcmpEQ(t *testing.T) {
 // LCMP: compare two longs (with val1 > val2)
 func TestNewLcmpGT(t *testing.T) {
 	f := newFrame(opcodes.LCMP)
-	push(&f, int64(22)) // longs require two slots, so pushed twice
-	push(&f, int64(21))
+	push(f, int64(22)) // longs require two slots, so pushed twice
+	push(f, int64(21))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 1 {
 		t.Errorf("LCMP: Expected comparison to result in 1, got: %d", value)
 	}
@@ -1023,14 +1023,14 @@ func TestNewLcmpGT(t *testing.T) {
 // LCMP: compare two longs (using val1 < val2)
 func TestNewLcmpLT(t *testing.T) {
 	f := newFrame(opcodes.LCMP)
-	push(&f, int64(21))
-	push(&f, int64(22))
+	push(f, int64(21))
+	push(f, int64(22))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != -1 {
 		t.Errorf("LCMP: Expected comparison to result in -1, got: %d", value)
 	}
@@ -1043,12 +1043,12 @@ func TestNewLcmpLT(t *testing.T) {
 func TestNewLconst0(t *testing.T) {
 	f := newFrame(opcodes.LCONST_0)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 0 {
 		t.Errorf("LCONST_0: Expected popped value to be 0, got: %d", value)
 	}
@@ -1058,12 +1058,12 @@ func TestNewLconst0(t *testing.T) {
 func TestNewLconst1(t *testing.T) {
 	f := newFrame(opcodes.LCONST_1)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 1 {
 		t.Errorf("LCONST_1: Expected popped value to be 1, got: %d", value)
 	}
@@ -1091,12 +1091,12 @@ func TestNewLdc(t *testing.T) {
 	CP.CpIndex = append(CP.CpIndex, doubleEntry)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 25 {
 		t.Errorf("LDC_W: Expected popped value to be 25, got: %d", value)
 	}
@@ -1126,13 +1126,13 @@ func TestNewLdcTest2(t *testing.T) {
 	CP.CpIndex = append(CP.CpIndex, stringEntry)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
 
-	strObj := pop(&f).(*object.Object)
+	strObj := pop(f).(*object.Object)
 	str := object.GoStringFromJavaByteArray(strObj.FieldTable["value"].Fvalue.([]types.JavaByte))
 	index := stringPool.GetStringIndex(&str)
 	checkStrPtr := stringPool.GetStringPointer(index)
@@ -1170,7 +1170,7 @@ func TestNewLdcInvalidDouble(t *testing.T) {
 	CP.CpIndex = append(CP.CpIndex, stringEntry)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -1211,12 +1211,12 @@ func TestNewLdcw(t *testing.T) {
 	CP.CpIndex = append(CP.CpIndex, doubleEntry)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 25 {
 		t.Errorf("LDC_W: Expected popped value to be 25, got: %d", value)
 	}
@@ -1245,12 +1245,12 @@ func TestNewLdcwFloat(t *testing.T) {
 	CP.CpIndex = append(CP.CpIndex, floatEntry)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	if value != 25.0 {
 		t.Errorf("LDC_W: Expected popped value to be 25.0, got: %f", value)
 	}
@@ -1279,12 +1279,12 @@ func TestNewLdc2wForDouble(t *testing.T) {
 	CP.CpIndex = append(CP.CpIndex, doubleEntry)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(float64)
+	value := pop(f).(float64)
 	if value != 25.0 {
 		t.Errorf("LDC2_W: Expected popped value to be 25.0, got: %f", value)
 	}
@@ -1313,14 +1313,14 @@ func TestNewLdc2wForLong(t *testing.T) {
 	CP.CpIndex = append(CP.CpIndex, doubleEntry)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 25. {
 		t.Errorf("LDC2_W: Expected popped value to be 25, got: %d", value)
 	}
@@ -1356,7 +1356,7 @@ func TestNewLdc2wInvalidForString(t *testing.T) {
 	CP.CpIndex = append(CP.CpIndex, stringEntry)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -1377,18 +1377,18 @@ func TestNewLdc2wInvalidForString(t *testing.T) {
 // LDIV: (pop 2 longs, divide second term by top of stack, push result)
 func TestNewLdiv(t *testing.T) {
 	f := newFrame(opcodes.LDIV)
-	push(&f, int64(70))
-	push(&f, int64(10))
+	push(f, int64(70))
+	push(f, int64(10))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != 0 {
 		t.Errorf("LDIV, Top of stack, expected 0, got: %d", f.TOS)
 	}
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 7 {
 		t.Errorf("LDIV: Expected popped value to be 70, got: %d", value)
 	}
@@ -1407,11 +1407,11 @@ func TestLdiv_DivideByZero_DefaultMessage(t *testing.T) {
 
 	f := newFrame(opcodes.LDIV)
 	// dividend / divisor; here divisor = 0 to trigger error
-	push(&f, int64(10)) // dividend
-	push(&f, int64(0))  // divisor
+	push(f, int64(10)) // dividend
+	push(f, int64(0))  // divisor
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -1436,11 +1436,11 @@ func TestLdiv_DivideByZero_StrictJDK(t *testing.T) {
 	os.Stderr = w
 
 	f := newFrame(opcodes.LDIV)
-	push(&f, int64(5)) // dividend
-	push(&f, int64(0)) // divisor
+	push(f, int64(5)) // dividend
+	push(f, int64(0)) // divisor
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -1459,12 +1459,12 @@ func TestLdiv_NegativeOperands(t *testing.T) {
 
 	// Case 1: negative dividend
 	f1 := newFrame(opcodes.LDIV)
-	push(&f1, int64(-7)) // dividend
-	push(&f1, int64(3))  // divisor
+	push(f1, int64(-7)) // dividend
+	push(f1, int64(3))  // divisor
 	fs1 := frames.CreateFrameStack()
-	fs1.PushFront(&f1)
+	fs1.PushFront(f1)
 	interpret(fs1)
-	got1 := pop(&f1).(int64)
+	got1 := pop(f1).(int64)
 	if got1 != -2 { // -7/3 truncates toward 0
 		t.Fatalf("LDIV negative dividend: want -2, got %d", got1)
 	}
@@ -1474,12 +1474,12 @@ func TestLdiv_NegativeOperands(t *testing.T) {
 
 	// Case 2: negative divisor
 	f2 := newFrame(opcodes.LDIV)
-	push(&f2, int64(7))  // dividend
-	push(&f2, int64(-3)) // divisor
+	push(f2, int64(7))  // dividend
+	push(f2, int64(-3)) // divisor
 	fs2 := frames.CreateFrameStack()
-	fs2.PushFront(&f2)
+	fs2.PushFront(f2)
 	interpret(fs2)
-	got2 := pop(&f2).(int64)
+	got2 := pop(f2).(int64)
 	if got2 != -2 { // 7/(-3) truncates toward 0
 		t.Fatalf("LDIV negative divisor: want -2, got %d", got2)
 	}

--- a/src/jvm/interpreter_INVOKE_test.go
+++ b/src/jvm/interpreter_INVOKE_test.go
@@ -43,10 +43,10 @@ func TestInvokeInterface_NotPointingToInterface(t *testing.T) {
 	f.CP = &CP
 
 	// push a dummy object (won't be used because we fail earlier)
-	push(&f, object.MakeEmptyObject())
+	push(f, object.MakeEmptyObject())
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -79,10 +79,10 @@ func TestInvokeInterface_NonZeroZeroByte(t *testing.T) {
 	CP.InterfaceRefs[0] = classloader.InterfaceRefEntry{ClassIndex: 0, NameAndType: 0}
 	f.CP = &CP
 
-	push(&f, object.MakeEmptyObject())
+	push(f, object.MakeEmptyObject())
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -132,10 +132,10 @@ func TestInvokeInterface_NullObjectRef(t *testing.T) {
 	f.CP = &CP
 
 	// Push a nil interface{} directly, so objRef == nil triggers
-	push(&f, nil)
+	push(f, nil)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -189,10 +189,10 @@ func TestInvokeInterface_ObjectClassNotFound(t *testing.T) {
 	bogusClass := "no/such/Class"
 	obj := object.MakeEmptyObject()
 	obj.KlassName = stringPool.GetStringIndex(&bogusClass)
-	push(&f, obj)
+	push(f, obj)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -251,10 +251,10 @@ func TestInvokeInterface_TargetNotAnInterface(t *testing.T) {
 	someClass := "pkg/SomeClass"
 	obj := object.MakeEmptyObject()
 	obj.KlassName = stringPool.GetStringIndex(&someClass)
-	push(&f, obj)
+	push(f, obj)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -315,9 +315,9 @@ func TestNewInvokeSpecialJavaLangObject(t *testing.T) {
 	f.CP = &CP
 	classloader.ResolveCPmethRefs(&CP)
 	classname := "java/lang/Object"
-	push(&f, object.MakeEmptyObjectWithClassName(&classname))
+	push(f, object.MakeEmptyObjectWithClassName(&classname))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 
 	interpret(fs)
 
@@ -387,10 +387,10 @@ func TestNewInvokeSpecialGmethodNoParams(t *testing.T) {
 	f.CP = &CP
 	classloader.ResolveCPmethRefs(&CP)
 	obj := object.MakeEmptyObject()
-	push(&f, obj) // INVOKESPECIAL expects a pointer to an object on the op stack
+	push(f, obj) // INVOKESPECIAL expects a pointer to an object on the op stack
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -458,10 +458,10 @@ func TestNewInvokeSpecialGmethodNoParamsReturnsD(t *testing.T) {
 	f.CP = &CP
 	classloader.ResolveCPmethRefs(&CP)
 	obj := object.MakeEmptyObject()
-	push(&f, obj) // INVOKESPECIAL expects a pointer to an object on the op stack
+	push(f, obj) // INVOKESPECIAL expects a pointer to an object on the op stack
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -529,11 +529,11 @@ func TestNewInvokeSpecialGmethodErrorReturn(t *testing.T) {
 	f.CP = &CP
 	classloader.ResolveCPmethRefs(&CP)
 	obj := object.MakeEmptyObject()
-	push(&f, obj)        // INVOKESPECIAL expects a pointer to an object on the op stack
-	push(&f, int64(999)) // push the one param
+	push(f, obj)        // INVOKESPECIAL expects a pointer to an object on the op stack
+	push(f, int64(999)) // push the one param
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -636,7 +636,7 @@ func TestNewInvokeStaticGmethodNoParams(t *testing.T) {
 
 	classloader.MethAreaInsert(className, &k)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -704,7 +704,7 @@ func TestNewInvokeStaticGmethodErrorReturn(t *testing.T) {
 	f.CP = &CP
 	classloader.ResolveCPmethRefs(&CP)
 
-	push(&f, int64(999)) // push the one param
+	push(f, int64(999)) // push the one param
 
 	// INVOKESTATIC needs a parsed/loaded object in the MethArea to function
 	clData := classloader.ClData{
@@ -738,7 +738,7 @@ func TestNewInvokeStaticGmethodErrorReturn(t *testing.T) {
 	// classloader.JLCmap[className] = &jlc
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()

--- a/src/jvm/interpreter_LL-end_test.go
+++ b/src/jvm/interpreter_LL-end_test.go
@@ -40,9 +40,9 @@ func TestLload(t *testing.T) {
 	f.Locals = append(f.Locals, int64(0x1234562)) // put value in locals[4]
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	x := pop(&f).(int64)
+	x := pop(f).(int64)
 	if x != 0x1234562 {
 		t.Errorf("LLOAD: Expecting 0x1234562 on stack, got: 0x%x", x)
 	}
@@ -60,10 +60,10 @@ func TestLload0(t *testing.T) {
 	f.Locals = append(f.Locals, int64(0x12345678)) // put value in locals[0]
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	x := pop(&f).(int64)
+	x := pop(f).(int64)
 	if x != 0x12345678 {
 		t.Errorf("LLOAD_0: Expecting 0x12345678 on stack, got: 0x%x", x)
 	}
@@ -80,9 +80,9 @@ func TestLload1(t *testing.T) {
 	f.Locals = append(f.Locals, int64(0x12345678)) // put value in locals[1]
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	x := pop(&f).(int64)
+	x := pop(f).(int64)
 
 	if x != 0x12345678 {
 		t.Errorf("LLOAD_1: Expecting 0x12345678 on stack, got: 0x%x", x)
@@ -101,9 +101,9 @@ func TestLload2(t *testing.T) {
 	f.Locals = append(f.Locals, int64(0x12345678)) // put value in locals[2]
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	x := pop(&f).(int64)
+	x := pop(f).(int64)
 
 	if x != 0x12345678 {
 		t.Errorf("LLOAD_2: Expecting 0x12345678 on stack, got: 0x%x", x)
@@ -127,9 +127,9 @@ func TestLload3(t *testing.T) {
 	f.Locals = append(f.Locals, int64(0x12345678)) // put value in locals[3]
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	x := pop(&f).(int64)
+	x := pop(f).(int64)
 	if x != 0x12345678 {
 		t.Errorf("LLOAD_3: Expecting 0x12345678 on stack, got: 0x%x", x)
 	}
@@ -142,18 +142,18 @@ func TestLload3(t *testing.T) {
 // LMUL: pop 2 longs, multiply them, push result
 func TestLmul(t *testing.T) {
 	f := newFrame(opcodes.LMUL)
-	push(&f, int64(10))
-	push(&f, int64(7))
+	push(f, int64(10))
+	push(f, int64(7))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != 0 {
 		t.Errorf("LMUL, Top of stack, expected 0, got: %d", f.TOS)
 	}
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 70 {
 		t.Errorf("LMUL: Expected popped value to be 70, got: %d", value)
 	}
@@ -162,17 +162,17 @@ func TestLmul(t *testing.T) {
 // LNEG: negate a long
 func TestLneg(t *testing.T) {
 	f := newFrame(opcodes.LNEG)
-	push(&f, int64(10))
+	push(f, int64(10))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != 0 {
 		t.Errorf("LNEG, Top of stack, expected 0, got: %d", f.TOS)
 	}
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != -10 {
 		t.Errorf("LNEG: Expected popped value to be -10, got: %d", value)
 	}
@@ -183,7 +183,7 @@ func TestLookupswitch_MatchCase(t *testing.T) {
 
 	f := newFrame(opcodes.LOOKUPSWITCH)
 	// key to match
-	push(&f, int64(10))
+	push(f, int64(10))
 
 	// Align: with PC==0 for the opcode, padding is 3 bytes (so PC+1 becomes 4)
 	f.Meth = append(f.Meth, 0x00, 0x00, 0x00)
@@ -201,7 +201,7 @@ func TestLookupswitch_MatchCase(t *testing.T) {
 	f.Meth = append(f.Meth, 0x00, 0x00, 0x00, 0x1E) // 30
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	if f.PC != 30 {
@@ -218,7 +218,7 @@ func TestLookupswitch_DefaultNoMatch(t *testing.T) {
 
 	f := newFrame(opcodes.LOOKUPSWITCH)
 	// key that does not match any pair
-	push(&f, int64(99))
+	push(f, int64(99))
 
 	// padding
 	f.Meth = append(f.Meth, 0x00, 0x00, 0x00)
@@ -236,7 +236,7 @@ func TestLookupswitch_DefaultNoMatch(t *testing.T) {
 	f.Meth = append(f.Meth, 0x00, 0x00, 0x00, 0x1E)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	if f.PC != 100 {
@@ -252,7 +252,7 @@ func TestLookupswitch_ZeroPairs_Default(t *testing.T) {
 	globals.InitGlobals("test")
 
 	f := newFrame(opcodes.LOOKUPSWITCH)
-	push(&f, int64(12345)) // any key; there are zero pairs
+	push(f, int64(12345)) // any key; there are zero pairs
 
 	// padding
 	f.Meth = append(f.Meth, 0x00, 0x00, 0x00)
@@ -263,7 +263,7 @@ func TestLookupswitch_ZeroPairs_Default(t *testing.T) {
 	f.Meth = append(f.Meth, 0x00, 0x00, 0x00, 0x00)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	if f.PC != 42 {
@@ -279,7 +279,7 @@ func TestLookupswitch_NegativeJump(t *testing.T) {
 	globals.InitGlobals("test")
 
 	f := newFrame(opcodes.LOOKUPSWITCH)
-	push(&f, int64(1)) // match key 1
+	push(f, int64(1)) // match key 1
 
 	// padding
 	f.Meth = append(f.Meth, 0x00, 0x00, 0x00)
@@ -301,7 +301,7 @@ func TestLookupswitch_NegativeJump(t *testing.T) {
 	f.MethType = "()V"
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 
 	t.Log("Expected exception: \"LOOKUPSWITCH ... impossible jump\"")
 	interpret(fs)
@@ -317,14 +317,14 @@ func TestLookupswitch_NegativeJump(t *testing.T) {
 // LOR: Logical OR of two longs
 func TestLor(t *testing.T) {
 	f := newFrame(opcodes.LOR)
-	push(&f, int64(21))
-	push(&f, int64(22))
+	push(f, int64(21))
+	push(f, int64(22))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(int64) // longs require two slots, so popped twice
+	value := pop(f).(int64) // longs require two slots, so popped twice
 
 	if value != 23 { // 21 | 22 = 23
 		t.Errorf("LOR: expected a result of 23, but got: %d", value)
@@ -338,18 +338,18 @@ func TestLor(t *testing.T) {
 // LREM: remainder of long division (the % operator)
 func TestLrem(t *testing.T) {
 	f := newFrame(opcodes.LREM)
-	push(&f, int64(74))
-	push(&f, int64(6))
+	push(f, int64(74))
+	push(f, int64(6))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != 0 {
 		t.Errorf("LREM, Top of stack, expected 0, got: %d", f.TOS)
 	}
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 2 {
 		t.Errorf("LREM: Expected popped value to be 2, got: %d", value)
 	}
@@ -365,11 +365,11 @@ func TestLremDivideByZero(t *testing.T) {
 	os.Stderr = w
 
 	f := newFrame(opcodes.LREM)
-	push(&f, int64(6))
-	push(&f, int64(0))
+	push(f, int64(6))
+	push(f, int64(0))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// reset stderr to its normal stream
@@ -386,13 +386,13 @@ func TestLremDivideByZero(t *testing.T) {
 // LRETURN: Return a long from a function
 func TestLreturn(t *testing.T) {
 	f0 := newFrame(0)
-	push(&f0, int64(20))
+	push(f0, int64(20))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f0)
+	fs.PushFront(f0)
 	f1 := newFrame(opcodes.LRETURN)
-	push(&f1, int64(21))
+	push(f1, int64(21))
 
-	fs.PushFront(&f1)
+	fs.PushFront(f1)
 	interpret(fs) // LRETURN pops the topmost frame it's returning from
 
 	f3 := fs.Front().Value.(*frames.Frame)
@@ -405,14 +405,14 @@ func TestLreturn(t *testing.T) {
 // LSHL: Left shift of long
 func TestLshl(t *testing.T) {
 	f := newFrame(opcodes.LSHL)
-	push(&f, int64(22))
-	push(&f, int64(3)) // shift left 3 bits
+	push(f, int64(22))
+	push(f, int64(3)) // shift left 3 bits
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(int64) // longs require two slots, so popped twice
+	value := pop(f).(int64) // longs require two slots, so popped twice
 
 	if value != 176 { // 22 << 3 = 176
 		t.Errorf("LSHL: expected a result of 176, but got: %d", value)
@@ -425,15 +425,15 @@ func TestLshl(t *testing.T) {
 // LSHR: Right shift of long
 func TestLshr(t *testing.T) {
 	f := newFrame(opcodes.LSHR)
-	push(&f, int64(200))
+	push(f, int64(200))
 
-	push(&f, int64(3)) // shift left 3 bits
+	push(f, int64(3)) // shift left 3 bits
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(int64) // longs require two slots, so popped twice
+	value := pop(f).(int64) // longs require two slots, so popped twice
 
 	if value != 25 { // 200 >> 3 = 25
 		t.Errorf("LSHR: expected a result of 25, but got: %d", value)
@@ -451,10 +451,10 @@ func TestLstore(t *testing.T) {
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
-	push(&f, int64(0x22223))
+	push(f, int64(0x22223))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.Locals[2] != int64(0x22223) {
@@ -471,10 +471,10 @@ func TestLstore0(t *testing.T) {
 	f := newFrame(opcodes.LSTORE_0)
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero) // LSTORE instructions fill two local variables (with the same value)
-	push(&f, int64(0x12345678))
+	push(f, int64(0x12345678))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.Locals[0] != int64(0x12345678) {
@@ -492,10 +492,10 @@ func TestLstore1(t *testing.T) {
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
-	push(&f, int64(0x12345678))
+	push(f, int64(0x12345678))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.Locals[1] != int64(0x12345678) {
@@ -514,10 +514,10 @@ func TestLstore2(t *testing.T) {
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero) // LSTORE instructions fill two local variables (with the same value)
-	push(&f, int64(0x12345678))
+	push(f, int64(0x12345678))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.Locals[2] != int64(0x12345678) {
@@ -537,10 +537,10 @@ func TestLstore3(t *testing.T) {
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero)
 	f.Locals = append(f.Locals, zero) // LSTORE instructions fill two local variables (with the same value)
-	push(&f, int64(0x12345678))
+	push(f, int64(0x12345678))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.Locals[3] != int64(0x12345678) {
@@ -555,14 +555,14 @@ func TestLstore3(t *testing.T) {
 // LSUB: Subtract two longs
 func TestLsub(t *testing.T) {
 	f := newFrame(opcodes.LSUB)
-	push(&f, int64(10))
-	push(&f, int64(7))
+	push(f, int64(10))
+	push(f, int64(7))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 
 	if f.TOS != -1 {
 		t.Errorf("LSUB, Top of stack, expected -1, got: %d", f.TOS)
@@ -576,14 +576,14 @@ func TestLsub(t *testing.T) {
 // LUSHR: Right unsigned shift of long
 func TestLushr(t *testing.T) {
 	f := newFrame(opcodes.LUSHR)
-	push(&f, int64(200))
-	push(&f, int64(3)) // shift left 3 bits
+	push(f, int64(200))
+	push(f, int64(3)) // shift left 3 bits
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(int64) // longs require two slots, so popped twice
+	value := pop(f).(int64) // longs require two slots, so popped twice
 
 	if value != 25 { // 200 >> 3 = 25
 		t.Errorf("LUSHR: expected a result of 25, but got: %d", value)
@@ -596,14 +596,14 @@ func TestLushr(t *testing.T) {
 // LXOR: Logical XOR of two longs
 func TestLxor(t *testing.T) {
 	f := newFrame(opcodes.LXOR)
-	push(&f, int64(21))
-	push(&f, int64(22))
+	push(f, int64(21))
+	push(f, int64(22))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	value := pop(&f).(int64) // longs require two slots, so popped twice
+	value := pop(f).(int64) // longs require two slots, so popped twice
 
 	if value != 3 { // 21 ^ 22 = 3
 		t.Errorf("LXOR: expected a result of 3, but got: %d", value)
@@ -618,10 +618,10 @@ func TestMonitorEnter(t *testing.T) {
 	globals.InitGlobals("test")
 	f := newFrame(opcodes.MONITORENTER)
 	obj := object.MakeEmptyObject()
-	push(&f, obj) // push an object and make sure it gets popped off
+	push(f, obj) // push an object and make sure it gets popped off
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != -1 {
@@ -642,7 +642,7 @@ func TestMonitorEnter_StackUnderflow(t *testing.T) {
 	// no operand pushed -> TOS stays -1
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -665,10 +665,10 @@ func TestMonitorEnter_InvalidRefType(t *testing.T) {
 
 	f := newFrame(opcodes.MONITORENTER)
 	// push a non-object (string) to trigger type assertion failure
-	push(&f, "not-an-object")
+	push(f, "not-an-object")
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -700,10 +700,10 @@ func TestMonitorEnter_ObjLockError_GCMarked(t *testing.T) {
 	obj := object.MakeEmptyObject()
 	object.SetLockState(obj, 0b11) // lockStateGCMarked
 
-	push(&f, obj)
+	push(f, obj)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -723,10 +723,10 @@ func TestMonitorEnter_Success_LocksObject(t *testing.T) {
 
 	f := newFrame(opcodes.MONITORENTER)
 	obj := object.MakeEmptyObject()
-	push(&f, obj)
+	push(f, obj)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	if f.TOS != -1 {
@@ -743,10 +743,10 @@ func TestMonitorExit(t *testing.T) {
 	f := newFrame(opcodes.MONITOREXIT)
 	obj := object.MakeEmptyObject()
 	_ = obj.ObjLock(int32(f.Thread))
-	push(&f, obj) // push a locked object and make sure it gets popped off
+	push(f, obj) // push a locked object and make sure it gets popped off
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != -1 {
@@ -766,7 +766,7 @@ func TestMonitorExit_StackUnderflow(t *testing.T) {
 	// nothing pushed; TOS remains -1
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -789,10 +789,10 @@ func TestMonitorExit_InvalidRefType(t *testing.T) {
 
 	f := newFrame(opcodes.MONITOREXIT)
 	// push a non-object (string) to trigger type assertion failure
-	push(&f, "not-an-object")
+	push(f, "not-an-object")
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -817,10 +817,10 @@ func TestMonitorExit_Success_UnlocksObject(t *testing.T) {
 		t.Fatalf("setup: ObjLock failed: %v", err)
 	}
 
-	push(&f, obj)
+	push(f, obj)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	if f.TOS != -1 {
@@ -845,10 +845,10 @@ func TestMonitorExit_AlreadyUnlocked(t *testing.T) {
 	f.MethType = "()V"
 
 	obj := object.MakeEmptyObject() // unlocked by default
-	push(&f, obj)
+	push(f, obj)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -879,10 +879,10 @@ func TestMonitorExit_FatLocked_MonitorNil(t *testing.T) {
 	// Force header to fat-locked but leave Monitor nil to trigger error path
 	object.SetObjectFatLocked(obj)
 
-	push(&f, obj)
+	push(f, obj)
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	_ = w.Close()
@@ -1067,19 +1067,19 @@ func TestPeekWithStackUnderflowStrictJDK(t *testing.T) {
 // POP: pop item off stack and discard it
 func TestPop(t *testing.T) {
 	f := newFrame(opcodes.POP)
-	push(&f, int64(34)) // push three different values
-	push(&f, int64(21))
-	push(&f, int64(0))
+	push(f, int64(34)) // push three different values
+	push(f, int64(21))
+	push(f, int64(0))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != 1 {
 		t.Errorf("POP: Expected stack with 2 items, but got a tos of: %d", f.TOS)
 	}
 
-	top := pop(&f).(int64)
+	top := pop(f).(int64)
 
 	if top != 21 {
 		t.Errorf("POP: expected top's value to be 21, but got: %d", top)
@@ -1089,12 +1089,12 @@ func TestPop(t *testing.T) {
 // POP with tracing enabled
 func TestPopWithTracing(t *testing.T) {
 	f := newFrame(opcodes.POP)
-	push(&f, int64(34)) // push three different values
-	push(&f, int64(21))
-	push(&f, int64(0))
+	push(f, int64(34)) // push three different values
+	push(f, int64(21))
+	push(f, int64(0))
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)         // push the new frame
+	fs.PushFront(f)         // push the new frame
 	globals.TraceInst = true // turn on tracing
 	interpret(fs)
 
@@ -1102,7 +1102,7 @@ func TestPopWithTracing(t *testing.T) {
 		t.Errorf("POP: Expected stack with 2 items, but got a tos of: %d", f.TOS)
 	}
 
-	top := pop(&f).(int64)
+	top := pop(f).(int64)
 
 	if top != 21 {
 		t.Errorf("POP: expected top's value to be 21, but got: %d", top)
@@ -1212,7 +1212,7 @@ func TestPopBytecodrUnderflow(t *testing.T) {
 
 	f := newFrame(opcodes.POP)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -1231,19 +1231,19 @@ func TestPop2(t *testing.T) {
 
 	f := newFrame(opcodes.POP2)
 	// push three different values; 34 at bottom
-	push(&f, int64(34)) // fload_0 : Load float from local variable
-	push(&f, int64(21)) // iload : Load int from local variable
-	push(&f, int64(10)) // lconst_1 : Push long constant
+	push(f, int64(34)) // fload_0 : Load float from local variable
+	push(f, int64(21)) // iload : Load int from local variable
+	push(f, int64(10)) // lconst_1 : Push long constant
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.TOS != 1 {
 		t.Errorf("POP2: Expected stack with 1 item, but got a tos of: %d", f.TOS)
 	}
 
-	top := pop(&f).(int64)
+	top := pop(f).(int64)
 
 	if top != 21 {
 		t.Errorf("POP2: expected top's value to be 21, but got: %d", top)
@@ -1254,12 +1254,12 @@ func TestPop2(t *testing.T) {
 func TestPop2WithTrace(t *testing.T) {
 	f := newFrame(opcodes.POP2)
 	// push three different values; 34 at bottom
-	push(&f, int64(34)) // fload_0 : Load float from local variable
-	push(&f, int64(21)) // iload : Load int from local variable
-	push(&f, int64(10)) // lconst_1 : Push long constant
+	push(f, int64(34)) // fload_0 : Load float from local variable
+	push(f, int64(21)) // iload : Load int from local variable
+	push(f, int64(10)) // lconst_1 : Push long constant
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)         // push the new frame
+	fs.PushFront(f)         // push the new frame
 	globals.TraceInst = true // turn on tracing
 	interpret(fs)
 
@@ -1267,7 +1267,7 @@ func TestPop2WithTrace(t *testing.T) {
 		t.Errorf("POP2: Expected stack with 1 item, but got a tos of: %d", f.TOS)
 	}
 
-	top := pop(&f).(int64)
+	top := pop(f).(int64)
 
 	if top != 21 {
 		t.Errorf("POP2: expected top's value to be 21, but got: %d", top)
@@ -1289,7 +1289,7 @@ func TestPop2Underflow(t *testing.T) {
 
 	f := newFrame(opcodes.POP2)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -1425,12 +1425,12 @@ func TestPutFieldSimpleInt(t *testing.T) {
 		Ftype:  types.Int,
 		Fvalue: int64(42),
 	}
-	push(&f, obj)
+	push(f, obj)
 
-	push(&f, int64(26)) // update the field to 26
+	push(f, int64(26)) // update the field to 26
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -1485,12 +1485,12 @@ func TestPutFieldDouble(t *testing.T) {
 		Ftype:  types.Double,
 		Fvalue: float64(42.0),
 	}
-	push(&f, obj)
+	push(f, obj)
 
-	push(&f, float64(26.8)) // update the field to 26.8
+	push(f, float64(26.8)) // update the field to 26.8
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -1548,12 +1548,12 @@ func TestPutFieldErrorUpdatingStatic(t *testing.T) {
 		Ftype:  types.Static + types.Int,
 		Fvalue: int64(42),
 	}
-	push(&f, obj)
+	push(f, obj)
 
-	push(&f, int64(26)) // update the field to 26
+	push(f, int64(26)) // update the field to 26
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -1583,7 +1583,7 @@ func TestPutStaticInt(t *testing.T) {
 	f := newFrame(opcodes.PUTSTATIC)
 	f.Meth = append(f.Meth, 0x00)
 	f.Meth = append(f.Meth, 0x01) // Go to slot 0x0001 in the CP
-	push(&f, int64(420))
+	push(f, int64(420))
 
 	CP := classloader.CPool{}
 	CP.CpIndex = make([]classloader.CpEntry, 10, 10)
@@ -1609,7 +1609,7 @@ func TestPutStaticInt(t *testing.T) {
 	})
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -1639,7 +1639,7 @@ func TestPutStaticIntWithTrace(t *testing.T) {
 	f := newFrame(opcodes.PUTSTATIC)
 	f.Meth = append(f.Meth, 0x00)
 	f.Meth = append(f.Meth, 0x01) // Go to slot 0x0001 in the CP
-	push(&f, int64(420))
+	push(f, int64(420))
 
 	CP := classloader.CPool{}
 	CP.CpIndex = make([]classloader.CpEntry, 10, 10)
@@ -1665,7 +1665,7 @@ func TestPutStaticIntWithTrace(t *testing.T) {
 	})
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -1695,7 +1695,7 @@ func TestPutStaticBool(t *testing.T) {
 	f := newFrame(opcodes.PUTSTATIC)
 	f.Meth = append(f.Meth, 0x00)
 	f.Meth = append(f.Meth, 0x01) // Go to slot 0x0001 in the CP
-	push(&f, types.JavaBoolTrue)
+	push(f, types.JavaBoolTrue)
 
 	CP := classloader.CPool{}
 	CP.CpIndex = make([]classloader.CpEntry, 10, 10)
@@ -1721,7 +1721,7 @@ func TestPutStaticBool(t *testing.T) {
 	})
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -1751,7 +1751,7 @@ func TestPutStaticByte(t *testing.T) {
 	f := newFrame(opcodes.PUTSTATIC)
 	f.Meth = append(f.Meth, 0x00)
 	f.Meth = append(f.Meth, 0x01) // Go to slot 0x0001 in the CP
-	push(&f, byte('A'))
+	push(f, byte('A'))
 
 	CP := classloader.CPool{}
 	CP.CpIndex = make([]classloader.CpEntry, 10, 10)
@@ -1777,7 +1777,7 @@ func TestPutStaticByte(t *testing.T) {
 	})
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -1807,7 +1807,7 @@ func TestPutStaticJavaByte(t *testing.T) {
 	f := newFrame(opcodes.PUTSTATIC)
 	f.Meth = append(f.Meth, 0x00)
 	f.Meth = append(f.Meth, 0x01) // Go to slot 0x0001 in the CP
-	push(&f, types.JavaByte('A'))
+	push(f, types.JavaByte('A'))
 
 	CP := classloader.CPool{}
 	CP.CpIndex = make([]classloader.CpEntry, 10, 10)
@@ -1833,7 +1833,7 @@ func TestPutStaticJavaByte(t *testing.T) {
 	})
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -1863,7 +1863,7 @@ func TestPutStaticByteAsInt64(t *testing.T) {
 	f := newFrame(opcodes.PUTSTATIC)
 	f.Meth = append(f.Meth, 0x00)
 	f.Meth = append(f.Meth, 0x01) // Go to slot 0x0001 in the CP
-	push(&f, int64('A'))
+	push(f, int64('A'))
 
 	CP := classloader.CPool{}
 	CP.CpIndex = make([]classloader.CpEntry, 10, 10)
@@ -1889,7 +1889,7 @@ func TestPutStaticByteAsInt64(t *testing.T) {
 	})
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -1919,7 +1919,7 @@ func TestPutStaticFloat(t *testing.T) {
 	f := newFrame(opcodes.PUTSTATIC)
 	f.Meth = append(f.Meth, 0x00)
 	f.Meth = append(f.Meth, 0x01) // Go to slot 0x0001 in the CP
-	push(&f, float64(420.1))
+	push(f, float64(420.1))
 
 	CP := classloader.CPool{}
 	CP.CpIndex = make([]classloader.CpEntry, 10, 10)
@@ -1945,7 +1945,7 @@ func TestPutStaticFloat(t *testing.T) {
 	})
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -1978,7 +1978,7 @@ func TestPutStaticInvalidNoSuchClass(t *testing.T) {
 	f := newFrame(opcodes.PUTSTATIC)
 	f.Meth = append(f.Meth, 0x00)
 	f.Meth = append(f.Meth, 0x01) // Go to slot 0x0001 in the CP
-	push(&f, float64(420.1))
+	push(f, float64(420.1))
 
 	CP := classloader.CPool{}
 	CP.CpIndex = make([]classloader.CpEntry, 10, 10)
@@ -1997,7 +1997,7 @@ func TestPutStaticInvalidNoSuchClass(t *testing.T) {
 	}
 	f.CP = &CP
 
-	ret := doPutStatic(&f, 0)
+	ret := doPutStatic(f, 0)
 
 	_ = w.Close()
 	msg, _ := io.ReadAll(r)
@@ -2015,7 +2015,7 @@ func TestPutStaticInvalidNoSuchClass(t *testing.T) {
 
 // Helper: sets up a frame and constant pool so bytecodes 0..2 form: PUTSTATIC, 0x00, 0x01
 // CP[1] -> FieldRef slot 0 with (className,fldName,fldSig)
-func setupPutStaticFrame(className, fldName, fldSig string) (frames.Frame, *classloader.CPool) {
+func setupPutStaticFrame(className, fldName, fldSig string) (*frames.Frame, *classloader.CPool) {
 	f := newFrame(opcodes.PUTSTATIC)
 	f.Meth = append(f.Meth, 0x00, 0x01)
 
@@ -2045,8 +2045,8 @@ func TestPutStaticStoreBoolean_NoTable_NoTypesType(t *testing.T) {
 	statics.AddStatic(key, statics.Static{Type: types.Bool, Value: int64(0)})
 
 	f, _ := setupPutStaticFrame(cls, fld, types.Bool)
-	push(&f, int64(3)) // doPutStatic will mask with & 0x01
-	ret := doPutStatic(&f, 0)
+	push(f, int64(3)) // doPutStatic will mask with & 0x01
+	ret := doPutStatic(f, 0)
 	if ret != 3 {
 		t.Fatalf("expected ret=3, got %d", ret)
 	}
@@ -2069,8 +2069,8 @@ func TestPutStaticStoreChar_NoTable_NoTypesType(t *testing.T) {
 	statics.AddStatic(key, statics.Static{Type: types.Char, Value: int64(0)})
 
 	f, _ := setupPutStaticFrame(cls, fld, types.Char)
-	push(&f, int64(65))
-	ret := doPutStatic(&f, 0)
+	push(f, int64(65))
+	ret := doPutStatic(f, 0)
 	if ret != 3 {
 		t.Fatalf("expected ret=3, got %d", ret)
 	}
@@ -2093,8 +2093,8 @@ func TestPutStaticStoreShort_NoTable_NoTypesType(t *testing.T) {
 	statics.AddStatic(key, statics.Static{Type: types.Short, Value: int64(0)})
 
 	f, _ := setupPutStaticFrame(cls, fld, types.Short)
-	push(&f, int64(-123))
-	ret := doPutStatic(&f, 0)
+	push(f, int64(-123))
+	ret := doPutStatic(f, 0)
 	if ret != 3 {
 		t.Fatalf("expected ret=3, got %d", ret)
 	}
@@ -2117,8 +2117,8 @@ func TestPutStaticStoreInt_NoTable_NoTypesType(t *testing.T) {
 	statics.AddStatic(key, statics.Static{Type: types.Int, Value: int64(0)})
 
 	f, _ := setupPutStaticFrame(cls, fld, types.Int)
-	push(&f, int64(42))
-	ret := doPutStatic(&f, 0)
+	push(f, int64(42))
+	ret := doPutStatic(f, 0)
 	if ret != 3 {
 		t.Fatalf("expected ret=3, got %d", ret)
 	}
@@ -2141,8 +2141,8 @@ func TestPutStaticStoreLong_NoTable_NoTypesType(t *testing.T) {
 	statics.AddStatic(key, statics.Static{Type: types.Long, Value: int64(0)})
 
 	f, _ := setupPutStaticFrame(cls, fld, types.Long)
-	push(&f, int64(9876543210))
-	ret := doPutStatic(&f, 0)
+	push(f, int64(9876543210))
+	ret := doPutStatic(f, 0)
 	if ret != 3 {
 		t.Fatalf("expected ret=3, got %d", ret)
 	}
@@ -2165,8 +2165,8 @@ func TestPutStaticStoreByteFromInt64_NoTable_NoTypesType(t *testing.T) {
 	statics.AddStatic(key, statics.Static{Type: types.Byte, Value: int64(0)})
 
 	f, _ := setupPutStaticFrame(cls, fld, types.Byte)
-	push(&f, int64(-7))
-	_ = doPutStatic(&f, 0)
+	push(f, int64(-7))
+	_ = doPutStatic(f, 0)
 	if v := statics.Statics[key].Value.(int64); v != -7 {
 		t.Fatalf("expected -7, got %d", v)
 	}
@@ -2182,8 +2182,8 @@ func TestPutStaticStoreByteFromUint8_NoTable_NoTypesType(t *testing.T) {
 	statics.AddStatic(key, statics.Static{Type: types.Byte, Value: int64(0)})
 
 	f, _ := setupPutStaticFrame(cls, fld, types.Byte)
-	push(&f, uint8(250))
-	_ = doPutStatic(&f, 0)
+	push(f, uint8(250))
+	_ = doPutStatic(f, 0)
 	if v := statics.Statics[key].Value.(int64); v != 250 {
 		t.Fatalf("expected 250, got %d", v)
 	}
@@ -2199,8 +2199,8 @@ func TestPutStaticStoreByteFromJavaByte_NoTable_NoTypesType(t *testing.T) {
 	statics.AddStatic(key, statics.Static{Type: types.Byte, Value: int64(0)})
 
 	f, _ := setupPutStaticFrame(cls, fld, types.Byte)
-	push(&f, types.JavaByte(-120))
-	_ = doPutStatic(&f, 0)
+	push(f, types.JavaByte(-120))
+	_ = doPutStatic(f, 0)
 	if v := statics.Statics[key].Value.(int64); v != -120 {
 		t.Fatalf("expected -120, got %d", v)
 	}
@@ -2216,8 +2216,8 @@ func TestPutStaticStoreFloat_NoTable_NoTypesType(t *testing.T) {
 	statics.AddStatic(key, statics.Static{Type: types.Float, Value: float64(0)})
 
 	f, _ := setupPutStaticFrame(cls, fld, types.Float)
-	push(&f, float64(3.5))
-	ret := doPutStatic(&f, 0)
+	push(f, float64(3.5))
+	ret := doPutStatic(f, 0)
 	if ret != 3 {
 		t.Fatalf("expected ret=3, got %d", ret)
 	}
@@ -2240,8 +2240,8 @@ func TestPutStaticStoreDouble_NoTable_NoTypesType(t *testing.T) {
 	statics.AddStatic(key, statics.Static{Type: types.Double, Value: float64(0)})
 
 	f, _ := setupPutStaticFrame(cls, fld, types.Double)
-	push(&f, float64(-42.25))
-	ret := doPutStatic(&f, 0)
+	push(f, float64(-42.25))
+	ret := doPutStatic(f, 0)
 	if ret != 3 {
 		t.Fatalf("expected ret=3, got %d", ret)
 	}
@@ -2264,8 +2264,8 @@ func TestPutStaticStoreRefNil_NoTable_NoTypesType(t *testing.T) {
 	statics.AddStatic(key, statics.Static{Type: types.Ref, Value: object.Null})
 
 	f, _ := setupPutStaticFrame(cls, fld, "Ljava/lang/Object;")
-	push(&f, nil)
-	_ = doPutStatic(&f, 0)
+	push(f, nil)
+	_ = doPutStatic(f, 0)
 	st := statics.Statics[key]
 	if st.Type != types.Ref {
 		t.Fatalf("type mismatch: %v", st.Type)
@@ -2286,8 +2286,8 @@ func TestPutStaticStoreRefObject_NoTable_NoTypesType(t *testing.T) {
 
 	f, _ := setupPutStaticFrame(cls, fld, "Ljava/lang/Object;")
 	obj := object.MakeEmptyObject()
-	push(&f, obj)
-	_ = doPutStatic(&f, 0)
+	push(f, obj)
+	_ = doPutStatic(f, 0)
 	st := statics.Statics[key]
 	if st.Type != types.Ref {
 		t.Fatalf("type mismatch: %v", st.Type)
@@ -2308,8 +2308,8 @@ func TestPutStaticClassNotFound_NoTable_NoTypesType(t *testing.T) {
 	os.Stderr = w
 
 	f, _ := setupPutStaticFrame("no/such/Class", "x", types.Int)
-	push(&f, int64(1))
-	ret := doPutStatic(&f, 0)
+	push(f, int64(1))
+	ret := doPutStatic(f, 0)
 
 	_ = w.Close()
 	_, _ = io.ReadAll(r) // drain
@@ -2330,7 +2330,7 @@ func TestRET(t *testing.T) {
 	f.PC = 0
 	fs := frames.CreateFrameStack()
 	f.Locals = append(f.Locals, int64(0), int64(0), int64(456))
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.PC-1 != 455 { // -1 because PC++ after processing RET
@@ -2348,7 +2348,7 @@ func TestReturn(t *testing.T) {
 
 	f := newFrame(opcodes.RETURN)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != -1 {
 		t.Errorf("Top of stack, expected -1, got: %d", f.TOS)
@@ -2371,12 +2371,12 @@ func TestSipush(t *testing.T) {
 	f.Meth = append(f.Meth, 0x01)
 	f.Meth = append(f.Meth, 0x02)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("BIPUSH: Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value != 258 {
 		t.Errorf("SIPUSH: Expected popped value to be 258, got: %d", value)
 	}
@@ -2393,12 +2393,12 @@ func TestSipushNegative(t *testing.T) {
 	f.Meth = append(f.Meth, byte(val))
 	f.Meth = append(f.Meth, 0x02)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("BIPUSH: Top of stack, expected 0, got: %d", f.TOS)
 	}
-	value := pop(&f).(int64)
+	value := pop(f).(int64)
 	if value >= 0 {
 		t.Errorf("SIPUSH: Expected popped value to be negative, got: %d", value)
 	}
@@ -2413,15 +2413,15 @@ func TestSwap(t *testing.T) {
 	// set the logger to low granularity, so that logging messages are not also captured in this test
 
 	f := newFrame(opcodes.SWAP)
-	push(&f, int64(34)) // push two different values
-	push(&f, int64(21)) // TOS now = 21
+	push(f, int64(34)) // push two different values
+	push(f, int64(21)) // TOS now = 21
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	top := pop(&f).(int64)
-	next := pop(&f).(int64)
+	top := pop(f).(int64)
+	next := pop(f).(int64)
 
 	if top != 34 {
 		t.Errorf("SWAP: expected top's value to be 34, but got: %d", top)
@@ -2441,7 +2441,7 @@ func TestTableswitchMatchHigh(t *testing.T) {
 	globals.InitGlobals("test")
 	f := newFrame(opcodes.TABLESWITCH)
 
-	push(&f, int64(7)) // matches high value
+	push(f, int64(7)) // matches high value
 
 	// Padding bytes
 	f.Meth = append(f.Meth, 0x00, 0x00, 0x00)
@@ -2461,7 +2461,7 @@ func TestTableswitchMatchHigh(t *testing.T) {
 	f.Meth = append(f.Meth, 0x00, 0x00, 0x00, 0x3C) // case 7: jump 60
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	if f.PC != 60 {
@@ -2478,7 +2478,7 @@ func TestTableswitchMatchMiddle(t *testing.T) {
 	globals.InitGlobals("test")
 	f := newFrame(opcodes.TABLESWITCH)
 
-	push(&f, int64(6)) // matches middle value
+	push(f, int64(6)) // matches middle value
 
 	// Padding bytes
 	f.Meth = append(f.Meth, 0x00, 0x00, 0x00)
@@ -2498,7 +2498,7 @@ func TestTableswitchMatchMiddle(t *testing.T) {
 	f.Meth = append(f.Meth, 0x00, 0x00, 0x00, 0x3C) // case 7: jump 60
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	if f.PC != 40 {
@@ -2515,7 +2515,7 @@ func TestTableswitchDefaultBelowLow(t *testing.T) {
 	globals.InitGlobals("test")
 	f := newFrame(opcodes.TABLESWITCH)
 
-	push(&f, int64(3)) // below low value, should use default
+	push(f, int64(3)) // below low value, should use default
 
 	// Padding bytes
 	f.Meth = append(f.Meth, 0x00, 0x00, 0x00)
@@ -2535,7 +2535,7 @@ func TestTableswitchDefaultBelowLow(t *testing.T) {
 	f.Meth = append(f.Meth, 0x00, 0x00, 0x00, 0x3C) // case 7: jump 60
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	if f.PC != 100 {
@@ -2552,7 +2552,7 @@ func TestTableswitchDefaultAboveHigh(t *testing.T) {
 	globals.InitGlobals("test")
 	f := newFrame(opcodes.TABLESWITCH)
 
-	push(&f, int64(10)) // above high value, should use default
+	push(f, int64(10)) // above high value, should use default
 
 	// Padding bytes
 	f.Meth = append(f.Meth, 0x00, 0x00, 0x00)
@@ -2572,7 +2572,7 @@ func TestTableswitchDefaultAboveHigh(t *testing.T) {
 	f.Meth = append(f.Meth, 0x00, 0x00, 0x00, 0x3C) // case 7: jump 60
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	if f.PC != 100 {
@@ -2589,7 +2589,7 @@ func TestTableswitchSingleCase(t *testing.T) {
 	globals.InitGlobals("test")
 	f := newFrame(opcodes.TABLESWITCH)
 
-	push(&f, int64(5)) // only case
+	push(f, int64(5)) // only case
 
 	// Padding bytes
 	f.Meth = append(f.Meth, 0x00, 0x00, 0x00)
@@ -2607,7 +2607,7 @@ func TestTableswitchSingleCase(t *testing.T) {
 	f.Meth = append(f.Meth, 0x00, 0x00, 0x00, 0x2A) // case 5: jump 42
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 
 	if f.PC != 42 {
@@ -2628,7 +2628,7 @@ func TestTableswitchSingleCase(t *testing.T) {
 // 	globals.InitGlobals("test")
 // 	f := newFrame(opcodes.TABLESWITCH)
 //
-// 	push(&f, int64(1)) // match case 1
+// 	push(f, int64(1)) // match case 1
 //
 // 	// Padding bytes
 // 	f.Meth = append(f.Meth, 0x00, 0x00, 0x00)
@@ -2648,7 +2648,7 @@ func TestTableswitchSingleCase(t *testing.T) {
 // 	f.Meth = append(f.Meth, 0x00, 0x00, 0x00, 0x0F) // case 2: jump 15
 //
 // 	fs := frames.CreateFrameStack()
-// 	fs.PushFront(&f)
+// 	fs.PushFront(f)
 // 	interpret(fs)
 //
 // 	if f.PC != -5 {
@@ -2670,10 +2670,10 @@ func TestWideDLOAD(t *testing.T) {
 	f.Meth = append(f.Meth, 0x01)
 	fs := frames.CreateFrameStack()
 	f.Locals = append(f.Locals, float64(0), float64(33.3), float64(0))
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	ret := pop(&f).(float64)
+	ret := pop(f).(float64)
 	if ret != 33.3 {
 		t.Errorf("WIDE,DLOAD: expected return of 33.3, got: %f", ret)
 	}
@@ -2692,7 +2692,7 @@ func TestWideDSTORE(t *testing.T) {
 	f.OpStack[1] = float64(26.2)
 	fs := frames.CreateFrameStack()
 	f.Locals = append(f.Locals, float64(0), float64(0), float64(0))
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	ret := f.Locals[1]
@@ -2714,7 +2714,7 @@ func TestWideIINC(t *testing.T) {
 	f.Meth = append(f.Meth, 0x24)
 	fs := frames.CreateFrameStack()
 	f.Locals = append(f.Locals, int64(10), int64(20), int64(30))
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.Locals[2] != int64(66) {
@@ -2732,9 +2732,9 @@ func TestWideILOAD(t *testing.T) {
 	f.Meth = append(f.Meth, 0x02)
 	fs := frames.CreateFrameStack()
 	f.Locals = append(f.Locals, int64(10), int64(20), int64(30))
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
-	ret := pop(&f).(int64)
+	ret := pop(f).(int64)
 	if ret != int64(30) {
 		t.Errorf("WIDE,ILOAD: expected return of 30, got: %d", ret)
 	}
@@ -2752,7 +2752,7 @@ func TestWideISTORE(t *testing.T) {
 	f.OpStack[0] = int64(25)
 	fs := frames.CreateFrameStack()
 	f.Locals = append(f.Locals, int64(0), int64(0), int64(0))
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	ret := f.Locals[2]
@@ -2772,10 +2772,10 @@ func TestWideLLOAD(t *testing.T) {
 
 	fs := frames.CreateFrameStack()
 	f.Locals = append(f.Locals, int64(33), int64(33), int64(0))
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
-	ret := pop(&f).(int64)
+	ret := pop(f).(int64)
 	if ret != 33 {
 		t.Errorf("WIDE,DLOAD: expected return of 33, got: %d", ret)
 	}
@@ -2794,7 +2794,7 @@ func TestWideLSTORE(t *testing.T) {
 	fs := frames.CreateFrameStack()
 	f.Locals = append(f.Locals, int64(0), int64(0), int64(0))
 
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	ret := f.Locals[1]
@@ -2815,7 +2815,7 @@ func TestWideRET(t *testing.T) {
 
 	fs := frames.CreateFrameStack()
 	f.Locals = append(f.Locals, int64(0), int64(0), int64(123456))
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	if f.PC != 123457 { // 123456 + 1 for the WIDE bytecode, which takes up 1 byte
@@ -2834,7 +2834,7 @@ func TestInvalidInstruction(t *testing.T) {
 	f := newFrame(252) // an invalid bytecode
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)          // push the new frame
+	fs.PushFront(f)          // push the new frame
 	globals.TraceInst = false // turn off tracing
 	interpret(fs)
 

--- a/src/jvm/interpreter_arrayBytecodes_test.go
+++ b/src/jvm/interpreter_arrayBytecodes_test.go
@@ -37,7 +37,7 @@ func TestNewAaload(t *testing.T) {
 	os.Stderr = w
 
 	f := newFrame(opcodes.ANEWARRAY)
-	push(&f, int64(30)) // make an array of 30 elements
+	push(f, int64(30)) // make an array of 30 elements
 	f.Meth = append(f.Meth, 0x00)
 	f.Meth = append(f.Meth, 0x01) // use the classRef at CP[1] as the type of reference
 
@@ -52,7 +52,7 @@ func TestNewAaload(t *testing.T) {
 	f.CP = &CP
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -66,27 +66,27 @@ func TestNewAaload(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f).(*object.Object)
+	ptr := pop(f).(*object.Object)
 
 	f = newFrame(opcodes.AASTORE)
-	push(&f, ptr)       // push the reference to the array
-	push(&f, int64(20)) // in array[20]
+	push(f, ptr)       // push the reference to the array
+	push(f, int64(20)) // in array[20]
 	oPtr := object.MakeEmptyObject()
-	push(&f, oPtr) // the value we're storing
+	push(f, oPtr) // the value we're storing
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	f = newFrame(opcodes.AALOAD) // now fetch the value in array[20]
-	push(&f, ptr)                // push the reference to the array
-	push(&f, int64(20))          // get contents in array[20]
+	push(f, ptr)                // push the reference to the array
+	push(f, int64(20))          // get contents in array[20]
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	os.Stderr = normalStderr
 
-	res := pop(&f)
+	res := pop(f)
 	if res != oPtr {
 		t.Errorf("AALOAD: Expected loaded array value = %v, got: %v", oPtr, res)
 	}
@@ -106,10 +106,10 @@ func TestNewAaloadWithNil(t *testing.T) {
 	fs := frames.CreateFrameStack()
 
 	f := newFrame(opcodes.AALOAD)
-	push(&f, nil)       // push the reference to the array -- here nil
-	push(&f, int64(20)) // index to array[20]
+	push(f, nil)       // push the reference to the array -- here nil
+	push(f, int64(20)) // index to array[20]
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	_ = w.Close()
@@ -138,9 +138,9 @@ func TestAaloadInvalidSubscript(t *testing.T) {
 	os.Stderr = w
 
 	f := newFrame(opcodes.AALOAD) // now fetch the value
-	push(&f, refArr)              // push the reference to the array
-	push(&f, int64(200))          // get contents in array[200] which is invalid
-	ret := doAaload(&f, 0)
+	push(f, refArr)              // push the reference to the array
+	push(f, int64(200))          // get contents in array[200] which is invalid
+	ret := doAaload(f, 0)
 
 	// restore stderr to what they were before
 	_ = w.Close()
@@ -166,7 +166,7 @@ func TestAaloadInvalidSubscript(t *testing.T) {
 func TestNewAastore(t *testing.T) {
 	globals.InitGlobals("test")
 	f := newFrame(opcodes.ANEWARRAY)
-	push(&f, int64(30)) // make an array of 30 elements
+	push(f, int64(30)) // make an array of 30 elements
 	f.Meth = append(f.Meth, 0x00)
 	f.Meth = append(f.Meth, 0x01) // use the classRef at CP[2] as the type of reference
 
@@ -182,7 +182,7 @@ func TestNewAastore(t *testing.T) {
 
 	globals.InitGlobals("test")
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("TestAastore: Top of stack, expected 0, got: %d", f.TOS)
@@ -198,17 +198,17 @@ func TestNewAastore(t *testing.T) {
 	statics.LoadStaticsString()
 
 	// now, get the reference to the array
-	ptr := pop(&f).(*object.Object)
+	ptr := pop(f).(*object.Object)
 	f = newFrame(opcodes.AASTORE)
 
-	push(&f, ptr)       // push the reference to the array
-	push(&f, int64(20)) // index to array[20]
+	push(f, ptr)       // push the reference to the array
+	push(f, int64(20)) // index to array[20]
 	// objRef := object.NewStringFromGoString("test")
 	objRef := object.StringObjectFromGoString("test")
-	push(&f, objRef) // store the address of a string
+	push(f, objRef) // store the address of a string
 
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	// now retrieve the updated element
@@ -224,9 +224,9 @@ func TestNewAastoreInvalid1(t *testing.T) {
 	globals.InitStringPool()
 	f := newFrame(opcodes.AASTORE)
 	obj := object.Make1DimArray(object.T_REF, 10)
-	push(&f, (*object.Object)(nil)) // this should point to an array, will here cause the error
-	push(&f, int64(30))             // the index into the array
-	push(&f, obj)                   // the value to insert
+	push(f, (*object.Object)(nil)) // this should point to an array, will here cause the error
+	push(f, int64(30))             // the index into the array
+	push(f, obj)                   // the value to insert
 
 	globals.InitGlobals("test")
 	trace.Init()
@@ -239,7 +239,7 @@ func TestNewAastoreInvalid1(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -262,9 +262,9 @@ func TestNewAastoreInvalid2(t *testing.T) {
 
 	o := object.Make1DimArray(object.T_INT, 10)
 	f := newFrame(opcodes.AASTORE)
-	push(&f, o)        // this should point to an array of refs, not ints, will here cause the error
-	push(&f, int64(5)) // the index into the array
-	push(&f, o)        // the value to insert
+	push(f, o)        // this should point to an array of refs, not ints, will here cause the error
+	push(f, int64(5)) // the index into the array
+	push(f, o)        // the value to insert
 
 	trace.Init()
 	globals.InitGlobals("test")
@@ -277,7 +277,7 @@ func TestNewAastoreInvalid2(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -300,9 +300,9 @@ func TestNewAastoreInvalid3(t *testing.T) {
 	objType := types.ObjectClassName
 	o := object.Make1DimRefArray(objType, 10)
 	f := newFrame(opcodes.AASTORE)
-	push(&f, o)         // an array of 10 ints, not floats
-	push(&f, int64(30)) // the index into the array: it's too big, causing error
-	push(&f, o)         // the value to insert
+	push(f, o)         // an array of 10 ints, not floats
+	push(f, int64(30)) // the index into the array: it's too big, causing error
+	push(f, o)         // the value to insert
 
 	trace.Init()
 	globals.InitGlobals("test")
@@ -315,7 +315,7 @@ func TestNewAastoreInvalid3(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -339,12 +339,12 @@ func TestNewAastoreNullValue(t *testing.T) {
 	objType := types.ObjectClassName
 	o := object.Make1DimRefArray(objType, 10)
 	f := newFrame(opcodes.AASTORE)
-	push(&f, o)        // valid array
-	push(&f, int64(5)) // valid index
-	push(&f, nil)      // null value to insert - this should now be valid
+	push(f, o)        // valid array
+	push(f, int64(5)) // valid index
+	push(f, nil)      // null value to insert - this should now be valid
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// Verify that the value was stored
@@ -361,9 +361,9 @@ func TestNewAastoreInvalidArgumentType(t *testing.T) {
 	objType := types.ObjectClassName
 	o := object.Make1DimRefArray(objType, 10)
 	f := newFrame(opcodes.AASTORE)
-	push(&f, o)                      // valid array
-	push(&f, int64(5))               // valid index
-	push(&f, "not an object.Object") // invalid type - this triggers the error
+	push(f, o)                      // valid array
+	push(f, int64(5))               // valid index
+	push(f, "not an object.Object") // invalid type - this triggers the error
 
 	trace.Init()
 	normalStderr := os.Stderr
@@ -375,7 +375,7 @@ func TestNewAastoreInvalidArgumentType(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -396,7 +396,7 @@ func TestNewAastoreInvalidArgumentType(t *testing.T) {
 // ANEWARRAY: creation of array for references to strings
 func TestNewAnewrray(t *testing.T) {
 	f := newFrame(opcodes.ANEWARRAY)
-	push(&f, int64(13)) // make an array of 13 elements
+	push(f, int64(13)) // make an array of 13 elements
 	f.Meth = append(f.Meth, 0x00)
 	f.Meth = append(f.Meth, 0x01) // use the classRef at CP[1] as the type of reference
 
@@ -413,7 +413,7 @@ func TestNewAnewrray(t *testing.T) {
 	globals.InitGlobals("test")
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -439,7 +439,7 @@ func TestNewAnewrray(t *testing.T) {
 // ANEWARRAY: creation of array for references; test contents of Klass field
 func TestNewAnewrrayKlassField(t *testing.T) {
 	f := newFrame(opcodes.ANEWARRAY)
-	push(&f, int64(13)) // make an array of 13 elements
+	push(f, int64(13)) // make an array of 13 elements
 	f.Meth = append(f.Meth, 0x00)
 	f.Meth = append(f.Meth, 0x02) // use the classRef at CP[2] as the type of reference
 
@@ -458,7 +458,7 @@ func TestNewAnewrrayKlassField(t *testing.T) {
 	globals.InitGlobals("test")
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -491,12 +491,12 @@ func TestNewAnewrrayInvalidSize(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stderr = w
 
-	push(&f, int64(-1)) // make the array an invalid size
+	push(f, int64(-1)) // make the array an invalid size
 
 	globals.InitGlobals("test")
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -519,12 +519,12 @@ func TestNewAnewrrayInvalidSize(t *testing.T) {
 // in the global array address list
 func TestNewByteArrayLength(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(13))                    // make the array 13 elements big
+	push(f, int64(13))                    // make the array 13 elements big
 	f.Meth = append(f.Meth, object.T_BYTE) // make it an array of bytes
 
 	globals.InitGlobals("test")
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -538,15 +538,15 @@ func TestNewByteArrayLength(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f)
+	ptr := pop(f)
 
 	f = newFrame(opcodes.ARRAYLENGTH)
-	push(&f, ptr) // push the reference to the array
+	push(f, ptr) // push the reference to the array
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
-	size := pop(&f).(int64)
+	size := pop(f).(int64)
 	if size != 13 {
 		t.Errorf("ARRAYLENGTH: Expecting array length of 13, got %d", size)
 	}
@@ -555,12 +555,12 @@ func TestNewByteArrayLength(t *testing.T) {
 // ARRAYLENGTH: Test length of int array
 func TestNewIntArrayLength(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(22))                   // make the array 22 elements big
+	push(f, int64(22))                   // make the array 22 elements big
 	f.Meth = append(f.Meth, object.T_INT) // make it an array of ints
 
 	globals.InitGlobals("test")
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -574,16 +574,16 @@ func TestNewIntArrayLength(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f)
+	ptr := pop(f)
 
 	f = newFrame(opcodes.ARRAYLENGTH)
 	// uptr := uintptr(unsafe.Pointer(ptr))
-	push(&f, ptr) // push the reference to the array
+	push(f, ptr) // push the reference to the array
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
-	size := pop(&f).(int64)
+	size := pop(f).(int64)
 	if size != 22 {
 		t.Errorf("ARRAYLENGTH: Expecting array length of 13, got %d", size)
 	}
@@ -592,12 +592,12 @@ func TestNewIntArrayLength(t *testing.T) {
 // ARRAYLENGTH: Test length of float array
 func TestNewFloatArrayLength(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(34))                      // make the array 34 elements big
+	push(f, int64(34))                      // make the array 34 elements big
 	f.Meth = append(f.Meth, object.T_DOUBLE) // make it an array of doubles
 
 	globals.InitGlobals("test")
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -611,16 +611,16 @@ func TestNewFloatArrayLength(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f)
+	ptr := pop(f)
 
 	f = newFrame(opcodes.ARRAYLENGTH)
 	// uptr := uintptr(unsafe.Pointer(ptr))
-	push(&f, ptr) // push the reference to the array
+	push(f, ptr) // push the reference to the array
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
-	size := pop(&f).(int64)
+	size := pop(f).(int64)
 	if size != 34 {
 		t.Errorf("ARRAYLENGTH: Expecting array length of 34, got %d", size)
 	}
@@ -629,12 +629,12 @@ func TestNewFloatArrayLength(t *testing.T) {
 // ARRAYLENGTH: Test length of array of longs
 func TestNewLongArrayLength(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(34))                    // make the array 34 elements big
+	push(f, int64(34))                    // make the array 34 elements big
 	f.Meth = append(f.Meth, object.T_LONG) // make it an array of longs
 
 	globals.InitGlobals("test")
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -648,16 +648,16 @@ func TestNewLongArrayLength(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f)
+	ptr := pop(f)
 
 	f = newFrame(opcodes.ARRAYLENGTH)
 	// uptr := uintptr(unsafe.Pointer(ptr))
-	push(&f, ptr) // push the reference to the array
+	push(f, ptr) // push the reference to the array
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
-	size := pop(&f).(int64)
+	size := pop(f).(int64)
 	if size != 34 {
 		t.Errorf("ARRAYLENGTH: Expecting array length of 34, got %d", size)
 	}
@@ -666,12 +666,12 @@ func TestNewLongArrayLength(t *testing.T) {
 // ARRAYLENGTH: Test length of array of references
 func TestNewRefArrayLength(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(34))                   // make the array 34 elements big
+	push(f, int64(34))                   // make the array 34 elements big
 	f.Meth = append(f.Meth, object.T_INT) // make it an array of references
 
 	globals.InitGlobals("test")
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -685,16 +685,16 @@ func TestNewRefArrayLength(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f)
+	ptr := pop(f)
 
 	f = newFrame(opcodes.ARRAYLENGTH)
 	// uptr := uintptr(unsafe.Pointer(ptr))
-	push(&f, ptr) // push the reference to the array
+	push(f, ptr) // push the reference to the array
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
-	size := pop(&f).(int64)
+	size := pop(f).(int64)
 	if size != 34 {
 		t.Errorf("ARRAYLENGTH: Expecting array length of 34, got %d", size)
 	}
@@ -710,9 +710,9 @@ func TestNewRawByteArrayLength(t *testing.T) {
 
 	array := []byte{'a', 'b', 'c'}
 	f := newFrame(opcodes.ARRAYLENGTH)
-	push(&f, &array) // push the reference to the array
+	push(f, &array) // push the reference to the array
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	_ = w.Close()
@@ -725,7 +725,7 @@ func TestNewRawByteArrayLength(t *testing.T) {
 		t.Errorf("ARRAYLENGTH: Got unexpected error message: %s", errMsg)
 	}
 
-	length := pop(&f).(int64)
+	length := pop(f).(int64)
 	if length != 3 {
 		t.Errorf("ARRAYLENGTH: Expecting length of 3, got: %d", length)
 	}
@@ -740,9 +740,9 @@ func TestNewRawInt8ArrayLength(t *testing.T) {
 
 	array := []uint8{'a', 'b', 'c'}
 	f := newFrame(opcodes.ARRAYLENGTH)
-	push(&f, &array) // push the reference to the array
+	push(f, &array) // push the reference to the array
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	_ = w.Close()
@@ -755,7 +755,7 @@ func TestNewRawInt8ArrayLength(t *testing.T) {
 		t.Errorf("TestRawInt8ArrayLength: Got unexpected error message: %s", errMsg)
 	}
 
-	length := pop(&f).(int64)
+	length := pop(f).(int64)
 	if length != 3 {
 		t.Errorf("TestRawInt8ArrayLength: Expecting length of 3, got: %d", length)
 	}
@@ -769,9 +769,9 @@ func TestNewNilArrayLength(t *testing.T) {
 	os.Stderr = w
 
 	f := newFrame(opcodes.ARRAYLENGTH)
-	push(&f, nil) // push the reference to the array
+	push(f, nil) // push the reference to the array
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	_ = w.Close()
@@ -793,12 +793,12 @@ func TestNewNilArrayLength(t *testing.T) {
 // The logic here is effectively identical to IALOAD. This code also tests BASTORE.
 func TestNewBaload(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(30))                    // make the array 30 elements big
+	push(f, int64(30))                    // make the array 30 elements big
 	f.Meth = append(f.Meth, object.T_BYTE) // make it an array of bytes
 
 	globals.InitGlobals("test")
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // NEWARRAY
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -812,24 +812,24 @@ func TestNewBaload(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f)
+	ptr := pop(f)
 
 	f = newFrame(opcodes.BASTORE)
-	push(&f, ptr)       // push the reference to the array
-	push(&f, int64(20)) // in array[20] (smaller than the original which was [30])
-	push(&f, byte(100)) // the value we're storing
+	push(f, ptr)       // push the reference to the array
+	push(f, int64(20)) // in array[20] (smaller than the original which was [30])
+	push(f, byte(100)) // the value we're storing
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute BASTORE
 
 	f = newFrame(opcodes.BALOAD) // now fetch the value in array[20]
-	push(&f, ptr)                // push the reference to the array
-	push(&f, int64(20))          // get contents in array[20]
+	push(f, ptr)                // push the reference to the array
+	push(f, int64(20))          // get contents in array[20]
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute BALOAD
 
-	res := pop(&f).(int64)
+	res := pop(f).(int64)
 	if res != 100 {
 		t.Errorf("BALOAD: Expected loaded array value of 100, got: %d", res)
 	}
@@ -849,10 +849,10 @@ func TestNewBaloadNilArray(t *testing.T) {
 	os.Stderr = w
 
 	f := newFrame(opcodes.BALOAD)
-	push(&f, object.Null) // push the reference to the array, here nil
-	push(&f, int64(20))   // get contents in array[20]
+	push(f, object.Null) // push the reference to the array, here nil
+	push(f, int64(20))   // get contents in array[20]
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode -- should generate exception
 
 	// restore stderr to what they were before
@@ -871,7 +871,7 @@ func TestNewBaloadNilArray(t *testing.T) {
 // BALOAD: using an invalid subscript into the array
 func TestNewBaloadInvalidSubscript(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(30))                    // make the array 30 elements big
+	push(f, int64(30))                    // make the array 30 elements big
 	f.Meth = append(f.Meth, object.T_BYTE) // make it an array of bytes
 
 	normalStderr := os.Stderr
@@ -881,23 +881,23 @@ func TestNewBaloadInvalidSubscript(t *testing.T) {
 	globals.InitGlobals("test")
 	trace.Init()
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // NEWARRAY
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f).(*object.Object)
+	ptr := pop(f).(*object.Object)
 
 	f = newFrame(opcodes.BALOAD) // now fetch the value
 	f.ClName = "foo"
 	f.MethName = "bar"
 	f.MethType = "()V"
-	push(&f, ptr)        // push the reference to the array
-	push(&f, int64(200)) // get contents in array[200] which is invalid
+	push(f, ptr)        // push the reference to the array
+	push(f, int64(200)) // get contents in array[200] which is invalid
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute BALOAD
 
 	// restore stderr to what they were before
@@ -922,14 +922,14 @@ func TestNewBaloadInt8Array(t *testing.T) {
 	int8Array[20] = 100
 
 	f := newFrame(opcodes.BALOAD)
-	push(&f, int8Array) // push the direct int8 array reference
-	push(&f, int64(20)) // index to array[20]
+	push(f, int8Array) // push the direct int8 array reference
+	push(f, int64(20)) // index to array[20]
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
-	res := pop(&f).(int64)
+	res := pop(f).(int64)
 	if res != 100 {
 		t.Errorf("BALOAD: Expected loaded array value of 100, got: %d", res)
 	}
@@ -953,11 +953,11 @@ func TestNewBaloadInvalidType(t *testing.T) {
 	os.Stdout = wout
 
 	f := newFrame(opcodes.BALOAD)
-	push(&f, "not a valid array") // push an invalid type (string instead of array)
-	push(&f, int64(20))           // index
+	push(f, "not a valid array") // push an invalid type (string instead of array)
+	push(f, int64(20))           // index
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode -- should generate exception
 
 	// restore stderr and stdout to what they were before
@@ -981,12 +981,12 @@ func TestNewBaloadInvalidType(t *testing.T) {
 // Note the value we store must be an int64 value--not a byte
 func TestNewBastore(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(30))                    // make the array 30 elements big
+	push(f, int64(30))                    // make the array 30 elements big
 	f.Meth = append(f.Meth, object.T_BYTE) // make it an array of bytes
 
 	globals.InitGlobals("test")
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -1000,14 +1000,14 @@ func TestNewBastore(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f).(*object.Object)
+	ptr := pop(f).(*object.Object)
 
 	f = newFrame(opcodes.BASTORE)
-	push(&f, ptr)       // push the reference to the array
-	push(&f, int64(20)) // in array[20]
-	push(&f, byte(100)) // the value we're storing
+	push(f, ptr)       // push the reference to the array
+	push(f, int64(20)) // in array[20]
+	push(f, byte(100)) // the value we're storing
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	o := ptr.FieldTable["value"]
@@ -1024,12 +1024,12 @@ func TestNewBastore(t *testing.T) {
 // BASTORE: Tests whether storing an int64 into a byte array does the right thing
 func TestNewBastoreInt64(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(30))                    // make the array 30 elements big
+	push(f, int64(30))                    // make the array 30 elements big
 	f.Meth = append(f.Meth, object.T_BYTE) // make it an array of bytes
 
 	globals.InitGlobals("test")
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -1043,14 +1043,14 @@ func TestNewBastoreInt64(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f).(*object.Object)
+	ptr := pop(f).(*object.Object)
 
 	f = newFrame(opcodes.BASTORE)
-	push(&f, ptr)        // push the reference to the array
-	push(&f, int64(20))  // in array[20]
-	push(&f, int64(100)) // the value we're storing
+	push(f, ptr)        // push the reference to the array
+	push(f, int64(20))  // in array[20]
+	push(f, int64(100)) // the value we're storing
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	o := ptr.FieldTable["value"]
@@ -1067,9 +1067,9 @@ func TestNewBastoreInt64(t *testing.T) {
 // BASTORE: Test error conditions: invalid array address
 func TestNewBastoreInvalid1(t *testing.T) {
 	f := newFrame(opcodes.BASTORE)
-	push(&f, (*object.Object)(nil)) // this should point to an array, will here cause the error
-	push(&f, int64(30))             // the index into the array
-	push(&f, int64(20))             // the value to insert
+	push(f, (*object.Object)(nil)) // this should point to an array, will here cause the error
+	push(f, int64(30))             // the index into the array
+	push(f, int64(20))             // the value to insert
 
 	trace.Init()
 	globals.InitGlobals("test")
@@ -1082,7 +1082,7 @@ func TestNewBastoreInvalid1(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -1105,9 +1105,9 @@ func TestNewBastoreInvalid2(t *testing.T) {
 	globals.InitGlobals("test")
 	f := newFrame(opcodes.BASTORE)
 	o := object.Make1DimArray(object.T_FLOAT, 10)
-	push(&f, o)         // this should point to an array of ints, not floats, will here cause the error
-	push(&f, int64(30)) // the index into the array
-	push(&f, int64(20)) // the value to insert
+	push(f, o)         // this should point to an array of ints, not floats, will here cause the error
+	push(f, int64(30)) // the index into the array
+	push(f, int64(20)) // the value to insert
 
 	trace.Init()
 	globals.InitGlobals("test")
@@ -1120,7 +1120,7 @@ func TestNewBastoreInvalid2(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -1144,9 +1144,9 @@ func TestNewBastoreInvalid3(t *testing.T) {
 	globals.InitGlobals("test")
 	o := object.Make1DimArray(object.T_BYTE, 10)
 	f := newFrame(opcodes.BASTORE)
-	push(&f, o)         // an array of 10 ints, not floats
-	push(&f, int64(30)) // the index into the array: it's too big, causing error
-	push(&f, int64(20)) // the value to insert
+	push(f, o)         // an array of 10 ints, not floats
+	push(f, int64(30)) // the index into the array: it's too big, causing error
+	push(f, int64(20)) // the value to insert
 
 	trace.Init()
 	normalStderr := os.Stderr
@@ -1158,7 +1158,7 @@ func TestNewBastoreInvalid3(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -1184,12 +1184,12 @@ func TestNewBastoreJavaByteArray(t *testing.T) {
 	javaByteArray := make([]types.JavaByte, 30)
 
 	f := newFrame(opcodes.BASTORE)
-	push(&f, javaByteArray) // push the direct JavaByte array reference
-	push(&f, int64(20))     // in array[20]
-	push(&f, int64(100))    // the value we're storing
+	push(f, javaByteArray) // push the direct JavaByte array reference
+	push(f, int64(20))     // in array[20]
+	push(f, int64(100))    // the value we're storing
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	// Verify the value was stored correctly
@@ -1213,9 +1213,9 @@ func TestNewBastoreInvalidType(t *testing.T) {
 	f := newFrame(opcodes.BASTORE)
 
 	// Push an unexpected type (e.g., a string instead of an array)
-	push(&f, "not an array") // this will trigger the default case
-	push(&f, int64(20))      // the index into the array
-	push(&f, int64(100))     // the value to insert
+	push(f, "not an array") // this will trigger the default case
+	push(f, int64(20))      // the index into the array
+	push(f, int64(100))     // the value to insert
 
 	trace.Init()
 	normalStderr := os.Stderr
@@ -1227,7 +1227,7 @@ func TestNewBastoreInvalidType(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -1250,12 +1250,12 @@ func TestNewBastoreInvalidType(t *testing.T) {
 // the logic here is effectively identical to IALOAD. This code also tests CASTORE.
 func TestNewCaload(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(30))                    // make the array 30 elements big
+	push(f, int64(30))                    // make the array 30 elements big
 	f.Meth = append(f.Meth, object.T_CHAR) // make it an array of chars
 
 	globals.InitGlobals("test")
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -1269,24 +1269,24 @@ func TestNewCaload(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f).(*object.Object)
+	ptr := pop(f).(*object.Object)
 
 	f = newFrame(opcodes.CASTORE)
-	push(&f, ptr)        // push the reference to the array
-	push(&f, int64(20))  // in array[20]
-	push(&f, int64(100)) // the value we're storing
+	push(f, ptr)        // push the reference to the array
+	push(f, int64(20))  // in array[20]
+	push(f, int64(100)) // the value we're storing
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	f = newFrame(opcodes.CALOAD) // now fetch the value in array[20]
-	push(&f, ptr)                // push the reference to the array
-	push(&f, int64(20))          // get contents in array[20]
+	push(f, ptr)                // push the reference to the array
+	push(f, int64(20))          // get contents in array[20]
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
-	res := pop(&f).(int64)
+	res := pop(f).(int64)
 	if res != 100 {
 		t.Errorf("CALOAD: Expected loaded array value of 100, got: %d", res)
 	}
@@ -1299,12 +1299,12 @@ func TestNewCaload(t *testing.T) {
 // DALOAD: Test fetching and pushing the value of an element in an float array
 func TestNewDaload(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(30))                      // make the array 30 elements big
+	push(f, int64(30))                      // make the array 30 elements big
 	f.Meth = append(f.Meth, object.T_DOUBLE) // make it an array of doubles
 
 	globals.InitGlobals("test")
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -1318,24 +1318,24 @@ func TestNewDaload(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f).(*object.Object)
+	ptr := pop(f).(*object.Object)
 
 	f = newFrame(opcodes.DASTORE)
-	push(&f, ptr)       // push the reference to the array
-	push(&f, int64(20)) // in array[20]
-	push(&f, 100.0)     // the value we're storing
+	push(f, ptr)       // push the reference to the array
+	push(f, int64(20)) // in array[20]
+	push(f, 100.0)     // the value we're storing
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	f = newFrame(opcodes.DALOAD) // now fetch the value in array[30]
-	push(&f, ptr)                // push the reference to the array
-	push(&f, int64(20))          // get contents in array[20]
+	push(f, ptr)                // push the reference to the array
+	push(f, int64(20))          // get contents in array[20]
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
-	res := pop(&f).(float64)
+	res := pop(f).(float64)
 	if res != 100.0 {
 		t.Errorf("FALOAD: Expected loaded array value of 100, got: %e", res)
 	}
@@ -1355,10 +1355,10 @@ func TestNewDaloadNilArray(t *testing.T) {
 	os.Stderr = w
 
 	f := newFrame(opcodes.DALOAD)
-	push(&f, object.Null) // push the reference to the array, here nil
-	push(&f, int64(20))   // get contents in array[20]
+	push(f, object.Null) // push the reference to the array, here nil
+	push(f, int64(20))   // get contents in array[20]
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode -- should generate exception
 
 	// restore stderr to what they were before
@@ -1377,7 +1377,7 @@ func TestNewDaloadNilArray(t *testing.T) {
 // DALOAD: using an invalid subscript into the array
 func TestNewLaDoadInvalidSubscript(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(30))                      // make the array 30 elements big
+	push(f, int64(30))                      // make the array 30 elements big
 	f.Meth = append(f.Meth, object.T_DOUBLE) // make it an array of doubles
 
 	normalStderr := os.Stderr
@@ -1387,20 +1387,20 @@ func TestNewLaDoadInvalidSubscript(t *testing.T) {
 	globals.InitGlobals("test")
 	trace.Init()
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f).(*object.Object)
+	ptr := pop(f).(*object.Object)
 
 	f = newFrame(opcodes.DALOAD) // now fetch the value
-	push(&f, ptr)                // push the reference to the array
-	push(&f, int64(200))         // get contents in array[200] which is invalid
+	push(f, ptr)                // push the reference to the array
+	push(f, int64(200))         // get contents in array[200] which is invalid
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	// restore stderr to what they were before
@@ -1420,12 +1420,12 @@ func TestNewLaDoadInvalidSubscript(t *testing.T) {
 // See comments for IASTORE for the logic of this test
 func TestNewDastore(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(30))                      // make the array 30 elements big
+	push(f, int64(30))                      // make the array 30 elements big
 	f.Meth = append(f.Meth, object.T_DOUBLE) // make it an array of doubles
 
 	globals.InitGlobals("test")
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -1439,14 +1439,14 @@ func TestNewDastore(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f).(*object.Object)
+	ptr := pop(f).(*object.Object)
 
 	f = newFrame(opcodes.DASTORE)
-	push(&f, ptr)                // push the reference to the array
-	push(&f, int64(20))          // in array[20]
-	push(&f, 100_000_000_000.25) // the value we're storing
+	push(f, ptr)                // push the reference to the array
+	push(f, int64(20))          // in array[20]
+	push(f, 100_000_000_000.25) // the value we're storing
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 	if f.TOS != -1 {
 		t.Errorf("Top of stack, expected -1, got: %d", f.TOS)
@@ -1468,9 +1468,9 @@ func TestNewDastore(t *testing.T) {
 func TestNewDastoreInvalid1(t *testing.T) {
 	globals.InitGlobals("test")
 	f := newFrame(opcodes.DASTORE)
-	push(&f, (*object.Object)(nil)) // this should point to an array, will here cause the error
-	push(&f, int64(30))             // the index into the array
-	push(&f, float64(20.0))         // the value to insert
+	push(f, (*object.Object)(nil)) // this should point to an array, will here cause the error
+	push(f, int64(30))             // the index into the array
+	push(f, float64(20.0))         // the value to insert
 
 	trace.Init()
 	normalStderr := os.Stderr
@@ -1482,7 +1482,7 @@ func TestNewDastoreInvalid1(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -1505,9 +1505,9 @@ func TestNewDastoreInvalid2(t *testing.T) {
 	globals.InitGlobals("test")
 	o := object.Make1DimArray(object.T_INT, 10)
 	f := newFrame(opcodes.DASTORE)
-	push(&f, o)             // this should point to an array of floats, not ints, will here cause the error
-	push(&f, int64(30))     // the index into the array
-	push(&f, float64(20.0)) // the value to insert
+	push(f, o)             // this should point to an array of floats, not ints, will here cause the error
+	push(f, int64(30))     // the index into the array
+	push(f, float64(20.0)) // the value to insert
 
 	trace.Init()
 	normalStderr := os.Stderr
@@ -1519,7 +1519,7 @@ func TestNewDastoreInvalid2(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -1543,9 +1543,9 @@ func TestNewDastoreInvalid3(t *testing.T) {
 	globals.InitGlobals("test")
 	o := object.Make1DimArray(object.T_FLOAT, 10)
 	f := newFrame(opcodes.DASTORE)
-	push(&f, o)             // an array of 10 ints, not floats
-	push(&f, int64(30))     // the index into the array: it's too big, causing error
-	push(&f, float64(20.0)) // the value to insert
+	push(f, o)             // an array of 10 ints, not floats
+	push(f, int64(30))     // the index into the array: it's too big, causing error
+	push(f, float64(20.0)) // the value to insert
 
 	trace.Init()
 	normalStderr := os.Stderr
@@ -1557,7 +1557,7 @@ func TestNewDastoreInvalid3(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -1578,12 +1578,12 @@ func TestNewDastoreInvalid3(t *testing.T) {
 // FALOAD: Test fetching and pushing the value of an element in an float array
 func TestNewFaload(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(30))                     // make the array 30 elements big
+	push(f, int64(30))                     // make the array 30 elements big
 	f.Meth = append(f.Meth, object.T_FLOAT) // make it an array of floats
 
 	globals.InitGlobals("test")
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -1597,24 +1597,24 @@ func TestNewFaload(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f).(*object.Object)
+	ptr := pop(f).(*object.Object)
 
 	f = newFrame(opcodes.FASTORE)
-	push(&f, ptr)       // push the reference to the array
-	push(&f, int64(20)) // in array[20]
-	push(&f, 100.0)     // the value we're storing
+	push(f, ptr)       // push the reference to the array
+	push(f, int64(20)) // in array[20]
+	push(f, 100.0)     // the value we're storing
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	f = newFrame(opcodes.FALOAD) // now fetch the value in array[30]
-	push(&f, ptr)                // push the reference to the array
-	push(&f, int64(20))          // get contents in array[20]
+	push(f, ptr)                // push the reference to the array
+	push(f, int64(20))          // get contents in array[20]
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
-	res := pop(&f).(float64)
+	res := pop(f).(float64)
 	if res != 100.0 {
 		t.Errorf("FALOAD: Expected loaded array value of 100, got: %e", res)
 	}
@@ -1628,19 +1628,19 @@ func TestNewFaload(t *testing.T) {
 func TestFaLoadWithRawFloatArray(t *testing.T) {
 	f := newFrame(opcodes.FALOAD)
 	fArray := []float64{1.0, 2.0, 3.0, 4.0, 50.}
-	push(&f, fArray)   // push the reference to the array, here a raw byte array
-	push(&f, int64(2)) // get contents in array[2]
+	push(f, fArray)   // push the reference to the array, here a raw byte array
+	push(f, int64(2)) // get contents in array[2]
 
 	globals.InitGlobals("test")
 
 	// execute the bytecode
-	ret := doFaload(&f, 0)
+	ret := doFaload(f, 0)
 
 	if ret != 1 {
 		t.Errorf("FALOAD: Expected error return of 1, got %d", ret)
 	}
 
-	fl := pop(&f).(float64)
+	fl := pop(f).(float64)
 	if fl != 3.0 {
 		t.Errorf("FALOAD: Expected 3.0, got %f", fl)
 	}
@@ -1656,10 +1656,10 @@ func TestNewFaloadNilArray(t *testing.T) {
 	os.Stderr = w
 
 	f := newFrame(opcodes.FALOAD)
-	push(&f, object.Null) // push the reference to the array, here nil
-	push(&f, int64(20))   // get contents in array[20]
+	push(f, object.Null) // push the reference to the array, here nil
+	push(f, int64(20))   // get contents in array[20]
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode -- should generate exception
 
 	// restore stderr to what they were before
@@ -1678,7 +1678,7 @@ func TestNewFaloadNilArray(t *testing.T) {
 // FALOAD: using an invalid subscript into the array
 func TestNewFaloadInvalidSubscript(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(30))                     // make the array 30 elements big
+	push(f, int64(30))                     // make the array 30 elements big
 	f.Meth = append(f.Meth, object.T_FLOAT) // make it an array of floats
 
 	normalStderr := os.Stderr
@@ -1688,20 +1688,20 @@ func TestNewFaloadInvalidSubscript(t *testing.T) {
 	globals.InitGlobals("test")
 	trace.Init()
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f).(*object.Object)
+	ptr := pop(f).(*object.Object)
 
 	f = newFrame(opcodes.FALOAD) // now fetch the value
-	push(&f, ptr)                // push the reference to the array
-	push(&f, int64(200))         // get contents in array[200] which is invalid
+	push(f, ptr)                // push the reference to the array
+	push(f, int64(200))         // get contents in array[200] which is invalid
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	// restore stderr to what they were before
@@ -1720,8 +1720,8 @@ func TestNewFaloadInvalidSubscript(t *testing.T) {
 func TestFaLoadWhenNotAValidArray(t *testing.T) {
 	f := newFrame(opcodes.FALOAD)
 	badArray := []byte{1, 2, 3, 4, 5}
-	push(&f, badArray)  // push the reference to the array, here a raw byte array
-	push(&f, int64(20)) // get contents in array[20]
+	push(f, badArray)  // push the reference to the array, here a raw byte array
+	push(f, int64(20)) // get contents in array[20]
 
 	globals.InitGlobals("test")
 
@@ -1730,7 +1730,7 @@ func TestFaLoadWhenNotAValidArray(t *testing.T) {
 	os.Stderr = w
 
 	// execute the bytecode
-	ret := doFaload(&f, 0)
+	ret := doFaload(f, 0)
 
 	_ = w.Close()
 	msg, _ := io.ReadAll(r)
@@ -1751,12 +1751,12 @@ func TestFaLoadWhenNotAValidArray(t *testing.T) {
 // sum all the elements in the array, and test for a sum of 100.0
 func TestNewFastore(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(30))                     // make the array 30 elements big
+	push(f, int64(30))                     // make the array 30 elements big
 	f.Meth = append(f.Meth, object.T_FLOAT) // make it an array of floats
 
 	globals.InitGlobals("test")
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -1770,14 +1770,14 @@ func TestNewFastore(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f).(*object.Object)
+	ptr := pop(f).(*object.Object)
 
 	f = newFrame(opcodes.FASTORE)
-	push(&f, ptr)       // push the reference to the array
-	push(&f, int64(20)) // in array[20]
-	push(&f, 100.0)     // the value we're storing
+	push(f, ptr)       // push the reference to the array
+	push(f, int64(20)) // in array[20]
+	push(f, 100.0)     // the value we're storing
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	oa := ptr.FieldTable["value"]
@@ -1794,9 +1794,9 @@ func TestNewFastore(t *testing.T) {
 // FASTORE: Test error conditions: invalid array address
 func TestFastoreInvalidArrayAddress(t *testing.T) {
 	f := newFrame(opcodes.FASTORE)
-	push(&f, (*object.Object)(nil)) // this should point to an array, will here cause the error
-	push(&f, int64(30))             // the index into the array
-	push(&f, float64(20.0))         // the value to insert
+	push(f, (*object.Object)(nil)) // this should point to an array, will here cause the error
+	push(f, int64(30))             // the index into the array
+	push(f, float64(20.0))         // the value to insert
 
 	trace.Init()
 	globals.InitGlobals("test")
@@ -1809,7 +1809,7 @@ func TestFastoreInvalidArrayAddress(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -1832,9 +1832,9 @@ func TestFastoreInvalidArrayType(t *testing.T) {
 	globals.InitGlobals("test")
 	o := object.Make1DimArray(object.T_INT, 10)
 	f := newFrame(opcodes.FASTORE)
-	push(&f, o)             // this should point to an array of floats, not ints, will here cause the error
-	push(&f, int64(30))     // the index into the array
-	push(&f, float64(20.0)) // the value to insert
+	push(f, o)             // this should point to an array of floats, not ints, will here cause the error
+	push(f, int64(30))     // the index into the array
+	push(f, float64(20.0)) // the value to insert
 
 	trace.Init()
 	normalStderr := os.Stderr
@@ -1846,7 +1846,7 @@ func TestFastoreInvalidArrayType(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -1869,9 +1869,9 @@ func TestFastoreInvalidIndexOutOfRange(t *testing.T) {
 	globals.InitGlobals("test")
 	o := object.Make1DimArray(object.T_FLOAT, 10)
 	f := newFrame(opcodes.FASTORE)
-	push(&f, o)             // an array of 10 ints, not floats
-	push(&f, int64(30))     // the index into the array: it's too big, causing error
-	push(&f, float64(20.0)) // the value to insert
+	push(f, o)             // an array of 10 ints, not floats
+	push(f, int64(30))     // the index into the array: it's too big, causing error
+	push(f, float64(20.0)) // the value to insert
 
 	trace.Init()
 	normalStderr := os.Stderr
@@ -1883,7 +1883,7 @@ func TestFastoreInvalidIndexOutOfRange(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -1905,11 +1905,11 @@ func TestFastoreInvalidIndexOutOfRange(t *testing.T) {
 func TestFastoreWithRawFloatArray(t *testing.T) {
 	f := newFrame(opcodes.FASTORE)
 	fArray := []float64{1.0, 2.0, 3.0, 4.0, 50.}
-	push(&f, fArray)   // push the reference to the array, here a raw byte array
-	push(&f, int64(2)) // in array[2]
-	push(&f, 100.0)    // the value we're storing
+	push(f, fArray)   // push the reference to the array, here a raw byte array
+	push(f, int64(2)) // in array[2]
+	push(f, 100.0)    // the value we're storing
 
-	ret := doFastore(&f, 0)
+	ret := doFastore(f, 0)
 
 	if fArray[2] != 100.0 {
 		t.Errorf("FASTORE: Expected array[2] to be 100.0, got: %f", fArray[2])
@@ -1931,11 +1931,11 @@ func TestFastoreWithRawNonArray(t *testing.T) {
 
 	f := newFrame(opcodes.FASTORE)
 	fArray := "non-array string"
-	push(&f, fArray)   // push the reference to the array, here a raw byte array
-	push(&f, int64(2)) // in array[2]
-	push(&f, 100.0)    // the value we're storing
+	push(f, fArray)   // push the reference to the array, here a raw byte array
+	push(f, int64(2)) // in array[2]
+	push(f, 100.0)    // the value we're storing
 
-	ret := doFastore(&f, 0)
+	ret := doFastore(f, 0)
 
 	// restore stderr and stdout to what they were before
 	_ = w.Close()
@@ -1956,12 +1956,12 @@ func TestFastoreWithRawNonArray(t *testing.T) {
 // IALOAD: Test fetching and pushing the value of an element in an int array
 func TestNewIaload(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(30))                   // make the array 30 elements big
+	push(f, int64(30))                   // make the array 30 elements big
 	f.Meth = append(f.Meth, object.T_INT) // make it an array of ints
 
 	globals.InitGlobals("test")
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -1975,24 +1975,24 @@ func TestNewIaload(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f).(*object.Object)
+	ptr := pop(f).(*object.Object)
 
 	f = newFrame(opcodes.IASTORE)
-	push(&f, ptr)        // push the reference to the array
-	push(&f, int64(20))  // in array[20]
-	push(&f, int64(100)) // the value we're storing
+	push(f, ptr)        // push the reference to the array
+	push(f, int64(20))  // in array[20]
+	push(f, int64(100)) // the value we're storing
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	f = newFrame(opcodes.IALOAD) // now fetch the value in array[20]
-	push(&f, ptr)                // push the reference to the array
-	push(&f, int64(20))          // get contents in array[20]
+	push(f, ptr)                // push the reference to the array
+	push(f, int64(20))          // get contents in array[20]
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
-	res := pop(&f).(int64)
+	res := pop(f).(int64)
 	if res != 100 {
 		t.Errorf("IALOAD: Expected loaded array value of 100, got: %d", res)
 	}
@@ -2012,10 +2012,10 @@ func TestNewIaloadNilArray(t *testing.T) {
 	os.Stderr = w
 
 	f := newFrame(opcodes.IALOAD)
-	push(&f, object.Null) // push the reference to the array, here nil
-	push(&f, int64(20))   // get contents in array[20]
+	push(f, object.Null) // push the reference to the array, here nil
+	push(f, int64(20))   // get contents in array[20]
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode -- should generate exception
 
 	// restore stderr to what they were before
@@ -2034,7 +2034,7 @@ func TestNewIaloadNilArray(t *testing.T) {
 // IALOAD: using an invalid subscript into the array
 func TestNewIaloadInvalidSubscript(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(30))                   // make the array 30 elements big
+	push(f, int64(30))                   // make the array 30 elements big
 	f.Meth = append(f.Meth, object.T_INT) // make it an array of ints
 
 	normalStderr := os.Stderr
@@ -2044,7 +2044,7 @@ func TestNewIaloadInvalidSubscript(t *testing.T) {
 	globals.InitGlobals("test")
 	trace.Init()
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -2058,21 +2058,21 @@ func TestNewIaloadInvalidSubscript(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f).(*object.Object)
+	ptr := pop(f).(*object.Object)
 
 	f = newFrame(opcodes.IASTORE)
-	push(&f, ptr)        // push the reference to the array
-	push(&f, int64(20))  // in array[20]
-	push(&f, int64(100)) // the value we're storing
+	push(f, ptr)        // push the reference to the array
+	push(f, int64(20))  // in array[20]
+	push(f, int64(100)) // the value we're storing
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	f = newFrame(opcodes.IALOAD) // now fetch the value
-	push(&f, ptr)                // push the reference to the array
-	push(&f, int64(200))         // get contents in array[200] which is invalid
+	push(f, ptr)                // push the reference to the array
+	push(f, int64(200))         // get contents in array[200] which is invalid
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	// restore stderr to what they were before
@@ -2092,8 +2092,8 @@ func TestNewIaloadInvalidSubscript(t *testing.T) {
 func TestIaLoadWhenNotAValidArray(t *testing.T) {
 	f := newFrame(opcodes.IALOAD)
 	badArray := []byte{1, 2, 3, 4, 5}
-	push(&f, badArray)  // push the reference to the array, here a raw byte array
-	push(&f, int64(20)) // get contents in array[20]
+	push(f, badArray)  // push the reference to the array, here a raw byte array
+	push(f, int64(20)) // get contents in array[20]
 
 	globals.InitGlobals("test")
 
@@ -2102,7 +2102,7 @@ func TestIaLoadWhenNotAValidArray(t *testing.T) {
 	os.Stderr = w
 
 	// execute the bytecode
-	ret := doIaload(&f, 0)
+	ret := doIaload(f, 0)
 
 	_ = w.Close()
 	msg, _ := io.ReadAll(r)
@@ -2123,12 +2123,12 @@ func TestIaLoadWhenNotAValidArray(t *testing.T) {
 // sum all the elements in the array, and test for a sum of 100.
 func TestNewIastore(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(30))                   // make the array 30 elements big
+	push(f, int64(30))                   // make the array 30 elements big
 	f.Meth = append(f.Meth, object.T_INT) // make it an array of ints
 
 	globals.InitGlobals("test")
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -2142,14 +2142,14 @@ func TestNewIastore(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f).(*object.Object)
+	ptr := pop(f).(*object.Object)
 
 	f = newFrame(opcodes.IASTORE)
-	push(&f, ptr)        // push the reference to the array
-	push(&f, int64(20))  // in array[20]
-	push(&f, int64(100)) // the value we're storing
+	push(f, ptr)        // push the reference to the array
+	push(f, int64(20))  // in array[20]
+	push(f, int64(100)) // the value we're storing
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	ao := ptr.FieldTable["value"].Fvalue
@@ -2167,9 +2167,9 @@ func TestNewIastore(t *testing.T) {
 func TestNewIastoreInvalid1(t *testing.T) {
 	globals.InitGlobals("test")
 	f := newFrame(opcodes.IASTORE)
-	push(&f, (*object.Object)(nil)) // this should point to an array, will here cause the error
-	push(&f, int64(30))             // the index into the array
-	push(&f, int64(20))             // the value to insert
+	push(f, (*object.Object)(nil)) // this should point to an array, will here cause the error
+	push(f, int64(30))             // the index into the array
+	push(f, int64(20))             // the value to insert
 
 	trace.Init()
 	normalStderr := os.Stderr
@@ -2181,7 +2181,7 @@ func TestNewIastoreInvalid1(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -2205,9 +2205,9 @@ func TestNewIastoreInvalid2(t *testing.T) {
 	globals.InitGlobals("test")
 	o := object.Make1DimArray(object.T_FLOAT, 10)
 	f := newFrame(opcodes.IASTORE)
-	push(&f, o)         // this should point to an array of ints, not floats, will here cause the error
-	push(&f, int64(30)) // the index into the array
-	push(&f, int64(20)) // the value to insert
+	push(f, o)         // this should point to an array of ints, not floats, will here cause the error
+	push(f, int64(30)) // the index into the array
+	push(f, int64(20)) // the value to insert
 
 	trace.Init()
 	normalStderr := os.Stderr
@@ -2219,7 +2219,7 @@ func TestNewIastoreInvalid2(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -2243,9 +2243,9 @@ func TestNewIastoreInvalid3(t *testing.T) {
 	globals.InitGlobals("test")
 	o := object.Make1DimArray(object.T_INT, 10)
 	f := newFrame(opcodes.IASTORE)
-	push(&f, o)         // an array of 10 ints, not floats
-	push(&f, int64(30)) // the index into the array: it's too big, causing error
-	push(&f, int64(20)) // the value to insert
+	push(f, o)         // an array of 10 ints, not floats
+	push(f, int64(30)) // the index into the array: it's too big, causing error
+	push(f, int64(20)) // the value to insert
 
 	trace.Init()
 	normalStderr := os.Stderr
@@ -2257,7 +2257,7 @@ func TestNewIastoreInvalid3(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -2283,12 +2283,12 @@ func TestNewIastoreInt64Array(t *testing.T) {
 	int64Array := make([]int64, 30)
 
 	f := newFrame(opcodes.IASTORE)
-	push(&f, int64Array) // push the direct int64 array reference
-	push(&f, int64(20))  // in array[20]
-	push(&f, int64(100)) // the value we're storing
+	push(f, int64Array) // push the direct int64 array reference
+	push(f, int64(20))  // in array[20]
+	push(f, int64(100)) // the value we're storing
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	// Verify the value was stored correctly
@@ -2312,9 +2312,9 @@ func TestNewIastoreInvalidType(t *testing.T) {
 	f := newFrame(opcodes.IASTORE)
 
 	// Push an unexpected type (e.g., a string instead of an array)
-	push(&f, "not an array") // this will trigger the default case
-	push(&f, int64(20))      // the index into the array
-	push(&f, int64(100))     // the value to insert
+	push(f, "not an array") // this will trigger the default case
+	push(f, int64(20))      // the index into the array
+	push(f, int64(100))     // the value to insert
 
 	trace.Init()
 	normalStderr := os.Stderr
@@ -2326,7 +2326,7 @@ func TestNewIastoreInvalidType(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -2347,12 +2347,12 @@ func TestNewIastoreInvalidType(t *testing.T) {
 // LALOAD: Test fetching and pushing the value of an element into a long array
 func TestNewLaload(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(30))                    // make the array 30 elements big
+	push(f, int64(30))                    // make the array 30 elements big
 	f.Meth = append(f.Meth, object.T_LONG) // make it an array of longs
 
 	globals.InitGlobals("test")
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -2366,28 +2366,28 @@ func TestNewLaload(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f).(*object.Object)
+	ptr := pop(f).(*object.Object)
 
 	f = newFrame(opcodes.LASTORE)
-	push(&f, ptr)        // push the reference to the array
-	push(&f, int64(20))  // in array[20]
-	push(&f, int64(100)) // the value we're storing
+	push(f, ptr)        // push the reference to the array
+	push(f, int64(20))  // in array[20]
+	push(f, int64(100)) // the value we're storing
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	f = newFrame(opcodes.LALOAD) // now fetch the value in array[20]
-	push(&f, ptr)                // push the reference to the array
-	push(&f, int64(20))          // get contents in array[20]
+	push(f, ptr)                // push the reference to the array
+	push(f, int64(20))          // get contents in array[20]
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	if f.TOS != 0 {
 		t.Errorf("LALOAD: Top of stack, expected 0, got: %d", f.TOS)
 	}
 
-	res := pop(&f).(int64)
+	res := pop(f).(int64)
 	if res != 100 {
 		t.Errorf("LALOAD: Expected loaded array value of 100, got: %d", res)
 	}
@@ -2403,10 +2403,10 @@ func TestNewLaloadNilArray(t *testing.T) {
 	os.Stderr = w
 
 	f := newFrame(opcodes.LALOAD)
-	push(&f, object.Null) // push the reference to the array, here nil
-	push(&f, int64(20))   // get contents in array[20]
+	push(f, object.Null) // push the reference to the array, here nil
+	push(f, int64(20))   // get contents in array[20]
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode -- should generate exception
 
 	// restore stderr to what they were before
@@ -2425,7 +2425,7 @@ func TestNewLaloadNilArray(t *testing.T) {
 // LALOAD: using an invalid subscript into the array
 func TestNewLaloadInvalidSubscript(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(30))                    // make the array 30 elements big
+	push(f, int64(30))                    // make the array 30 elements big
 	f.Meth = append(f.Meth, object.T_LONG) // make it an array of longs
 
 	normalStderr := os.Stderr
@@ -2435,20 +2435,20 @@ func TestNewLaloadInvalidSubscript(t *testing.T) {
 	globals.InitGlobals("test")
 	trace.Init()
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f).(*object.Object)
+	ptr := pop(f).(*object.Object)
 
 	f = newFrame(opcodes.LALOAD) // now fetch the value
-	push(&f, ptr)                // push the reference to the array
-	push(&f, int64(200))         // get contents in array[200] which is invalid
+	push(f, ptr)                // push the reference to the array
+	push(f, int64(200))         // get contents in array[200] which is invalid
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	// restore stderr to what they were before
@@ -2468,12 +2468,12 @@ func TestNewLaloadInvalidSubscript(t *testing.T) {
 // See comments for IASTORE for the logic of this test
 func TestNewLastore(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(30))                    // make the array 30 elements big
+	push(f, int64(30))                    // make the array 30 elements big
 	f.Meth = append(f.Meth, object.T_LONG) // make it an array of longs
 
 	globals.InitGlobals("test")
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -2487,14 +2487,14 @@ func TestNewLastore(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f).(*object.Object)
+	ptr := pop(f).(*object.Object)
 
 	f = newFrame(opcodes.LASTORE)
-	push(&f, ptr)        // push the reference to the array
-	push(&f, int64(20))  // in array[20]
-	push(&f, int64(100)) // the value we're storing
+	push(f, ptr)        // push the reference to the array
+	push(f, int64(20))  // in array[20]
+	push(f, int64(100)) // the value we're storing
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 	if f.TOS != -1 {
 		t.Errorf("Top of stack, expected -1, got: %d", f.TOS)
@@ -2514,9 +2514,9 @@ func TestNewLastore(t *testing.T) {
 // LASTORE: Test error conditions: invalid array address
 func TestNewLastoreInvalid1(t *testing.T) {
 	f := newFrame(opcodes.LASTORE)
-	push(&f, (*object.Object)(nil)) // this should point to an array, will here cause the error
-	push(&f, int64(30))             // the index into the array
-	push(&f, int64(20))             // the value to insert
+	push(f, (*object.Object)(nil)) // this should point to an array, will here cause the error
+	push(f, int64(30))             // the index into the array
+	push(f, int64(20))             // the value to insert
 
 	trace.Init()
 	globals.InitGlobals("test")
@@ -2529,7 +2529,7 @@ func TestNewLastoreInvalid1(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -2553,9 +2553,9 @@ func TestNewLastoreInvalid2(t *testing.T) {
 	globals.InitGlobals("test")
 	o := object.Make1DimArray(object.T_FLOAT, 10)
 	f := newFrame(opcodes.LASTORE)
-	push(&f, o)         // this should point to an array of ints, not floats, will here cause the error
-	push(&f, int64(30)) // the index into the array
-	push(&f, int64(20)) // the value to insert
+	push(f, o)         // this should point to an array of ints, not floats, will here cause the error
+	push(f, int64(30)) // the index into the array
+	push(f, int64(20)) // the value to insert
 
 	trace.Init()
 	normalStderr := os.Stderr
@@ -2567,7 +2567,7 @@ func TestNewLastoreInvalid2(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -2591,9 +2591,9 @@ func TestNewLastoreInvalid3(t *testing.T) {
 	globals.InitGlobals("test")
 	o := object.Make1DimArray(object.T_INT, 10)
 	f := newFrame(opcodes.LASTORE)
-	push(&f, o)         // an array of 10 ints, not floats
-	push(&f, int64(30)) // the index into the array: it's too big, causing error
-	push(&f, int64(20)) // the value to insert
+	push(f, o)         // an array of 10 ints, not floats
+	push(f, int64(30)) // the index into the array: it's too big, causing error
+	push(f, int64(20)) // the value to insert
 
 	trace.Init()
 	normalStderr := os.Stderr
@@ -2605,7 +2605,7 @@ func TestNewLastoreInvalid3(t *testing.T) {
 	os.Stdout = wout
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	// restore stderr and stdout to what they were before
@@ -2686,24 +2686,24 @@ func TestNew3DimArray1(t *testing.T) {
 	f.Meth = append(f.Meth, 0x00) // this byte and next form index into CP
 	f.Meth = append(f.Meth, 0x02)
 	f.Meth = append(f.Meth, 0x03) // the number of dimensions
-	push(&f, int64(0x03))         // size of the three dimensions: 4x3x2
-	push(&f, int64(0x03))
-	push(&f, int64(0x04))
+	push(f, int64(0x03))         // size of the three dimensions: 4x3x2
+	push(f, int64(0x03))
+	push(f, int64(0x04))
 	f.CP = &CP
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 	if f.TOS != 0 {
 		t.Errorf("MULTIANEWARRAY: Top of stack, expected 0, got: %d", f.TOS)
 	}
 
-	arrayPtr := pop(&f)
+	arrayPtr := pop(f)
 	if arrayPtr == nil {
 		t.Error("MULTIANEWARRAY: Expected a pointer to an array, got nil")
 	}
 
-	topLevelArray := *(arrayPtr.(*object.Object))
+	topLevelArray := arrayPtr.(*object.Object)
 	if topLevelArray.FieldTable["value"].Ftype != "[L" {
 		t.Errorf("MULTIANEWARRAY: Expected 1st dim to be type '[L', got %s",
 			topLevelArray.FieldTable["value"].Ftype)
@@ -2771,13 +2771,13 @@ func TestNew3DimArray2(t *testing.T) {
 	f.Meth = append(f.Meth, 0x00) // this byte and next form index into CP
 	f.Meth = append(f.Meth, 0x02)
 	f.Meth = append(f.Meth, 0x03) // the number of dimensions
-	push(&f, int64(0x03))         // size of the three dimensions: 4x0x3
-	push(&f, int64(0x00))
-	push(&f, int64(0x04))
+	push(f, int64(0x03))         // size of the three dimensions: 4x0x3
+	push(f, int64(0x00))
+	push(f, int64(0x04))
 	f.CP = &CP
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	_ = w.Close()
@@ -2787,12 +2787,12 @@ func TestNew3DimArray2(t *testing.T) {
 		t.Errorf("MULTIANEWARRAY: Top of stack, expected 0, got: %d", f.TOS)
 	}
 
-	arrayPtr := pop(&f)
+	arrayPtr := pop(f)
 	if arrayPtr == nil {
 		t.Error("MULTIANEWARRAY: Expected a pointer to an array, got nil")
 	}
 
-	topLevelArray := *(arrayPtr.(*object.Object))
+	topLevelArray := arrayPtr.(*object.Object)
 	if topLevelArray.FieldTable["value"].Ftype != "[I" {
 		t.Errorf("MULTIANEWARRAY: Expected 1st dim to be type '[I', got %s",
 			topLevelArray.FieldTable["value"].Ftype)
@@ -2808,13 +2808,13 @@ func TestNew3DimArray2(t *testing.T) {
 // NEWARRAY: creation of array for primitive values
 func TestNewNewrray(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(13))                    // make the array 13 elements big
+	push(f, int64(13))                    // make the array 13 elements big
 	f.Meth = append(f.Meth, object.T_LONG) // make it an array of longs
 
 	globals.InitGlobals("test")
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -2844,13 +2844,13 @@ func TestNewNewrrayForByteArray(t *testing.T) {
 	os.Stderr = w
 
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(13))                    // size
+	push(f, int64(13))                    // size
 	f.Meth = append(f.Meth, object.T_BYTE) // make it an array of bytes
 
 	globals.InitGlobals("test")
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -2863,7 +2863,7 @@ func TestNewNewrrayForByteArray(t *testing.T) {
 		t.Errorf("NEWARRAY: Got unexpected error: %s", errMsg)
 	}
 
-	arrayPtr := pop(&f).(*object.Object)
+	arrayPtr := pop(f).(*object.Object)
 	array := arrayPtr.FieldTable["value"].Fvalue.([]types.JavaByte)
 	if len(array) != 13 {
 		t.Errorf("NEWARRAY: Got unexpected array size: %d", len(array))
@@ -2878,13 +2878,13 @@ func TestNewNewArrayInvalidSize(t *testing.T) {
 	os.Stderr = w
 
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(-13))                   // invalid size (less than 0)
+	push(f, int64(-13))                   // invalid size (less than 0)
 	f.Meth = append(f.Meth, object.T_LONG) // make it an array of longs
 
 	globals.InitGlobals("test")
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 
 	_ = w.Close()
@@ -2910,13 +2910,13 @@ func TestNewNewrrayInvalidTypeError(t *testing.T) {
 	os.Stderr = w
 
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(13))                     // size
+	push(f, int64(13))                     // size
 	f.Meth = append(f.Meth, object.T_ERROR) // invalid type
 
 	globals.InitGlobals("test")
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	globals.GetGlobalRef().FuncThrowException = exceptions.ThrowExNil
 	interpret(fs)
 
@@ -2943,11 +2943,11 @@ func TestNewNewrrayInvalidTypeRef(t *testing.T) {
 	os.Stderr = w
 
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(13))         // size
+	push(f, int64(13))         // size
 	f.Meth = append(f.Meth, 86) // invalid type
 
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	globals.GetGlobalRef().FuncThrowException = exceptions.ThrowExNil
 	interpret(fs)
 
@@ -2970,12 +2970,12 @@ func TestNewNewrrayInvalidTypeRef(t *testing.T) {
 // SALOAD: Test fetching and pushing the value of an element in a short array
 func TestNewSaload(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(30))                   // make the array 30 elements big
+	push(f, int64(30))                   // make the array 30 elements big
 	f.Meth = append(f.Meth, object.T_INT) // make it an array of ints
 
 	globals.InitGlobals("test")
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -2989,24 +2989,24 @@ func TestNewSaload(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f).(*object.Object)
+	ptr := pop(f).(*object.Object)
 
 	f = newFrame(opcodes.SASTORE)
-	push(&f, ptr)        // push the reference to the array
-	push(&f, int64(20))  // in array[20]
-	push(&f, int64(100)) // the value we're storing
+	push(f, ptr)        // push the reference to the array
+	push(f, int64(20))  // in array[20]
+	push(f, int64(100)) // the value we're storing
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	f = newFrame(opcodes.SALOAD) // now fetch the value in array[30]
-	push(&f, ptr)                // push the reference to the array
-	push(&f, int64(20))          // get contents in array[20]
+	push(f, ptr)                // push the reference to the array
+	push(f, int64(20))          // get contents in array[20]
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
-	res := pop(&f).(int64)
+	res := pop(f).(int64)
 	if res != 100 {
 		t.Errorf("SALOAD: Expected loaded array value of 100, got: %d", res)
 	}
@@ -3020,12 +3020,12 @@ func TestNewSaload(t *testing.T) {
 // See comments for IASTORE for the logic of this test
 func TestNewSastore(t *testing.T) {
 	f := newFrame(opcodes.NEWARRAY)
-	push(&f, int64(30))                   // make the array 30 elements big
+	push(f, int64(30))                   // make the array 30 elements big
 	f.Meth = append(f.Meth, object.T_INT) // make it an array of ints
 
 	globals.InitGlobals("test")
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)
 	if f.TOS != 0 {
 		t.Errorf("Top of stack, expected 0, got: %d", f.TOS)
@@ -3039,14 +3039,14 @@ func TestNewSastore(t *testing.T) {
 	}
 
 	// now, get the reference to the array
-	ptr := pop(&f).(*object.Object)
+	ptr := pop(f).(*object.Object)
 
 	f = newFrame(opcodes.SASTORE)
-	push(&f, ptr)        // push the reference to the array
-	push(&f, int64(20))  // in array[20]
-	push(&f, int64(100)) // the value we're storing
+	push(f, ptr)        // push the reference to the array
+	push(f, int64(20))  // in array[20]
+	push(f, int64(100)) // the value we're storing
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f) // push the new frame
+	fs.PushFront(f) // push the new frame
 	interpret(fs)    // execute the bytecode
 
 	array := ptr.FieldTable["value"].Fvalue.([]int64)

--- a/src/jvm/interpreter_checkcast_test.go
+++ b/src/jvm/interpreter_checkcast_test.go
@@ -59,15 +59,15 @@ func ensureClassWithSuper(name string, super string) {
 // and the object that remains on the stack (should be unchanged on success).
 func runCheckcast(t *testing.T, obj interface{}, targetName string) (ok bool, top interface{}, pc int) {
 	fr := newFrame(opcodes.CHECKCAST)
-	setCPClassRefFor(&fr, targetName)
-	push(&fr, obj)
+	setCPClassRefFor(fr, targetName)
+	push(fr, obj)
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&fr)
+	fs.PushFront(fr)
 	interpret(fs)
 	pc = fr.PC
 	// If no exception occurred, CHECKCAST leaves the object on the stack unchanged.
 	if fr.TOS >= 0 {
-		top = peek(&fr)
+		top = peek(fr)
 		ok = true
 	} else {
 		ok = false

--- a/src/jvm/interpreter_int_boundary_test.go
+++ b/src/jvm/interpreter_int_boundary_test.go
@@ -32,12 +32,12 @@ func TestIaddBoundary(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newFrame(opcodes.IADD)
-			push(&f, int64(tt.v1))
-			push(&f, int64(tt.v2))
+			push(f, int64(tt.v1))
+			push(f, int64(tt.v2))
 			fs := frames.CreateFrameStack()
-			fs.PushFront(&f)
+			fs.PushFront(f)
 			interpret(fs)
-			res := pop(&f).(int64)
+			res := pop(f).(int64)
 			if int32(res) != tt.expected {
 				t.Errorf("%s: expected %d, got %d", tt.name, tt.expected, int32(res))
 			}
@@ -61,12 +61,12 @@ func TestIsubBoundary(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newFrame(opcodes.ISUB)
-			push(&f, int64(tt.v1))
-			push(&f, int64(tt.v2))
+			push(f, int64(tt.v1))
+			push(f, int64(tt.v2))
 			fs := frames.CreateFrameStack()
-			fs.PushFront(&f)
+			fs.PushFront(f)
 			interpret(fs)
-			res := pop(&f).(int64)
+			res := pop(f).(int64)
 			if int32(res) != tt.expected {
 				t.Errorf("%s: expected %d, got %d", tt.name, tt.expected, int32(res))
 			}
@@ -89,12 +89,12 @@ func TestImulBoundary(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newFrame(opcodes.IMUL)
-			push(&f, int64(tt.v1))
-			push(&f, int64(tt.v2))
+			push(f, int64(tt.v1))
+			push(f, int64(tt.v2))
 			fs := frames.CreateFrameStack()
-			fs.PushFront(&f)
+			fs.PushFront(f)
 			interpret(fs)
-			res := pop(&f).(int64)
+			res := pop(f).(int64)
 			if int32(res) != tt.expected {
 				t.Errorf("%s: expected %d, got %d", tt.name, tt.expected, int32(res))
 			}
@@ -116,11 +116,11 @@ func TestInegBoundary(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newFrame(opcodes.INEG)
-			push(&f, int64(tt.v))
+			push(f, int64(tt.v))
 			fs := frames.CreateFrameStack()
-			fs.PushFront(&f)
+			fs.PushFront(f)
 			interpret(fs)
-			res := pop(&f).(int64)
+			res := pop(f).(int64)
 			if int32(res) != tt.expected {
 				t.Errorf("%s: expected %d, got %d", tt.name, tt.expected, int32(res))
 			}
@@ -144,12 +144,12 @@ func TestIshlBoundary(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newFrame(opcodes.ISHL)
-			push(&f, int64(tt.v))
-			push(&f, tt.dist)
+			push(f, int64(tt.v))
+			push(f, tt.dist)
 			fs := frames.CreateFrameStack()
-			fs.PushFront(&f)
+			fs.PushFront(f)
 			interpret(fs)
-			res := pop(&f).(int64)
+			res := pop(f).(int64)
 			if int32(res) != tt.expected {
 				t.Errorf("%s: expected %d, got %d", tt.name, tt.expected, int32(res))
 			}
@@ -174,12 +174,12 @@ func TestIshrBoundary(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newFrame(opcodes.ISHR)
-			push(&f, int64(tt.v))
-			push(&f, tt.dist)
+			push(f, int64(tt.v))
+			push(f, tt.dist)
 			fs := frames.CreateFrameStack()
-			fs.PushFront(&f)
+			fs.PushFront(f)
 			interpret(fs)
-			res := pop(&f).(int64)
+			res := pop(f).(int64)
 			if int32(res) != tt.expected {
 				t.Errorf("%s: expected %d, got %d", tt.name, tt.expected, int32(res))
 			}
@@ -203,12 +203,12 @@ func TestIushrBoundary(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newFrame(opcodes.IUSHR)
-			push(&f, int64(tt.v))
-			push(&f, tt.dist)
+			push(f, int64(tt.v))
+			push(f, tt.dist)
 			fs := frames.CreateFrameStack()
-			fs.PushFront(&f)
+			fs.PushFront(f)
 			interpret(fs)
-			res := pop(&f).(int64)
+			res := pop(f).(int64)
 			if int32(res) != tt.expected {
 				t.Errorf("%s: expected %d, got %d", tt.name, tt.expected, int32(res))
 			}
@@ -219,36 +219,36 @@ func TestIushrBoundary(t *testing.T) {
 func TestIbitwiseBoundary(t *testing.T) {
 	t.Run("IAND Neg", func(t *testing.T) {
 		f := newFrame(opcodes.IAND)
-		push(&f, int64(-1))
-		push(&f, int64(123))
+		push(f, int64(-1))
+		push(f, int64(123))
 		fs := frames.CreateFrameStack()
-		fs.PushFront(&f)
+		fs.PushFront(f)
 		interpret(fs)
-		res := pop(&f).(int64)
+		res := pop(f).(int64)
 		if int32(res) != 123 {
 			t.Errorf("IAND: expected 123, got %d", int32(res))
 		}
 	})
 	t.Run("IOR Neg", func(t *testing.T) {
 		f := newFrame(opcodes.IOR)
-		push(&f, int64(-1))
-		push(&f, int64(123))
+		push(f, int64(-1))
+		push(f, int64(123))
 		fs := frames.CreateFrameStack()
-		fs.PushFront(&f)
+		fs.PushFront(f)
 		interpret(fs)
-		res := pop(&f).(int64)
+		res := pop(f).(int64)
 		if int32(res) != -1 {
 			t.Errorf("IOR: expected -1, got %d", int32(res))
 		}
 	})
 	t.Run("IXOR Neg", func(t *testing.T) {
 		f := newFrame(opcodes.IXOR)
-		push(&f, int64(-1))
-		push(&f, int64(0))
+		push(f, int64(-1))
+		push(f, int64(0))
 		fs := frames.CreateFrameStack()
-		fs.PushFront(&f)
+		fs.PushFront(f)
 		interpret(fs)
-		res := pop(&f).(int64)
+		res := pop(f).(int64)
 		if int32(res) != -1 {
 			t.Errorf("IXOR: expected -1, got %d", int32(res))
 		}
@@ -271,11 +271,11 @@ func TestI2bBoundary(t *testing.T) {
 
 	for _, tt := range tests {
 		f := newFrame(opcodes.I2B)
-		push(&f, int64(tt.v))
+		push(f, int64(tt.v))
 		fs := frames.CreateFrameStack()
-		fs.PushFront(&f)
+		fs.PushFront(f)
 		interpret(fs)
-		res := pop(&f).(int64)
+		res := pop(f).(int64)
 		if int8(res) != tt.expected {
 			t.Errorf("I2B(%d): expected %d, got %d", tt.v, tt.expected, int8(res))
 		}
@@ -294,11 +294,11 @@ func TestI2cBoundary(t *testing.T) {
 
 	for _, tt := range tests {
 		f := newFrame(opcodes.I2C)
-		push(&f, int64(tt.v))
+		push(f, int64(tt.v))
 		fs := frames.CreateFrameStack()
-		fs.PushFront(&f)
+		fs.PushFront(f)
 		interpret(fs)
-		res := pop(&f).(int64)
+		res := pop(f).(int64)
 		if uint16(res) != tt.expected {
 			t.Errorf("I2C(%d): expected %d, got %d", tt.v, tt.expected, uint16(res))
 		}
@@ -319,11 +319,11 @@ func TestI2sBoundary(t *testing.T) {
 
 	for _, tt := range tests {
 		f := newFrame(opcodes.I2S)
-		push(&f, int64(tt.v))
+		push(f, int64(tt.v))
 		fs := frames.CreateFrameStack()
-		fs.PushFront(&f)
+		fs.PushFront(f)
 		interpret(fs)
-		res := pop(&f).(int64)
+		res := pop(f).(int64)
 		if int16(res) != tt.expected {
 			t.Errorf("I2S(%d): expected %d, got %d", tt.v, tt.expected, int16(res))
 		}
@@ -344,12 +344,12 @@ func TestLaddBoundary(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newFrame(opcodes.LADD)
-			push(&f, tt.v1)
-			push(&f, tt.v2)
+			push(f, tt.v1)
+			push(f, tt.v2)
 			fs := frames.CreateFrameStack()
-			fs.PushFront(&f)
+			fs.PushFront(f)
 			interpret(fs)
-			res := pop(&f).(int64)
+			res := pop(f).(int64)
 			if res != tt.expected {
 				t.Errorf("%s: expected %d, got %d", tt.name, tt.expected, res)
 			}
@@ -372,12 +372,12 @@ func TestLshlBoundary(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newFrame(opcodes.LSHL)
-			push(&f, tt.v)
-			push(&f, tt.dist)
+			push(f, tt.v)
+			push(f, tt.dist)
 			fs := frames.CreateFrameStack()
-			fs.PushFront(&f)
+			fs.PushFront(f)
 			interpret(fs)
-			res := pop(&f).(int64)
+			res := pop(f).(int64)
 			if res != tt.expected {
 				t.Errorf("%s: expected %d, got %d", tt.name, tt.expected, res)
 			}
@@ -400,12 +400,12 @@ func TestLshrBoundary(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newFrame(opcodes.LSHR)
-			push(&f, tt.v)
-			push(&f, tt.dist)
+			push(f, tt.v)
+			push(f, tt.dist)
 			fs := frames.CreateFrameStack()
-			fs.PushFront(&f)
+			fs.PushFront(f)
 			interpret(fs)
-			res := pop(&f).(int64)
+			res := pop(f).(int64)
 			if res != tt.expected {
 				t.Errorf("%s: expected %d, got %d", tt.name, tt.expected, res)
 			}
@@ -428,12 +428,12 @@ func TestLushrBoundary(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newFrame(opcodes.LUSHR)
-			push(&f, tt.v)
-			push(&f, tt.dist)
+			push(f, tt.v)
+			push(f, tt.dist)
 			fs := frames.CreateFrameStack()
-			fs.PushFront(&f)
+			fs.PushFront(f)
 			interpret(fs)
-			res := pop(&f).(int64)
+			res := pop(f).(int64)
 			if res != tt.expected {
 				t.Errorf("%s: expected %d, got %d", tt.name, tt.expected, res)
 			}
@@ -448,12 +448,12 @@ func TestIaloadBoundary(t *testing.T) {
 	f := newFrame(opcodes.IALOAD)
 	arr := []int64{1, 2, 3}
 	obj := object.MakePrimitiveObject(types.IntArray, types.IntArray, arr)
-	push(&f, obj)
-	push(&f, int64(1))
+	push(f, obj)
+	push(f, int64(1))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
-	res := pop(&f).(int64)
+	res := pop(f).(int64)
 	if int32(res) != 2 {
 		t.Errorf("IALOAD: expected 2, got %d", int32(res))
 	}
@@ -462,12 +462,12 @@ func TestIaloadBoundary(t *testing.T) {
 	f = newFrame(opcodes.SALOAD)
 	sarr := []int64{-1, 2, 3}
 	sobj := object.MakePrimitiveObject(types.ShortArray, types.ShortArray, sarr)
-	push(&f, sobj)
-	push(&f, int64(0))
+	push(f, sobj)
+	push(f, int64(0))
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
-	res = pop(&f).(int64)
+	res = pop(f).(int64)
 	if int32(res) != -1 {
 		t.Errorf("SALOAD: expected -1, got %d", int32(res))
 	}
@@ -476,12 +476,12 @@ func TestIaloadBoundary(t *testing.T) {
 	f = newFrame(opcodes.CALOAD)
 	carr := []int64{0xFFFF, 2, 3}
 	cobj := object.MakePrimitiveObject(types.CharArray, types.CharArray, carr)
-	push(&f, cobj)
-	push(&f, int64(0))
+	push(f, cobj)
+	push(f, int64(0))
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
-	res = pop(&f).(int64)
+	res = pop(f).(int64)
 	if int32(res) != 65535 {
 		t.Errorf("CALOAD: expected 65535, got %d", int32(res))
 	}
@@ -494,11 +494,11 @@ func TestIastoreBoundary(t *testing.T) {
 	f := newFrame(opcodes.IASTORE)
 	arr := []int64{0, 0, 0}
 	obj := object.MakePrimitiveObject(types.IntArray, types.IntArray, arr)
-	push(&f, obj)
-	push(&f, int64(1))
-	push(&f, int64(-123))
+	push(f, obj)
+	push(f, int64(1))
+	push(f, int64(-123))
 	fs := frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 	if arr[1] != -123 {
 		t.Errorf("IASTORE: expected -123, got %d", arr[1])
@@ -508,11 +508,11 @@ func TestIastoreBoundary(t *testing.T) {
 	f = newFrame(opcodes.SASTORE)
 	sarr := []int64{0, 0, 0}
 	sobj := object.MakePrimitiveObject(types.ShortArray, types.ShortArray, sarr)
-	push(&f, sobj)
-	push(&f, int64(2))
-	push(&f, int64(0x12345678)) // should be truncated to 0x5678
+	push(f, sobj)
+	push(f, int64(2))
+	push(f, int64(0x12345678)) // should be truncated to 0x5678
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 	if sarr[2] != 0x5678 {
 		t.Errorf("SASTORE: expected 0x5678, got 0x%x", sarr[2])
@@ -522,11 +522,11 @@ func TestIastoreBoundary(t *testing.T) {
 	f = newFrame(opcodes.CASTORE)
 	carr := []int64{0, 0, 0}
 	cobj := object.MakePrimitiveObject(types.CharArray, types.CharArray, carr)
-	push(&f, cobj)
-	push(&f, int64(0))
-	push(&f, int64(-1)) // should be truncated to 0xFFFF
+	push(f, cobj)
+	push(f, int64(0))
+	push(f, int64(-1)) // should be truncated to 0xFFFF
 	fs = frames.CreateFrameStack()
-	fs.PushFront(&f)
+	fs.PushFront(f)
 	interpret(fs)
 	if carr[0] != 0xFFFF {
 		t.Errorf("CASTORE: expected 0xFFFF, got 0x%x", carr[0])

--- a/src/object/object_lock_test.go
+++ b/src/object/object_lock_test.go
@@ -321,13 +321,17 @@ func TestObjLock_TwoThreads_ThinLockContentionAndHandoff(t *testing.T) {
 	// Thread 2 attempts to lock while thin-locked by thread 1
 	go func() {
 		if err := obj.ObjLock(2); err != nil {
-			t.Fatalf("thread 2 ObjLock (thin contention) returned error: %v", err)
+			t.Errorf("thread 2 ObjLock (thin contention) returned error: %v", err)
+			close(done)
+			return
 		}
 		t.Log("Thread 2 locked object successfully (thin).")
 		close(acquired)
 		// Release and finish
 		if err := obj.ObjUnlock(2); err != nil {
-			t.Fatalf("thread 2 ObjUnlock after thin handoff returned error: %v", err)
+			t.Errorf("thread 2 ObjUnlock after thin handoff returned error: %v", err)
+			close(done)
+			return
 		}
 		t.Log("Thread 2 released object successfully (thin).")
 		close(done)
@@ -392,13 +396,15 @@ func TestObjLock_EightThreads_ThinLockContentionAndHandoff(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			if err := obj.ObjLock(tid); err != nil {
-				t.Fatalf("contender %d ObjLock (thin) returned error: %v", tid, err)
+				t.Errorf("contender %d ObjLock (thin) returned error: %v", tid, err)
+				return
 			}
 			t.Logf("Thread %d locked object successfully (thin).", tid)
 			// Record acquisition
 			acquiredCh <- int(tid)
 			if err := obj.ObjUnlock(tid); err != nil {
-				t.Fatalf("contender %d ObjUnlock (thin) returned error: %v", tid, err)
+				t.Errorf("contender %d ObjUnlock (thin) returned error: %v", tid, err)
+				return
 			}
 			t.Logf("Thread %d released object successfully (thin).", tid)
 		}()

--- a/src/object/string_test.go
+++ b/src/object/string_test.go
@@ -22,7 +22,7 @@ import (
 func TestNewStringObject(t *testing.T) {
 	globals.InitGlobals("test")
 
-	str := *NewStringObject()
+	str := NewStringObject()
 	klassStr := *(stringPool.GetStringPointer(str.KlassName))
 	if klassStr != types.StringClassName {
 		t.Errorf("Klass should be java/lang/String, observed: %s", klassStr)


### PR DESCRIPTION
modified:   object/object_lock_test.go
	modified:   classloader/cpUtils_test.go
	modified:   gfunction/javaLang/javaLangString_test.go
	modified:   gfunction/javaUtil/javaUtilArrays_test.go
	modified:   gfunction/javaUtil/javaUtilLinkedListFuncAtoQ_test.go
	modified:   jvm/double_precision_repro_test.go
	modified:   jvm/gfunctionExec_test.go
	modified:   jvm/interpreter_A-E_test.go
	modified:   jvm/interpreter_F-IF_test.go
	modified:   jvm/interpreter_II-LD_test.go
	modified:   jvm/interpreter_INVOKE_test.go
	modified:   jvm/interpreter_LL-end_test.go
	modified:   jvm/interpreter_arrayBytecodes_test.go
	modified:   jvm/interpreter_checkcast_test.go
	modified:   jvm/interpreter_int_boundary_test.go
	modified:   object/string_test.go
