### PR TITLE
JACOBIN-947 Jacobin is initializing thread objects twice in some cases

### DIFF
--- a/src/gfunction/javaLang/javaLangThread_helpers.go
+++ b/src/gfunction/javaLang/javaLangThread_helpers.go
@@ -87,12 +87,20 @@ func populateThreadObject(t *object.Object) {
 	t.ThMutex.Lock()
 	defer t.ThMutex.Unlock()
 
-	idField := object.Field{Ftype: types.Int, Fvalue: threadNumberingNext(nil).(int64)}
+	// If this function has already been called, just return.
+	idField, ok := t.FieldTable["ID"]
+	if ok {
+		return
+	}
+
+	// Establish the thread ID.
+	thid := threadNumberingNext(nil).(int64)
+	idField = object.Field{Ftype: types.Int, Fvalue: thid}
 	t.FieldTable["ID"] = idField
 
 	// the JDK defaults to "Thread-N" where N is the thread number
 	// the sole exception is the main thread, which is called "main"
-	defaultName := fmt.Sprintf("Thread-%d", idField.Fvalue)
+	defaultName := fmt.Sprintf("Thread-%d", thid)
 	nameField := object.Field{Ftype: types.JavaByteArray, Fvalue: object.StringObjectFromGoString(defaultName)}
 	t.FieldTable["name"] = nameField
 
@@ -152,9 +160,6 @@ func ThreadCreateObject(_ []interface{}) any {
 //   - the thread state is not an object
 //   - the thread state is missing the value field
 //   - max wait time <= 0
-//
-// Sentinel for continuing the loop
-var continueLoop = struct{}{}
 
 func waitForTermination(waitingThread, targetThread *object.Object, maxTime int64) interface{} {
 

--- a/src/gfunction/javaLang/javaLangThread_helpers.go
+++ b/src/gfunction/javaLang/javaLangThread_helpers.go
@@ -136,7 +136,7 @@ func RegisterThread(th *object.Object) {
 }
 
 // Should we need to create a thread (as in tests), here is the instantiable implementation
-func ThreadCreateNoarg(_ []interface{}) any {
+func ThreadCreateObject(_ []interface{}) any {
 	th := object.MakeEmptyObjectWithClassName(&types.ClassNameThread)
 	populateThreadObject(th)
 	return th

--- a/src/gfunction/javaLang/javaLangThread_test.go
+++ b/src/gfunction/javaLang/javaLangThread_test.go
@@ -50,7 +50,7 @@ func staticsGet(cls, name string) any { return statics.GetStaticValue(cls, name)
 
 func TestThreadCreateNoarg_Defaults(t *testing.T) {
 	EnsureTGInit()
-	obj := ThreadCreateNoarg(nil).(*object.Object)
+	obj := ThreadCreateObject(nil).(*object.Object)
 	if obj.FieldTable["ID"].Fvalue.(int64) == 0 {
 		t.Errorf("expected non-zero thread ID")
 	}
@@ -97,7 +97,7 @@ func TestThreadCreateNoarg_Defaults(t *testing.T) {
 
 func TestThreadInitWithName_ErrWrongArity(t *testing.T) {
 	EnsureTGInit()
-	ret := ThreadInitWithName([]any{ThreadCreateNoarg(nil)})
+	ret := ThreadInitWithName([]any{ThreadCreateObject(nil)})
 	g := ret.(*ghelpers.GErrBlk)
 	if g.ExceptionType != excNames.IllegalArgumentException {
 		t.Fatalf("expected IllegalArgumentException, got %d", g.ExceptionType)
@@ -111,7 +111,7 @@ func TestThreadInitWithName_ErrWrongTypes(t *testing.T) {
 	if ret.(*ghelpers.GErrBlk).ExceptionType != excNames.IllegalArgumentException {
 		t.Fatalf("expected IllegalArgumentException for non-thread first arg")
 	}
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 	ret2 := ThreadInitWithName([]any{th, 5})
 	if ret2.(*ghelpers.GErrBlk).ExceptionType != excNames.IllegalArgumentException {
 		t.Fatalf("expected IllegalArgumentException for non-string name")
@@ -120,7 +120,7 @@ func TestThreadInitWithName_ErrWrongTypes(t *testing.T) {
 
 func TestThreadInitWithName_Success(t *testing.T) {
 	EnsureTGInit()
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 	nm := object.StringObjectFromGoString("Alpha")
 	fs := makeAframeSet()
 	_ = ThreadInitWithName([]any{fs, th, nm})
@@ -133,11 +133,11 @@ func TestThreadInitWithName_Success(t *testing.T) {
 func TestThreadInitWithRunnableAndName_Paths(t *testing.T) {
 	EnsureTGInit()
 	// wrong arity
-	if threadInitWithRunnableAndName([]any{ThreadCreateNoarg(nil)}).(*ghelpers.GErrBlk).ExceptionType != excNames.IllegalArgumentException {
+	if threadInitWithRunnableAndName([]any{ThreadCreateObject(nil)}).(*ghelpers.GErrBlk).ExceptionType != excNames.IllegalArgumentException {
 		t.Fatal("expected IllegalArgumentException for arity")
 	}
 	// wrong types each position
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 	nm := object.StringObjectFromGoString("B")
 	runnable := makeRunnableDescriptor("C", "run", "()V")
 
@@ -164,7 +164,7 @@ func TestThreadInitWithThreadGroupAndName_Paths(t *testing.T) {
 	EnsureTGInit()
 	gr := globals.GetGlobalRef()
 	mainTG := gr.ThreadGroups["main"].(*object.Object)
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 	nm := object.StringObjectFromGoString("D")
 	fs := makeAframeSet()
 
@@ -190,7 +190,7 @@ func TestThreadInitWithThreadGroupRunnableAndName_Paths(t *testing.T) {
 	EnsureTGInit()
 	gr := globals.GetGlobalRef()
 	mainTG := gr.ThreadGroups["main"].(*object.Object)
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 	nm := object.StringObjectFromGoString("E")
 	runnable := makeRunnableDescriptor("C2", "run", "()V")
 
@@ -219,7 +219,7 @@ func TestThreadInitFromPackageConstructor_Paths(t *testing.T) {
 	EnsureTGInit()
 	gr := globals.GetGlobalRef()
 	mainTG := gr.ThreadGroups["main"].(*object.Object)
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 	nm := object.StringObjectFromGoString("P")
 	runnable := makeRunnableDescriptor("RC", "run", "()V")
 
@@ -272,8 +272,8 @@ func TestThreadActiveCount(t *testing.T) {
 	EnsureTGInit()
 	gr := globals.GetGlobalRef()
 	gr.Threads = map[int]interface{}{}
-	gr.Threads[1] = ThreadCreateNoarg(nil)
-	gr.Threads[2] = ThreadCreateNoarg(nil)
+	gr.Threads[1] = ThreadCreateObject(nil)
+	gr.Threads[2] = ThreadCreateObject(nil)
 	if threadActiveCount(nil).(int64) != 2 {
 		t.Errorf("expected 2 active threads")
 	}
@@ -301,7 +301,7 @@ func TestThreadDumpStack_Paths(t *testing.T) {
 	f.Thread = 5
 	fs.PushFront(f)
 	// register thread with name
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 	th.FieldTable["name"] = object.Field{Ftype: types.Ref, Fvalue: object.StringObjectFromGoString("T")}
 	globals.GetGlobalRef().Threads[5] = th
 
@@ -334,7 +334,7 @@ func TestThreadGetId_Paths(t *testing.T) {
 	if threadGetId([]any{123}).(*ghelpers.GErrBlk).ExceptionType != excNames.IllegalArgumentException {
 		t.Fatal("type")
 	}
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 	// success
 	id := threadGetId([]any{th}).(int64)
 	if id != th.FieldTable["ID"].Fvalue.(int64) {
@@ -344,7 +344,7 @@ func TestThreadGetId_Paths(t *testing.T) {
 
 func TestThreadGetNamePriorityStateGroupInterrupted(t *testing.T) {
 	EnsureTGInit()
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 	// getName
 	if threadGetName(nil).(*ghelpers.GErrBlk).ExceptionType != excNames.IllegalArgumentException {
 		t.Fatal("arity getName")
@@ -425,7 +425,7 @@ func TestThreadSetName_Paths(t *testing.T) {
 	if threadSetName([]any{123, object.StringObjectFromGoString("x")}).(*ghelpers.GErrBlk).ExceptionType != excNames.IllegalArgumentException {
 		t.Fatal("type")
 	}
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 	if threadSetName([]any{th, object.Null}).(*ghelpers.GErrBlk).ExceptionType != excNames.NullPointerException {
 		t.Fatal("npe expected")
 	}
@@ -447,7 +447,7 @@ func TestThreadSetPriority_Paths(t *testing.T) {
 	if threadSetPriority([]any{123, int64(5)}).(*ghelpers.GErrBlk).ExceptionType != excNames.IllegalArgumentException {
 		t.Fatal("type")
 	}
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 	if threadSetPriority([]any{th, "x"}).(*ghelpers.GErrBlk).ExceptionType != excNames.IllegalArgumentException {
 		t.Fatal("priority type")
 	}
@@ -511,7 +511,7 @@ func TestThreadInitWithRunnable_Paths(t *testing.T) {
 	if threadInitWithRunnable([]any{123, runnable}).(*ghelpers.GErrBlk).ExceptionType != excNames.IllegalArgumentException {
 		t.Fatal("expected IllegalArgumentException for non-thread first arg")
 	}
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 	if threadInitWithRunnable([]any{th, 456}).(*ghelpers.GErrBlk).ExceptionType != excNames.IllegalArgumentException {
 		t.Fatal("expected IllegalArgumentException for non-runnable second arg")
 	}
@@ -526,7 +526,7 @@ func TestThreadCurrentThread(t *testing.T) {
 	EnsureTGInit()
 	fs := makeAframeSet()
 	f := fs.Front().Value.(*frames.Frame)
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 	globals.GetGlobalRef().Threads[f.Thread] = th
 
 	// Arity error
@@ -549,8 +549,8 @@ func TestThreadEnumerate(t *testing.T) {
 	EnsureTGInit()
 	gr := globals.GetGlobalRef()
 	gr.Threads = map[int]interface{}{}
-	th1 := ThreadCreateNoarg(nil).(*object.Object)
-	th2 := ThreadCreateNoarg(nil).(*object.Object)
+	th1 := ThreadCreateObject(nil).(*object.Object)
+	th2 := ThreadCreateObject(nil).(*object.Object)
 	gr.Threads[1] = th1
 	gr.Threads[2] = th2
 
@@ -584,7 +584,7 @@ func TestThreadEnumerate(t *testing.T) {
 
 func TestThreadIsAliveTerminated(t *testing.T) {
 	EnsureTGInit()
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 
 	// isAlive arity
 	if threadIsAlive(nil).(*ghelpers.GErrBlk).ExceptionType != excNames.IllegalArgumentException {
@@ -644,7 +644,7 @@ func TestThreadToString_AllPaths(t *testing.T) {
 	}
 
 	// Success
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 	th.KlassName = types.StringPoolThreadIndex
 	th.FieldTable["ID"] = object.Field{Ftype: types.Int, Fvalue: int64(10)}
 	th.FieldTable["name"] = object.Field{Ftype: types.JavaByteArray, Fvalue: object.StringObjectFromGoString("Thread-10")}
@@ -665,7 +665,7 @@ func TestThreadToString_AllPaths(t *testing.T) {
 
 func TestThreadHelpers(t *testing.T) {
 	EnsureTGInit()
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 
 	// GetThreadState
 	if GetThreadState(th) != NEW {
@@ -704,7 +704,7 @@ func TestThreadHelpers(t *testing.T) {
 
 func TestRegisterThread(t *testing.T) {
 	EnsureTGInit()
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 	th.FieldTable["ID"] = object.Field{Ftype: types.Int, Fvalue: int64(999)}
 
 	RegisterThread(th)
@@ -730,7 +730,7 @@ func TestThreadRun_Paths(t *testing.T) {
 		t.Fatal("type")
 	}
 
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 	th.FieldTable["name"] = object.Field{Ftype: types.Ref, Fvalue: object.StringObjectFromGoString("Runner")}
 
 	// Success (returns nil, logs warning)
@@ -743,10 +743,10 @@ func TestThreadJoin_Paths(t *testing.T) {
 	EnsureTGInit()
 	fs := makeAframeSet()
 	f := fs.Front().Value.(*frames.Frame)
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 	globals.GetGlobalRef().Threads[f.Thread] = th
 
-	target := ThreadCreateNoarg(nil).(*object.Object)
+	target := ThreadCreateObject(nil).(*object.Object)
 
 	// Arity/Type errors
 	if threadJoin([]any{123, target}).(*ghelpers.GErrBlk).ExceptionType != excNames.IllegalArgumentException {
@@ -781,7 +781,7 @@ func TestThreadInitNull(t *testing.T) {
 		t.Fatal("type")
 	}
 	// Success
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 	if threadInitNull([]any{fs, th}) != nil {
 		t.Errorf("expected nil on success")
 	}
@@ -791,7 +791,7 @@ func TestThreadInitWithThreadGroupRunnable(t *testing.T) {
 	EnsureTGInit()
 	gr := globals.GetGlobalRef()
 	mainTG := gr.ThreadGroups["main"].(*object.Object)
-	th := ThreadCreateNoarg(nil).(*object.Object)
+	th := ThreadCreateObject(nil).(*object.Object)
 	runnable := makeRunnableDescriptor("RC3", "run", "()V")
 
 	// Arity

--- a/src/gfunction/javaUtil/javaUtilConcurrentAtomicAtomicInteger.go
+++ b/src/gfunction/javaUtil/javaUtilConcurrentAtomicAtomicInteger.go
@@ -15,7 +15,7 @@ func Load_Util_Concurrent_Atomic_AtomicInteger() {
 	ghelpers.MethodSignatures["java/util/concurrent/atomic/AtomicInteger.<clinit>()V"] =
 		ghelpers.GMeth{
 			ParamSlots: 0,
-			GFunction:  atomicIntegerClinit,
+			GFunction:  ghelpers.ClinitGeneric,
 		}
 
 	ghelpers.MethodSignatures["java/util/concurrent/atomic/AtomicInteger.<init>()V"] =
@@ -135,7 +135,7 @@ func Load_Util_Concurrent_Atomic_AtomicInteger() {
 	ghelpers.MethodSignatures["java/util/concurrent/atomic/AtomicInteger.getOpaque()I"] =
 		ghelpers.GMeth{
 			ParamSlots: 0,
-			GFunction:  ghelpers.TrapFunction,
+			GFunction:  atomicIntegerGet,
 		}
 
 	ghelpers.MethodSignatures["java/util/concurrent/atomic/AtomicInteger.getPlain()I"] =
@@ -192,7 +192,7 @@ func Load_Util_Concurrent_Atomic_AtomicInteger() {
 			GFunction:  atomicIntegerSet,
 		}
 
-	ghelpers.MethodSignatures["java/util/concurrent/atomic/AtomicInteger.toString()Ljava/base/String;"] =
+	ghelpers.MethodSignatures["java/util/concurrent/atomic/AtomicInteger.toString()Ljava/lang/String;"] =
 		ghelpers.GMeth{
 			ParamSlots: 0,
 			GFunction:  atomicIntegerToString,
@@ -228,17 +228,12 @@ func Load_Util_Concurrent_Atomic_AtomicInteger() {
 			GFunction:  ghelpers.TrapFunction,
 		}
 
-}
+	ghelpers.MethodSignatures["java/util/concurrent/atomic/AtomicInteger.weakCompareAndSetVolatile(II)Z"] =
+		ghelpers.GMeth{
+			ParamSlots: 2,
+			GFunction:  ghelpers.TrapFunction,
+		}
 
-// "java/util/concurrent/atomic/AtomicInteger.<clinit>()V"
-func atomicIntegerClinit([]interface{}) interface{} {
-	className := "java/util/concurrent/atomic/AtomicInteger"
-	obj := object.MakeEmptyObjectWithClassName(&className)
-	initialField := object.Field{Ftype: types.Int, Fvalue: int64(0)}
-	obj.ThMutex.Lock()
-	defer obj.ThMutex.Unlock()
-	obj.FieldTable["value"] = initialField
-	return nil
 }
 
 // "java/util/concurrent/atomic/AtomicInteger.<init>()V"
@@ -254,7 +249,7 @@ func atomicIntegerInitVoid(params []interface{}) interface{} {
 // "java/util/concurrent/atomic/AtomicInteger.<init>(I)V"
 func atomicIntegerInitInt(params []interface{}) interface{} {
 	obj := params[0].(*object.Object)
-	initialValue := params[1].(int64)
+	initialValue := int64(int32(params[1].(int64)))
 	initialField := object.Field{Ftype: types.Int, Fvalue: initialValue}
 	obj.ThMutex.Lock()
 	defer obj.ThMutex.Unlock()
@@ -265,7 +260,7 @@ func atomicIntegerInitInt(params []interface{}) interface{} {
 // "java/util/concurrent/atomic/AtomicInteger.Set(I)V"
 func atomicIntegerSet(params []interface{}) interface{} {
 	obj := params[0].(*object.Object)
-	initialValue := params[1].(int64)
+	initialValue := int64(int32(params[1].(int64)))
 	initialField := object.Field{Ftype: types.Int, Fvalue: initialValue}
 	obj.ThMutex.Lock()
 	defer obj.ThMutex.Unlock()
@@ -291,7 +286,7 @@ func atomicIntegerGetAndSet(params []interface{}) interface{} {
 	obj.ThMutex.Lock()
 	defer obj.ThMutex.Unlock()
 	oldValue := obj.FieldTable["value"].Fvalue.(int64)
-	newValue := params[1].(int64)
+	newValue := int64(int32(params[1].(int64)))
 	newField := object.Field{Ftype: types.Int, Fvalue: newValue}
 	obj.FieldTable["value"] = newField
 	return oldValue
@@ -302,11 +297,11 @@ func atomicIntegerCompareAndSet(params []interface{}) interface{} {
 	obj.ThMutex.Lock()
 	defer obj.ThMutex.Unlock()
 	oldValue := obj.FieldTable["value"].Fvalue.(int64)
-	expectedValue := params[1].(int64)
+	expectedValue := int64(int32(params[1].(int64)))
 	if oldValue != expectedValue {
 		return int64(0)
 	}
-	newValue := params[2].(int64)
+	newValue := int64(int32(params[2].(int64)))
 	newField := object.Field{Ftype: types.Int, Fvalue: newValue}
 	obj.FieldTable["value"] = newField
 	return int64(1)
@@ -402,11 +397,12 @@ func fnAtomicIntegerAdd(params []interface{}, newFlag bool) interface{} {
 	}
 
 	// Validate the second parameter (int64 value to add)
-	addend, ok := params[1].(int64)
+	addendRaw, ok := params[1].(int64)
 	if !ok {
 		errMsg := "fnAtomicIntegerAdd: Second parameter is not a valid int64"
 		return ghelpers.GetGErrBlk(excNames.ClassCastException, errMsg)
 	}
+	addend := int64(int32(addendRaw))
 
 	// Set up for lock and deferred unlock.
 	obj.ThMutex.Lock()
@@ -430,8 +426,8 @@ func fnAtomicIntegerAdd(params []interface{}, newFlag bool) interface{} {
 		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
-	// Perform addition and update the AtomicInteger value field.
-	newValue := formerValue + addend
+	// Perform addition and update the AtomicInteger value field with 32-bit wrapping.
+	newValue := int64(int32(formerValue + addend))
 	obj.FieldTable["value"] = object.Field{
 		Ftype:  types.Int,
 		Fvalue: newValue,

--- a/src/gfunction/javaUtil/javaUtilConcurrentAtomicAtomicInteger_test.go
+++ b/src/gfunction/javaUtil/javaUtilConcurrentAtomicAtomicInteger_test.go
@@ -243,3 +243,53 @@ func TestAtomicInteger_ErrorPaths_In_AddHelper(t *testing.T) {
 		}
 	}
 }
+
+func TestAtomicInteger_32BitOverflow(t *testing.T) {
+	globals.InitStringPool()
+
+	ai := newAtomicIntegerObj()
+	_ = atomicIntegerInitInt([]interface{}{ai, int64(2147483647)}) // Integer.MAX_VALUE
+
+	// incrementAndGet on Integer.MAX_VALUE should wrap to Integer.MIN_VALUE (-2147483648)
+	newv := atomicIntegerIncrementAndGet([]interface{}{ai}).(int64)
+	if newv != -2147483648 {
+		t.Fatalf("expected wrap to -2147483648 on increment, got %d", newv)
+	}
+	if cur := aiGet(t, ai); cur != -2147483648 {
+		t.Fatalf("expected current value -2147483648, got %d", cur)
+	}
+
+	// decrementAndGet on Integer.MIN_VALUE should wrap back to Integer.MAX_VALUE (2147483647)
+	newv = atomicIntegerDecrementAndGet([]interface{}{ai}).(int64)
+	if newv != 2147483647 {
+		t.Fatalf("expected wrap to 2147483647 on decrement, got %d", newv)
+	}
+
+	// addAndGet with overflow
+	newv = atomicIntegerAddAndGet([]interface{}{ai, int64(2)}).(int64)
+	if newv != -2147483647 {
+		t.Fatalf("expected wrap to -2147483647, got %d", newv)
+	}
+}
+
+func TestAtomicInteger_MethodSignatures(t *testing.T) {
+	globals.InitStringPool()
+	Load_Util_Concurrent_Atomic_AtomicInteger()
+
+	sigToString := "java/util/concurrent/atomic/AtomicInteger.toString()Ljava/lang/String;"
+	if gmeth, ok := ghelpers.MethodSignatures[sigToString]; !ok {
+		t.Fatalf("missing method signature: %s", sigToString)
+	} else if gmeth.ParamSlots != 0 {
+		t.Fatalf("expected 0 param slots for %s, got %d", sigToString, gmeth.ParamSlots)
+	}
+
+	sigGetOpaque := "java/util/concurrent/atomic/AtomicInteger.getOpaque()I"
+	if _, ok := ghelpers.MethodSignatures[sigGetOpaque]; !ok {
+		t.Fatalf("missing method signature: %s", sigGetOpaque)
+	}
+
+	sigWeakVolatile := "java/util/concurrent/atomic/AtomicInteger.weakCompareAndSetVolatile(II)Z"
+	if _, ok := ghelpers.MethodSignatures[sigWeakVolatile]; !ok {
+		t.Fatalf("missing method signature: %s", sigWeakVolatile)
+	}
+}

--- a/src/gfunction/javaUtil/javaUtilConcurrentAtomicAtomicLong.go
+++ b/src/gfunction/javaUtil/javaUtilConcurrentAtomicAtomicLong.go
@@ -22,7 +22,7 @@ func Load_Util_Concurrent_Atomic_Atomic_Long() {
 	ghelpers.MethodSignatures["java/util/concurrent/atomic/AtomicLong.<clinit>()V"] =
 		ghelpers.GMeth{
 			ParamSlots: 0,
-			GFunction:  atomicLongClinit,
+			GFunction:  ghelpers.ClinitGeneric,
 		}
 
 	ghelpers.MethodSignatures["java/util/concurrent/atomic/AtomicLong.<init>()V"] =
@@ -82,7 +82,7 @@ func Load_Util_Concurrent_Atomic_Atomic_Long() {
 	ghelpers.MethodSignatures["java/util/concurrent/atomic/AtomicLong.doubleValue()D"] =
 		ghelpers.GMeth{
 			ParamSlots: 0,
-			GFunction:  atomicLongToFloat,
+			GFunction:  atomicLongToDouble,
 		}
 
 	ghelpers.MethodSignatures["java/util/concurrent/atomic/AtomicLong.floatValue()F"] =
@@ -142,7 +142,7 @@ func Load_Util_Concurrent_Atomic_Atomic_Long() {
 	ghelpers.MethodSignatures["java/util/concurrent/atomic/AtomicLong.getOpaque()J"] =
 		ghelpers.GMeth{
 			ParamSlots: 0,
-			GFunction:  ghelpers.TrapFunction,
+			GFunction:  atomicLongGet,
 		}
 
 	ghelpers.MethodSignatures["java/util/concurrent/atomic/AtomicLong.getPlain()J"] =
@@ -160,7 +160,7 @@ func Load_Util_Concurrent_Atomic_Atomic_Long() {
 	ghelpers.MethodSignatures["java/util/concurrent/atomic/AtomicLong.intValue()I"] =
 		ghelpers.GMeth{
 			ParamSlots: 0,
-			GFunction:  atomicLongGet,
+			GFunction:  atomicLongToInt,
 		}
 
 	ghelpers.MethodSignatures["java/util/concurrent/atomic/AtomicLong.lazySet(J)V"] =
@@ -235,22 +235,18 @@ func Load_Util_Concurrent_Atomic_Atomic_Long() {
 			GFunction:  ghelpers.TrapFunction,
 		}
 
+	ghelpers.MethodSignatures["java/util/concurrent/atomic/AtomicLong.weakCompareAndSetVolatile(JJ)Z"] =
+		ghelpers.GMeth{
+			ParamSlots: 2,
+			GFunction:  ghelpers.TrapFunction,
+		}
+
 	ghelpers.MethodSignatures["java/util/concurrent/atomic/AtomicLong.VMSupportsCS8()Z"] =
 		ghelpers.GMeth{
 			ParamSlots: 0,
 			GFunction:  atomicLongVMSupportsCS8,
 		}
 
-}
-
-func atomicLongClinit([]interface{}) interface{} {
-	className := "java/util/concurrent/atomic/AtomicLong"
-	obj := object.MakeEmptyObjectWithClassName(&className)
-	initialField := object.Field{Ftype: types.Long, Fvalue: int64(0)}
-	obj.ThMutex.Lock()
-	defer obj.ThMutex.Unlock()
-	obj.FieldTable["value"] = initialField
-	return nil
 }
 
 func atomicLongInitVoid(params []interface{}) interface{} {
@@ -367,7 +363,23 @@ func atomicLongToString(params []interface{}) interface{} {
 	return object.StringObjectFromGoString(str)
 }
 
+func atomicLongToInt(params []interface{}) interface{} {
+	obj := params[0].(*object.Object)
+	obj.ThMutex.RLock()
+	defer obj.ThMutex.RUnlock()
+	longValue := obj.FieldTable["value"].Fvalue.(int64)
+	return int64(int32(longValue))
+}
+
 func atomicLongToFloat(params []interface{}) interface{} {
+	obj := params[0].(*object.Object)
+	obj.ThMutex.RLock()
+	defer obj.ThMutex.RUnlock()
+	longValue := obj.FieldTable["value"].Fvalue.(int64)
+	return float32(longValue)
+}
+
+func atomicLongToDouble(params []interface{}) interface{} {
 	obj := params[0].(*object.Object)
 	obj.ThMutex.RLock()
 	defer obj.ThMutex.RUnlock()

--- a/src/gfunction/javaUtil/javaUtilConcurrentAtomicAtomicLong_test.go
+++ b/src/gfunction/javaUtil/javaUtilConcurrentAtomicAtomicLong_test.go
@@ -1,11 +1,192 @@
 package javaUtil
 
 import (
+	"jacobin/src/gfunction/ghelpers"
 	"jacobin/src/globals"
+	"jacobin/src/object"
 	"jacobin/src/types"
 	"runtime"
 	"testing"
 )
+
+func newAtomicLongObj() *object.Object {
+	className := "java/util/concurrent/atomic/AtomicLong"
+	return object.MakeEmptyObjectWithClassName(&className)
+}
+
+func alGet(t *testing.T, obj *object.Object) int64 {
+	t.Helper()
+	obj.ThMutex.RLock()
+	defer obj.ThMutex.RUnlock()
+	f, ok := obj.FieldTable["value"]
+	if !ok {
+		t.Fatalf("expected 'value' field on AtomicLong object")
+	}
+	v, ok := f.Fvalue.(int64)
+	if !ok {
+		t.Fatalf("expected 'value' to be int64, got %T (%v)", f.Fvalue, f.Fvalue)
+	}
+	return v
+}
+
+func TestAtomicLong_Init_And_Set_Get(t *testing.T) {
+	globals.InitStringPool()
+
+	al := newAtomicLongObj()
+	ret := atomicLongInitVoid([]interface{}{al})
+	if ret != nil {
+		t.Fatalf("expected initVoid to return nil, got %v", ret)
+	}
+	if v := alGet(t, al); v != 0 {
+		t.Fatalf("expected initial value 0, got %d", v)
+	}
+
+	ret = atomicLongInitLong([]interface{}{al, int64(123456789012345)})
+	if ret != nil {
+		t.Fatalf("expected initLong to return nil, got %v", ret)
+	}
+	if v := alGet(t, al); v != 123456789012345 {
+		t.Fatalf("expected initial value 123456789012345, got %d", v)
+	}
+
+	ret = atomicLongSet([]interface{}{al, int64(-98765432109876)})
+	if ret != nil {
+		t.Fatalf("expected set to return nil, got %v", ret)
+	}
+	if v := atomicLongGet([]interface{}{al}); v != int64(-98765432109876) {
+		t.Fatalf("expected get -98765432109876, got %v", v)
+	}
+}
+
+func TestAtomicLong_GetAndSet_And_CompareAndSet(t *testing.T) {
+	globals.InitStringPool()
+
+	al := newAtomicLongObj()
+	_ = atomicLongInitLong([]interface{}{al, int64(100)})
+
+	old := atomicLongGetAndSet([]interface{}{al, int64(200)})
+	if old != int64(100) {
+		t.Fatalf("expected old value 100, got %v", old)
+	}
+	if cur := alGet(t, al); cur != 200 {
+		t.Fatalf("expected current value 200, got %d", cur)
+	}
+
+	casFail := atomicLongCompareAndSet([]interface{}{al, int64(999), int64(300)})
+	if casFail != types.JavaBoolFalse {
+		t.Fatalf("expected CAS fail (JavaBoolFalse), got %v", casFail)
+	}
+	if cur := alGet(t, al); cur != 200 {
+		t.Fatalf("expected value unchanged at 200, got %d", cur)
+	}
+
+	casSuccess := atomicLongCompareAndSet([]interface{}{al, int64(200), int64(300)})
+	if casSuccess != types.JavaBoolTrue {
+		t.Fatalf("expected CAS success (JavaBoolTrue), got %v", casSuccess)
+	}
+	if cur := alGet(t, al); cur != 300 {
+		t.Fatalf("expected value updated to 300, got %d", cur)
+	}
+}
+
+func TestAtomicLong_IncDec_Add_Variants(t *testing.T) {
+	globals.InitStringPool()
+
+	al := newAtomicLongObj()
+	_ = atomicLongInitLong([]interface{}{al, int64(10)})
+
+	if v := atomicLongGetAndIncrement([]interface{}{al}); v != int64(10) {
+		t.Fatalf("expected getAndIncrement 10, got %v", v)
+	}
+	if cur := alGet(t, al); cur != 11 {
+		t.Fatalf("expected current 11, got %d", cur)
+	}
+
+	if v := atomicLongIncrementAndGet([]interface{}{al}); v != int64(12) {
+		t.Fatalf("expected incrementAndGet 12, got %v", v)
+	}
+
+	if v := atomicLongGetAndDecrement([]interface{}{al}); v != int64(12) {
+		t.Fatalf("expected getAndDecrement 12, got %v", v)
+	}
+	if cur := alGet(t, al); cur != 11 {
+		t.Fatalf("expected current 11, got %d", cur)
+	}
+
+	if v := atomicLongDecrementAndGet([]interface{}{al}); v != int64(10) {
+		t.Fatalf("expected decrementAndGet 10, got %v", v)
+	}
+
+	if v := atomicLongGetAndAdd([]interface{}{al, int64(5)}); v != int64(10) {
+		t.Fatalf("expected getAndAdd 10, got %v", v)
+	}
+	if cur := alGet(t, al); cur != 15 {
+		t.Fatalf("expected current 15, got %d", cur)
+	}
+
+	if v := atomicLongAddAndGet([]interface{}{al, int64(-20)}); v != int64(-5) {
+		t.Fatalf("expected addAndGet -5, got %v", v)
+	}
+}
+
+func TestAtomicLong_Conversations(t *testing.T) {
+	globals.InitStringPool()
+
+	al := newAtomicLongObj()
+	// Set to a value that exceeds 32 bits: 0x100000005L = 4294967301
+	_ = atomicLongInitLong([]interface{}{al, int64(4294967301)})
+
+	// intValue should truncate to 32 bits signed: int32(4294967301) = 5
+	iv := atomicLongToInt([]interface{}{al}).(int64)
+	if iv != 5 {
+		t.Fatalf("expected intValue to truncate to 5, got %d", iv)
+	}
+
+	fv := atomicLongToFloat([]interface{}{al}).(float32)
+	if fv != float32(4294967301) {
+		t.Fatalf("expected floatValue float32, got %v", fv)
+	}
+
+	dv := atomicLongToDouble([]interface{}{al}).(float64)
+	if dv != float64(4294967301) {
+		t.Fatalf("expected doubleValue float64, got %v", dv)
+	}
+
+	strObj := atomicLongToString([]interface{}{al}).(*object.Object)
+	if strObj == nil {
+		t.Fatalf("expected non-nil string object")
+	}
+	goStr := object.GoStringFromStringObject(strObj)
+	if goStr != "4294967301" {
+		t.Fatalf("expected toString '4294967301', got %q", goStr)
+	}
+}
+
+func TestAtomicLong_MethodSignatures(t *testing.T) {
+	globals.InitStringPool()
+	Load_Util_Concurrent_Atomic_Atomic_Long()
+
+	sigGetOpaque := "java/util/concurrent/atomic/AtomicLong.getOpaque()J"
+	if _, ok := ghelpers.MethodSignatures[sigGetOpaque]; !ok {
+		t.Fatalf("missing method signature: %s", sigGetOpaque)
+	}
+
+	sigWeakVolatile := "java/util/concurrent/atomic/AtomicLong.weakCompareAndSetVolatile(JJ)Z"
+	if _, ok := ghelpers.MethodSignatures[sigWeakVolatile]; !ok {
+		t.Fatalf("missing method signature: %s", sigWeakVolatile)
+	}
+
+	sigDouble := "java/util/concurrent/atomic/AtomicLong.doubleValue()D"
+	if _, ok := ghelpers.MethodSignatures[sigDouble]; !ok {
+		t.Fatalf("missing method signature: %s", sigDouble)
+	}
+
+	sigInt := "java/util/concurrent/atomic/AtomicLong.intValue()I"
+	if _, ok := ghelpers.MethodSignatures[sigInt]; !ok {
+		t.Fatalf("missing method signature: %s", sigInt)
+	}
+
+}
 
 func TestAtomicLong_VMSupportsCS8_ReflectsArchitecture(t *testing.T) {
 	globals.InitStringPool()

--- a/src/jvm/TestHexHello2Class_test.go
+++ b/src/jvm/TestHexHello2Class_test.go
@@ -150,7 +150,7 @@ func TestHexHello2ValidClass(t *testing.T) {
 	classloader.MTable = make(map[string]classloader.MTentry)
 	gfunction.MTableLoadGFunctions(&classloader.MTable)
 	InitializePrimitiveWrappers()
-	th := javaLang.ThreadCreateNoarg(nil).(*object.Object)
+	th := javaLang.ThreadCreateObject(nil).(*object.Object)
 	className := "Hello2"
 	methName := "main"
 	methType := "([Ljava/lang/String;)V"

--- a/src/jvm/TestHexIDIVexception_test.go
+++ b/src/jvm/TestHexIDIVexception_test.go
@@ -124,7 +124,7 @@ func TestHexIDIVException(t *testing.T) {
 	// Run class ThrowIDIVexception
 	classloader.MTable = make(map[string]classloader.MTentry)
 	gfunction.MTableLoadGFunctions(&classloader.MTable)
-	th := javaLang.ThreadCreateNoarg(nil).(*object.Object)
+	th := javaLang.ThreadCreateObject(nil).(*object.Object)
 	args := []interface{}{th, "ThrowIDIVexception", "main", "([Ljava/lang/String;)V"}
 	RunJavaThread(args)
 

--- a/src/jvm/instantiate.go
+++ b/src/jvm/instantiate.go
@@ -51,7 +51,7 @@ func InstantiateClass(classname string, frameStack *list.List) (any, error) {
 	case types.StringClassName:
 		return object.NewStringObject(), nil
 	case types.ClassNameThread:
-		return javaLang.ThreadCreateNoarg(nil), nil
+		return javaLang.ThreadCreateObject(nil), nil
 	case types.ClassNameThreadGroup:
 		return javaLang.MakeThreadGroup(), nil
 	}

--- a/src/jvm/interpreter_LL-end_test.go
+++ b/src/jvm/interpreter_LL-end_test.go
@@ -933,7 +933,7 @@ func TestPeekWithStackUnderflow(t *testing.T) {
 	InitGlobalFunctionPointers()
 	javaLang.InitializeGlobalThreadGroups()
 
-	thObj := javaLang.ThreadCreateNoarg(nil).(*object.Object)
+	thObj := javaLang.ThreadCreateObject(nil).(*object.Object)
 	main := object.StringObjectFromGoString("main")
 	params := []any{thObj, main}
 	javaLang.ThreadInitWithName(params)
@@ -1017,7 +1017,7 @@ func TestPeekWithStackUnderflowStrictJDK(t *testing.T) {
 	// Create a Java-level Thread object (no use of jvmThread.go ExecThread)
 	InitGlobalFunctionPointers()
 	javaLang.InitializeGlobalThreadGroups()
-	thObj := javaLang.ThreadCreateNoarg(nil).(*object.Object)
+	thObj := javaLang.ThreadCreateObject(nil).(*object.Object)
 	main := object.StringObjectFromGoString("main")
 	params := []any{thObj, main}
 	javaLang.ThreadInitWithName(params)
@@ -1152,7 +1152,7 @@ func TestPopWithStackUnderflow(t *testing.T) {
 	var f *frames.Frame
 	globals.InitGlobals("test")
 	javaLang.InitializeGlobalThreadGroups()
-	thObj := javaLang.ThreadCreateNoarg(nil).(*object.Object)
+	thObj := javaLang.ThreadCreateObject(nil).(*object.Object)
 	main := object.StringObjectFromGoString("main")
 	params := []any{thObj, main}
 	javaLang.ThreadInitWithName(params)
@@ -1342,7 +1342,7 @@ func TestPushWithStackOverflow(t *testing.T) {
 	classloader.FetchMethodAndCP("java/lang/Object", "wait", "(JI)V")
 
 	var f *frames.Frame
-	thObj := javaLang.ThreadCreateNoarg(nil).(*object.Object)
+	thObj := javaLang.ThreadCreateObject(nil).(*object.Object)
 	main := object.StringObjectFromGoString("main")
 	params := []any{thObj, main}
 	javaLang.ThreadInitWithName(params)

--- a/src/jvm/run.go
+++ b/src/jvm/run.go
@@ -335,20 +335,22 @@ func createAndInitNewFrame(
 		destLocal = 1                               // The first parameter starts at index 1
 		lenLocals++                                 // There is 1 more local needed
 
-		// Lock the instance-object.
-		err := obj.ObjLock(int32(fram.Thread))
-		if err != nil {
-			fqn := fram.ClName + "." + fram.MethName + fram.MethType
-			errMsg := fmt.Sprintf("createAndInitNewFrame: ObjLock error, PC: %d, FQN: %s", fram.PC, fqn)
-			return nil, errors.New(errMsg)
-		}
-		if globals.TraceInst {
-			traceInfo := fmt.Sprintf("\tcreateAndInitNewFrame: Locked class-object %s", fram.ClName)
-			trace.Trace(traceInfo)
-		}
+		// Lock the instance-object if the method is synchronized.
+		if fram.AccessFlags&classloader.ACC_SYNCHRONIZED > 0 {
+			err := obj.ObjLock(int32(fram.Thread))
+			if err != nil {
+				fqn := fram.ClName + "." + fram.MethName + fram.MethType
+				errMsg := fmt.Sprintf("createAndInitNewFrame: ObjLock error, PC: %d, FQN: %s", fram.PC, fqn)
+				return nil, errors.New(errMsg)
+			}
+			if globals.TraceInst {
+				traceInfo := fmt.Sprintf("\tcreateAndInitNewFrame: Locked class-object %s", fram.ClName)
+				trace.Trace(traceInfo)
+			}
 
-		// Save class-name object pointer in the frame for return and catch-frame processing.
-		fram.ObjSync = obj
+			// Save class-name object pointer in the frame for return and catch-frame processing.
+			fram.ObjSync = obj
+		}
 	} else {
 		// Since includeObjectRef is false, this is a static case: invokestatic.
 		// Check for synchronized method and lock the class object if so.


### PR DESCRIPTION
See JACOBIN-947 -948, and -949.

#### JACOBIN-947 Renamed function ThreadCreateNoArg to ThreadCreateObject 
	modified:   gfunction/javaLang/javaLangThread_helpers.go
	modified:   gfunction/javaLang/javaLangThread_test.go
	modified:   jvm/TestHexHello2Class_test.go
	modified:   jvm/TestHexIDIVexception_test.go
	modified:   jvm/instantiate.go
	modified:   jvm/interpreter_LL-end_test.go

#### JACOBIN-947 Avoid initializing twice for the same thread object
        modified:   gfunction/javaLang/javaLangThread_helpers.go

### JACOBIN-948 Object locking should only occur for synchronized methods in `run.go` `createAndInitNewFrame()`
	modified:   jvm/run.go

### JACOBIN-949 Fixes to AtomicInteger and AtomicLong
	modified:   gfunction/javaUtil/javaUtilConcurrentAtomicAtomicInteger.go
	modified:   gfunction/javaUtil/javaUtilConcurrentAtomicAtomicInteger_test.go
	modified:   gfunction/javaUtil/javaUtilConcurrentAtomicAtomicLong.go
	modified:   gfunction/javaUtil/javaUtilConcurrentAtomicAtomicLong_test.go

