### PR TITLE
JACOBIN-950, -951, and -952

### DIFF
--- a/src/gfunction/javaLang/javaLangThread_members.go
+++ b/src/gfunction/javaLang/javaLangThread_members.go
@@ -254,8 +254,11 @@ func threadInterrupt(params []interface{}) any {
 		errMsg := "threadInterrupt: Expected thread to be an object"
 		return ghelpers.GetGErrBlk(excNames.VirtualMachineError, errMsg)
 	}
+
+	thObj.ThMutex.Lock()
 	fld, ok := thObj.FieldTable["interrupted"]
 	if !ok {
+		thObj.ThMutex.Unlock()
 		errMsg := "threadInterrupt: Missing the \"interrupted\" field in the thread object"
 		return ghelpers.GetGErrBlk(excNames.VirtualMachineError, errMsg)
 	}
@@ -263,6 +266,7 @@ func threadInterrupt(params []interface{}) any {
 	thObj.FieldTable["interrupted"] = fld
 
 	thID, ok := thObj.FieldTable["ID"].Fvalue.(int64)
+	thObj.ThMutex.Unlock()
 	if !ok {
 		errMsg := "threadInterrupt: Missing the \"ID\" field in the thread object"
 		return ghelpers.GetGErrBlk(excNames.VirtualMachineError, errMsg)
@@ -272,7 +276,6 @@ func threadInterrupt(params []interface{}) any {
 	object.WaitingThreads.RLock()
 	defer object.WaitingThreads.RUnlock()
 	if obj := object.WaitingThreads.MapThToObj[uint32(thID)]; obj != nil {
-		// The interrupted thread is waiting on an object (obj).
 		monitor := obj.GetMonitor()
 		if monitor != nil || monitor.Owner == object.MONITOR_OWNER_NONE {
 			monitor.Cond.Broadcast()

--- a/src/gfunction/javaLang/javaLangThread_test.go
+++ b/src/gfunction/javaLang/javaLangThread_test.go
@@ -16,7 +16,10 @@ import (
 	"jacobin/src/statics"
 	"jacobin/src/types"
 	"os"
+	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -624,10 +627,131 @@ func TestThreadIsAliveTerminated(t *testing.T) {
 }
 
 func TestThreadYield(t *testing.T) {
-	// yield just returns nil
+	EnsureTGInit()
+	// yield returns nil for various inputs
 	if threadYield(nil) != nil {
-		t.Errorf("threadYield should return nil")
+		t.Errorf("threadYield(nil) should return nil")
 	}
+	if threadYield([]any{}) != nil {
+		t.Errorf("threadYield([]any{}) should return nil")
+	}
+	if threadYield([]any{1, 2, "test"}) != nil {
+		t.Errorf("threadYield with extra params should return nil")
+	}
+
+	// Verify method signature registration
+	Load_Lang_Thread()
+	meth, exists := ghelpers.MethodSignatures["java/lang/Thread.yield()V"]
+	if !exists {
+		t.Fatalf("Method signature java/lang/Thread.yield()V not registered")
+	}
+	if meth.ParamSlots != 0 {
+		t.Errorf("Expected ParamSlots 0 for Thread.yield, got %d", meth.ParamSlots)
+	}
+	if meth.GFunction == nil {
+		t.Fatalf("Expected non-nil GFunction for Thread.yield")
+	}
+	if res := meth.GFunction(nil); res != nil {
+		t.Errorf("Expected nil result from Thread.yield GFunction, got %v", res)
+	}
+}
+
+func TestThreadYield_Contention(t *testing.T) {
+	EnsureTGInit()
+	Load_Lang_Thread()
+
+	origProcs := runtime.GOMAXPROCS(2)
+	defer runtime.GOMAXPROCS(origProcs)
+
+	const (
+		numGoroutines = 16
+		numIterations = 500
+	)
+
+	meth := ghelpers.MethodSignatures["java/lang/Thread.yield()V"]
+	yieldFn := meth.GFunction
+
+	// Test Scenario 1: CAS Spin-Lock under contention with Thread.yield()
+	var (
+		spinLock   atomic.Bool
+		counter    int64
+		yieldCount atomic.Int64
+		wg         sync.WaitGroup
+	)
+
+	for range numGoroutines {
+		wg.Go(func() {
+			for range numIterations {
+				for !spinLock.CompareAndSwap(false, true) {
+					yieldCount.Add(1)
+					yieldFn(nil)
+				}
+				// Critical section
+				counter++
+				spinLock.Store(false)
+				yieldFn(nil)
+			}
+		})
+	}
+
+	wg.Wait()
+
+	expectedCount := int64(numGoroutines * numIterations)
+	if counter != expectedCount {
+		t.Errorf("CAS spinlock counter mismatch: expected %d, got %d", expectedCount, counter)
+	}
+	if yieldCount.Load() == 0 {
+		t.Logf("Warning: 0 yield calls during CAS contention")
+	}
+
+	// Test Scenario 2: Token Ring Passing with Thread.yield()
+	var (
+		turn      atomic.Int64
+		ringDone  atomic.Bool
+		ringWg    sync.WaitGroup
+		completed atomic.Int64
+	)
+
+	for id := range numGoroutines {
+		ringWg.Go(func() {
+			for !ringDone.Load() {
+				if turn.Load()%int64(numGoroutines) == int64(id) {
+					c := completed.Add(1)
+					if c >= expectedCount {
+						ringDone.Store(true)
+						turn.Add(1)
+						break
+					}
+					turn.Add(1)
+				} else {
+					yieldFn(nil)
+				}
+			}
+		})
+	}
+
+	ringWg.Wait()
+
+	if completed.Load() < expectedCount {
+		t.Errorf("Token ring did not reach expected completions: got %d, expected at least %d", completed.Load(), expectedCount)
+	}
+
+	// Test Scenario 3: Shared Object FieldTable mutation under contention with Thread.yield()
+	th := ThreadCreateObject(nil).(*object.Object)
+	var objWg sync.WaitGroup
+	for range numGoroutines {
+		objWg.Go(func() {
+			for range 100 {
+				th.ThMutex.Lock()
+				fld := th.FieldTable["priority"]
+				fld.Fvalue = (fld.Fvalue.(int64) % 10) + 1
+				th.FieldTable["priority"] = fld
+				th.ThMutex.Unlock()
+				yieldFn(nil)
+			}
+		})
+	}
+	objWg.Wait()
 }
 
 func TestThreadToString_AllPaths(t *testing.T) {

--- a/src/gfunction/javaUtil/javaUtilConcurrentCyclicBarrier.go
+++ b/src/gfunction/javaUtil/javaUtilConcurrentCyclicBarrier.go
@@ -7,21 +7,39 @@
 package javaUtil
 
 import (
+	"container/list"
 	"jacobin/src/excNames"
+	"jacobin/src/frames"
 	"jacobin/src/gfunction/ghelpers"
+	"jacobin/src/globals"
 	"jacobin/src/object"
 	"jacobin/src/types"
 	"sync"
 )
 
+type generation struct {
+	broken bool
+}
+
 type cyclicBarrierState struct {
-	parties       int
-	count         int
-	generation    int
-	broken        bool
-	lastBroken    bool
+	mu            sync.RWMutex
+	parties       int64
+	count         int64
+	gen           *generation
 	barrierCond   *sync.Cond
 	barrierAction *object.Object
+}
+
+func (s *cyclicBarrierState) nextGeneration() {
+	s.barrierCond.Broadcast()
+	s.count = s.parties
+	s.gen = &generation{broken: false}
+}
+
+func (s *cyclicBarrierState) breakBarrier() {
+	s.gen.broken = true
+	s.count = s.parties
+	s.barrierCond.Broadcast()
 }
 
 func Load_Util_Concurrent_CyclicBarrier() {
@@ -39,8 +57,9 @@ func Load_Util_Concurrent_CyclicBarrier() {
 
 	ghelpers.MethodSignatures["java/util/concurrent/CyclicBarrier.await()I"] =
 		ghelpers.GMeth{
-			ParamSlots: 0,
-			GFunction:  cyclicBarrierAwait,
+			ParamSlots:   0,
+			NeedsContext: true,
+			GFunction:    cyclicBarrierAwait,
 		}
 
 	ghelpers.MethodSignatures["java/util/concurrent/CyclicBarrier.await(JLjava/util/concurrent/TimeUnit;)I"] =
@@ -80,11 +99,37 @@ func isThreadInterrupted(th *object.Object) bool {
 	}
 	th.ThMutex.RLock()
 	defer th.ThMutex.RUnlock()
-	interrupted, ok := th.FieldTable["interrupted"].Fvalue.(types.JavaBool)
-	return ok && interrupted == types.JavaBoolTrue
+	fld, ok := th.FieldTable["interrupted"]
+	if !ok {
+		return false
+	}
+	switch v := fld.Fvalue.(type) {
+	case int64:
+		return v == types.JavaBoolTrue
+	case int:
+		return v != 0
+	default:
+		return false
+	}
+}
+
+func clearThreadInterrupted(th *object.Object) {
+	if th == nil || th == object.Null {
+		return
+	}
+	th.ThMutex.Lock()
+	defer th.ThMutex.Unlock()
+	fld, ok := th.FieldTable["interrupted"]
+	if ok {
+		fld.Fvalue = types.JavaBoolFalse
+		th.FieldTable["interrupted"] = fld
+	}
 }
 
 func getCyclicBarrierState(self *object.Object) (*cyclicBarrierState, interface{}) {
+	if self == nil || object.IsNull(self) {
+		return nil, ghelpers.GetGErrBlk(excNames.NullPointerException, "getCyclicBarrierState: CyclicBarrier is null")
+	}
 	self.ThMutex.RLock()
 	defer self.ThMutex.RUnlock()
 	field, exists := self.FieldTable["state"]
@@ -92,62 +137,115 @@ func getCyclicBarrierState(self *object.Object) (*cyclicBarrierState, interface{
 		return nil, ghelpers.GetGErrBlk(excNames.NullPointerException, "getCyclicBarrierState: CyclicBarrier not initialized")
 	}
 	state, ok := field.Fvalue.(*cyclicBarrierState)
-	if !ok {
+	if !ok || state == nil {
 		return nil, ghelpers.GetGErrBlk(excNames.VirtualMachineError, "getCyclicBarrierState: Invalid CyclicBarrier storage")
 	}
 	return state, nil
 }
 
 func cyclicBarrierInit(params []interface{}) interface{} {
+	if len(params) == 0 {
+		return ghelpers.GetGErrBlk(excNames.NullPointerException, "CyclicBarrier.<init>: null parameters")
+	}
+	self, ok := params[0].(*object.Object)
+	if !ok || object.IsNull(self) {
+		return ghelpers.GetGErrBlk(excNames.NullPointerException, "CyclicBarrier.<init>: self is null")
+	}
+	if len(params) < 2 {
+		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, "CyclicBarrier.<init>: missing parties parameter")
+	}
 	return cyclicBarrierInitAction([]interface{}{params[0], params[1], object.Null})
 }
 
 func cyclicBarrierInitAction(params []interface{}) interface{} {
-	self := params[0].(*object.Object)
+	if len(params) < 2 {
+		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, "CyclicBarrier.<init>: insufficient parameters")
+	}
+	self, ok := params[0].(*object.Object)
+	if !ok || object.IsNull(self) {
+		return ghelpers.GetGErrBlk(excNames.NullPointerException, "CyclicBarrier.<init>: self is null")
+	}
 	parties, ok := params[1].(int64)
 	if !ok || parties <= 0 {
 		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, "CyclicBarrier parties must be positive")
 	}
-	barrierAction, _ := params[2].(*object.Object)
+	var barrierAction *object.Object
+	if len(params) > 2 {
+		barrierAction, _ = params[2].(*object.Object)
+	}
 
-	mu := &sync.RWMutex{}
 	state := &cyclicBarrierState{
-		parties:       int(parties),
-		count:         int(parties),
-		generation:    0,
-		broken:        false,
-		barrierCond:   sync.NewCond(mu),
+		parties:       parties,
+		count:         parties,
+		gen:           &generation{broken: false},
 		barrierAction: barrierAction,
 	}
+	state.barrierCond = sync.NewCond(&state.mu)
 
 	self.ThMutex.Lock()
 	defer self.ThMutex.Unlock()
-	self.FieldTable["state"] = object.Field{Ftype: types.ArrayList, Fvalue: state} // Using ArrayList type as a placeholder for pointer
+	self.FieldTable["state"] = object.Field{Ftype: types.Ref, Fvalue: state}
 	return nil
 }
 
 func cyclicBarrierAwait(params []interface{}) interface{} {
-	self := params[0].(*object.Object)
+	if len(params) == 0 {
+		return ghelpers.GetGErrBlk(excNames.NullPointerException, "cyclicBarrierAwait: null parameters")
+	}
+
+	var self *object.Object
+	var currentThread *object.Object
+
+	if fs, ok := params[0].(*list.List); ok {
+		// NeedsContext=true: params = [fs, self]
+		if len(params) < 2 {
+			return ghelpers.GetGErrBlk(excNames.NullPointerException, "cyclicBarrierAwait: missing self object")
+		}
+		var isObj bool
+		self, isObj = params[1].(*object.Object)
+		if !isObj || object.IsNull(self) {
+			return ghelpers.GetGErrBlk(excNames.NullPointerException, "cyclicBarrierAwait: null self object")
+		}
+		if fs != nil && fs.Front() != nil {
+			if fr, ok := fs.Front().Value.(*frames.Frame); ok {
+				gr := globals.GetGlobalRef()
+				gr.ThreadLock.RLock()
+				if th, exists := gr.Threads[fr.Thread]; exists && th != nil {
+					currentThread, _ = th.(*object.Object)
+				}
+				gr.ThreadLock.RUnlock()
+			}
+		}
+	} else if obj, ok := params[0].(*object.Object); ok {
+		self = obj
+		if len(params) > 1 {
+			currentThread, _ = params[1].(*object.Object)
+		}
+	} else {
+		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, "cyclicBarrierAwait: invalid parameters")
+	}
+
+	if object.IsNull(self) {
+		return ghelpers.GetGErrBlk(excNames.NullPointerException, "cyclicBarrierAwait: null self object")
+	}
+
 	state, err := getCyclicBarrierState(self)
 	if err != nil {
 		return err
 	}
 
-	state.barrierCond.L.Lock()
-	defer state.barrierCond.L.Unlock()
+	state.mu.Lock()
+	defer state.mu.Unlock()
 
-	generation := state.generation
+	g := state.gen
 
-	if state.broken {
+	if g.broken {
 		return ghelpers.GetGErrBlk(excNames.BrokenBarrierException, "CyclicBarrier is broken")
 	}
 
-	// Check for thread interruption
-	currentThread := params[len(params)-1].(*object.Object)
 	if isThreadInterrupted(currentThread) {
-		state.broken = true
-		state.lastBroken = true
-		state.barrierCond.Broadcast()
+		clearThreadInterrupted(currentThread)
+		state.breakBarrier()
 		return ghelpers.GetGErrBlk(excNames.InterruptedException, "Thread interrupted before wait")
 	}
 
@@ -155,100 +253,101 @@ func cyclicBarrierAwait(params []interface{}) interface{} {
 	state.count = index
 
 	if index == 0 {
-		// Last thread arrived
-		ranAction := false
-		if state.barrierAction != nil && state.barrierAction != object.Null {
-			// Action execution not fully implemented (requires Java call)
-		}
-
-		if !ranAction {
-			// Success
-			state.lastBroken = false
-			state.generation++
-			state.count = state.parties
-			state.barrierCond.Broadcast()
-			return int64(0)
-		}
-		// If action failed, break barrier
-		state.broken = true
-		state.lastBroken = true
-		state.barrierCond.Broadcast()
-		return ghelpers.GetGErrBlk(excNames.BrokenBarrierException, "Barrier action failed")
+		state.nextGeneration()
+		return int64(0)
 	}
 
-	// Wait for others
-	for generation == state.generation {
+	for {
 		state.barrierCond.Wait()
 
-		// Check for thread interruption
 		if isThreadInterrupted(currentThread) {
-			state.broken = true
-			state.lastBroken = true
-			state.barrierCond.Broadcast()
+			clearThreadInterrupted(currentThread)
+			if g == state.gen && !g.broken {
+				state.breakBarrier()
+				return ghelpers.GetGErrBlk(excNames.InterruptedException, "Thread interrupted during wait")
+			}
 			return ghelpers.GetGErrBlk(excNames.InterruptedException, "Thread interrupted during wait")
 		}
 
-		if generation != state.generation {
-			if state.lastBroken {
-				return ghelpers.GetGErrBlk(excNames.BrokenBarrierException, "CyclicBarrier broken or reset during wait")
-			}
-			return int64(index)
+		if g.broken {
+			return ghelpers.GetGErrBlk(excNames.BrokenBarrierException, "CyclicBarrier broken or reset during wait")
+		}
+
+		if g != state.gen {
+			return index
 		}
 	}
-
-	return int64(index)
 }
 
 func cyclicBarrierGetParties(params []interface{}) interface{} {
-	self := params[0].(*object.Object)
+	if len(params) == 0 {
+		return ghelpers.GetGErrBlk(excNames.NullPointerException, "cyclicBarrierGetParties: null parameters")
+	}
+	self, ok := params[0].(*object.Object)
+	if !ok || object.IsNull(self) {
+		return ghelpers.GetGErrBlk(excNames.NullPointerException, "cyclicBarrierGetParties: null self object")
+	}
 	state, err := getCyclicBarrierState(self)
 	if err != nil {
 		return err
 	}
-	state.barrierCond.L.(*sync.RWMutex).RLock()
-	defer state.barrierCond.L.(*sync.RWMutex).RUnlock()
-	return int64(state.parties)
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+	return state.parties
 }
 
 func cyclicBarrierIsBroken(params []interface{}) interface{} {
-	self := params[0].(*object.Object)
+	if len(params) == 0 {
+		return ghelpers.GetGErrBlk(excNames.NullPointerException, "cyclicBarrierIsBroken: null parameters")
+	}
+	self, ok := params[0].(*object.Object)
+	if !ok || object.IsNull(self) {
+		return ghelpers.GetGErrBlk(excNames.NullPointerException, "cyclicBarrierIsBroken: null self object")
+	}
 	state, err := getCyclicBarrierState(self)
 	if err != nil {
 		return err
 	}
-	state.barrierCond.L.(*sync.RWMutex).RLock()
-	defer state.barrierCond.L.(*sync.RWMutex).RUnlock()
-	return object.JavaBooleanFromGoBoolean(state.broken)
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+	return object.JavaBooleanFromGoBoolean(state.gen.broken)
 }
 
 func cyclicBarrierReset(params []interface{}) interface{} {
-	self := params[0].(*object.Object)
+	if len(params) == 0 {
+		return ghelpers.GetGErrBlk(excNames.NullPointerException, "cyclicBarrierReset: null parameters")
+	}
+	self, ok := params[0].(*object.Object)
+	if !ok || object.IsNull(self) {
+		return ghelpers.GetGErrBlk(excNames.NullPointerException, "cyclicBarrierReset: null self object")
+	}
 	state, err := getCyclicBarrierState(self)
 	if err != nil {
 		return err
 	}
 
-	state.barrierCond.L.Lock()
-	defer state.barrierCond.L.Unlock()
+	state.mu.Lock()
+	defer state.mu.Unlock()
 
-	state.broken = true
-	state.lastBroken = true
-	state.generation++ // Mark this generation as done/broken
-	state.barrierCond.Broadcast()
-
-	state.count = state.parties
-	state.broken = false // Start new generation fresh
+	state.breakBarrier()
+	state.nextGeneration()
 
 	return nil
 }
 
 func cyclicBarrierGetNumberWaiting(params []interface{}) interface{} {
-	self := params[0].(*object.Object)
+	if len(params) == 0 {
+		return ghelpers.GetGErrBlk(excNames.NullPointerException, "cyclicBarrierGetNumberWaiting: null parameters")
+	}
+	self, ok := params[0].(*object.Object)
+	if !ok || object.IsNull(self) {
+		return ghelpers.GetGErrBlk(excNames.NullPointerException, "cyclicBarrierGetNumberWaiting: null self object")
+	}
 	state, err := getCyclicBarrierState(self)
 	if err != nil {
 		return err
 	}
-	state.barrierCond.L.(*sync.RWMutex).RLock()
-	defer state.barrierCond.L.(*sync.RWMutex).RUnlock()
-	return int64(state.parties - state.count)
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+	return state.parties - state.count
 }

--- a/src/gfunction/javaUtil/javaUtilConcurrentCyclicBarrier_test.go
+++ b/src/gfunction/javaUtil/javaUtilConcurrentCyclicBarrier_test.go
@@ -8,6 +8,7 @@ package javaUtil
 
 import (
 	"jacobin/src/excNames"
+	"jacobin/src/frames"
 	"jacobin/src/gfunction/ghelpers"
 	"jacobin/src/globals"
 	"jacobin/src/object"
@@ -59,13 +60,11 @@ func TestCyclicBarrier_Basic(t *testing.T) {
 		results <- res.(int64)
 	}()
 
-	// Wait a bit to ensure Thread 1 is waiting
-	// (Not foolproof but usually works for unit tests)
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 100; i++ {
 		if waiting := cyclicBarrierGetNumberWaiting([]interface{}{cb}).(int64); waiting == 1 {
 			break
 		}
-		// small sleep or yield if needed, but for unit tests simplicity:
+		time.Sleep(1 * time.Millisecond)
 	}
 
 	go func() {
@@ -96,6 +95,45 @@ func TestCyclicBarrier_Basic(t *testing.T) {
 	}
 }
 
+func TestCyclicBarrier_MultipleCycles(t *testing.T) {
+	globals.InitStringPool()
+	cb := newCyclicBarrierObj()
+	cyclicBarrierInit([]interface{}{cb, int64(3)})
+
+	for cycle := 0; cycle < 3; cycle++ {
+		var wg sync.WaitGroup
+		wg.Add(3)
+		results := make(chan int64, 3)
+
+		for i := 0; i < 3; i++ {
+			go func() {
+				defer wg.Done()
+				res := cyclicBarrierAwait([]interface{}{cb})
+				if err, ok := res.(*ghelpers.GErrBlk); ok {
+					t.Errorf("Await failed in cycle %d: %v", cycle, err.ErrMsg)
+					return
+				}
+				results <- res.(int64)
+			}()
+		}
+
+		wg.Wait()
+		close(results)
+
+		var sum int64
+		for r := range results {
+			sum += r
+		}
+		// Indices should be 2 + 1 + 0 = 3
+		if sum != 3 {
+			t.Fatalf("Cycle %d expected index sum 3, got %d", cycle, sum)
+		}
+		if waiting := cyclicBarrierGetNumberWaiting([]interface{}{cb}).(int64); waiting != 0 {
+			t.Fatalf("Cycle %d expected 0 waiting, got %d", cycle, waiting)
+		}
+	}
+}
+
 func TestCyclicBarrier_Interrupt(t *testing.T) {
 	globals.InitStringPool()
 	cb := newCyclicBarrierObj()
@@ -110,7 +148,7 @@ func TestCyclicBarrier_Interrupt(t *testing.T) {
 		t.Fatalf("Expected InterruptedException, got %v", res)
 	}
 
-	if broken := cyclicBarrierIsBroken([]interface{}{cb}).(types.JavaBool); broken != types.JavaBoolTrue {
+	if broken := cyclicBarrierIsBroken([]interface{}{cb}).(int64); broken != types.JavaBoolTrue {
 		t.Fatalf("expected broken barrier after interrupt, got %v", broken)
 	}
 }
@@ -144,5 +182,89 @@ func TestCyclicBarrier_Reset(t *testing.T) {
 
 	if broken := cyclicBarrierIsBroken([]interface{}{cb}).(int64); broken != types.JavaBoolFalse {
 		t.Fatalf("expected not broken after reset")
+	}
+}
+
+func TestCyclicBarrier_NeedsContext_Await(t *testing.T) {
+	globals.InitGlobals("test")
+	globals.InitStringPool()
+
+	th := object.MakeEmptyObject()
+	th.FieldTable["interrupted"] = object.Field{Ftype: types.Int, Fvalue: types.JavaBoolFalse}
+
+	thID := 42
+	gr := globals.GetGlobalRef()
+	gr.ThreadLock.Lock()
+	gr.Threads[thID] = th
+	gr.ThreadLock.Unlock()
+
+	fs := frames.CreateFrameStack()
+	f := frames.CreateFrame(0)
+	f.Thread = thID
+	_ = frames.PushFrame(fs, f)
+
+	cb := newCyclicBarrierObj()
+	cyclicBarrierInit([]interface{}{cb, int64(1)})
+
+	// Await with [fs, cb]
+	res := cyclicBarrierAwait([]interface{}{fs, cb})
+	if idx, ok := res.(int64); !ok || idx != 0 {
+		t.Fatalf("expected return 0 for single party barrier, got %v (%T)", res, res)
+	}
+}
+
+func TestCyclicBarrier_MethodSignatures(t *testing.T) {
+	saved := ghelpers.MethodSignatures
+	defer func() { ghelpers.MethodSignatures = saved }()
+	ghelpers.MethodSignatures = make(map[string]ghelpers.GMeth)
+
+	Load_Util_Concurrent_CyclicBarrier()
+
+	awaitSig := "java/util/concurrent/CyclicBarrier.await()I"
+	gm, ok := ghelpers.MethodSignatures[awaitSig]
+	if !ok {
+		t.Fatalf("missing signature %s", awaitSig)
+	}
+	if !gm.NeedsContext {
+		t.Fatalf("expected %s NeedsContext to be true", awaitSig)
+	}
+
+	initSig := "java/util/concurrent/CyclicBarrier.<init>(ILjava/lang/Runnable;)V"
+	if gmInit, ok := ghelpers.MethodSignatures[initSig]; !ok || gmInit.ParamSlots != 2 {
+		t.Fatalf("missing or invalid %s", initSig)
+	}
+}
+
+func TestCyclicBarrier_DefensiveChecks(t *testing.T) {
+	globals.InitStringPool()
+
+	// Null / invalid params to Init
+	if err := cyclicBarrierInit(nil); err == nil {
+		t.Fatalf("expected error on nil params to init")
+	}
+	if err := cyclicBarrierInit([]interface{}{object.Null, int64(2)}); err == nil {
+		t.Fatalf("expected error on null obj to init")
+	}
+	cb := newCyclicBarrierObj()
+	if err := cyclicBarrierInit([]interface{}{cb, int64(-1)}); err == nil {
+		t.Fatalf("expected error on negative parties to init")
+	}
+
+	// Uninitialized await / parties / isBroken / reset
+	uninitCb := newCyclicBarrierObj()
+	if err, ok := cyclicBarrierAwait([]interface{}{uninitCb}).(*ghelpers.GErrBlk); !ok || err.ExceptionType != excNames.NullPointerException {
+		t.Fatalf("expected NPE on uninitialized await, got %v", err)
+	}
+	if err, ok := cyclicBarrierGetParties([]interface{}{uninitCb}).(*ghelpers.GErrBlk); !ok || err.ExceptionType != excNames.NullPointerException {
+		t.Fatalf("expected NPE on uninitialized getParties, got %v", err)
+	}
+	if err, ok := cyclicBarrierIsBroken([]interface{}{uninitCb}).(*ghelpers.GErrBlk); !ok || err.ExceptionType != excNames.NullPointerException {
+		t.Fatalf("expected NPE on uninitialized isBroken, got %v", err)
+	}
+	if err, ok := cyclicBarrierReset([]interface{}{uninitCb}).(*ghelpers.GErrBlk); !ok || err.ExceptionType != excNames.NullPointerException {
+		t.Fatalf("expected NPE on uninitialized reset, got %v", err)
+	}
+	if err, ok := cyclicBarrierGetNumberWaiting([]interface{}{uninitCb}).(*ghelpers.GErrBlk); !ok || err.ExceptionType != excNames.NullPointerException {
+		t.Fatalf("expected NPE on uninitialized getNumberWaiting, got %v", err)
 	}
 }

--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -3284,6 +3284,18 @@ func doInvokeinterface(fr *frames.Frame, _ int64) int {
 		return RESUME_HERE // caught
 	}
 
+	// Make sure that the reference is truly an object.
+	switch objRef.(type) {
+	case *object.Object:
+	default:
+		errMsg := fmt.Sprintf("INVOKEINTERFACE: objRef is not an object, observed type: %T", objRef)
+		status := exceptions.ThrowEx(excNames.IllegalArgumentException, errMsg, fr)
+		if status != exceptions.Caught {
+			return ERROR_OCCURRED // applies only if in test
+		}
+		return RESUME_HERE // caught
+	}
+
 	// get the name of the objectRef's class, and make sure it's loaded
 	objRefClassName := *(stringPool.GetStringPointer(objRef.(*object.Object).KlassName))
 	if err := classloader.LoadClassFromNameOnly(objRefClassName); err != nil {

--- a/src/object/object.go
+++ b/src/object/object.go
@@ -574,8 +574,8 @@ func (obj *Object) ObjectWait(threadID int32, millis int64) error {
 	}
 
 	// Check if already interrupted before waiting
-	if isThreadInterrupted(uint32(threadID)) {
-		clearThreadInterrupted(uint32(threadID))
+	if IsThreadInterrupted(uint32(threadID)) {
+		ClearThreadInterrupted(uint32(threadID))
 		return errors.New("thread interrupted")
 	}
 
@@ -633,8 +633,8 @@ func (obj *Object) ObjectWait(threadID int32, millis int64) error {
 		}
 
 		// Check thread interruption status
-		if isThreadInterrupted(uint32(threadID)) {
-			clearThreadInterrupted(uint32(threadID))
+		if IsThreadInterrupted(uint32(threadID)) {
+			ClearThreadInterrupted(uint32(threadID))
 			interruptErr = errors.New("thread interrupted during wait")
 		}
 
@@ -643,8 +643,8 @@ func (obj *Object) ObjectWait(threadID int32, millis int64) error {
 		monitor.Cond.Wait() // Atomically unlocks Mutex, waits, relocks on wakeup
 
 		// Check thread interruption status
-		if isThreadInterrupted(uint32(threadID)) {
-			clearThreadInterrupted(uint32(threadID))
+		if IsThreadInterrupted(uint32(threadID)) {
+			ClearThreadInterrupted(uint32(threadID))
 			interruptErr = errors.New("thread interrupted during wait")
 		}
 	}
@@ -677,20 +677,26 @@ func (obj *Object) ObjectWait(threadID int32, millis int64) error {
 	return nil
 }
 
-func isThreadInterrupted(thID uint32) bool {
+func IsThreadInterrupted(thID uint32) bool {
 	gr := globals.GetGlobalRef()
 	gr.ThreadLock.RLock()
-	defer gr.ThreadLock.RUnlock()
 	thObj := gr.Threads[int(thID)].(*Object)
+	gr.ThreadLock.RUnlock()
+
+	thObj.ThMutex.RLock()
+	defer thObj.ThMutex.RUnlock()
 	interrupted := thObj.FieldTable["interrupted"].Fvalue.(types.JavaBool)
 	return interrupted == types.JavaBoolTrue
 }
 
-func clearThreadInterrupted(thID uint32) {
+func ClearThreadInterrupted(thID uint32) {
 	gr := globals.GetGlobalRef()
-	gr.ThreadLock.Lock()
-	defer gr.ThreadLock.Unlock()
+	gr.ThreadLock.RLock()
 	thObj := gr.Threads[int(thID)].(*Object)
+	gr.ThreadLock.RUnlock()
+
+	thObj.ThMutex.Lock()
+	defer thObj.ThMutex.Unlock()
 	fld := thObj.FieldTable["interrupted"]
 	fld.Fvalue = types.JavaBoolFalse
 	thObj.FieldTable["interrupted"] = fld


### PR DESCRIPTION
See JACOBIN-950, -951, and -952.

### JACOBIN-950
modified:   jvm/interpreter.go doInvokeinterface - ensure that `objRef` is type `*object.Object`

### JACOBIN-951
modified:   gfunction/javaUtil/javaUtilConcurrentCyclicBarrier.go
modified:   gfunction/javaUtil/javaUtilConcurrentCyclicBarrier_test.go

### JACOBIN-952 (improve coverage of multithreading with intermittent thread yielding)
modified:   gfunction/javaLang/javaLangThread_test.go
modified:   src/gfunction/javaLang/javaLangThread_members.go
modified:   src/object/object.go
