### PR TITLE
JACOBIN-952 protext CP mutex in doGetStatic, doPutStatic, doInvokeinterface, cpUtils.go

### DIFF
--- a/src/classloader/cpUtils.go
+++ b/src/classloader/cpUtils.go
@@ -61,11 +61,14 @@ func FetchCPentry(cp *CPool, index int) CpType {
 	}
 
 	// if index is out of range, return error
+	cp.Mutex.RLock()
 	if index < 1 || index >= len(cp.CpIndex) {
+		cp.Mutex.RUnlock()
 		return CpType{EntryType: 0, RetType: IS_ERROR}
 	}
 
 	entry := cp.CpIndex[index]
+	cp.Mutex.RUnlock()
 
 	switch entry.Type {
 	// integers
@@ -104,7 +107,9 @@ func FetchCPentry(cp *CPool, index int) CpType {
 			RetType: IS_CLASS_REF, StringVal: &className}
 
 	case StringConst: // points to a CP entry, which is a UTF-8 string constant
+		cp.Mutex.RLock()
 		e := cp.CpIndex[entry.Slot]
+		cp.Mutex.RUnlock()
 		// should point to a UTF-8
 		if e.Type != UTF8 {
 			return CpType{EntryType: 0, RetType: IS_ERROR}
@@ -194,25 +199,35 @@ func GetMethInfoFromCPmethref(CP *CPool, cpIndex int) (string, string, string, s
 }
 
 func GetMethInfoFromCPinterfaceRef(CP *CPool, cpIndex int) (string, string, string) {
+	// All the reads of CP.CpIndex below can race with concurrent cache writes
+	// performed by doInvokestatic/doInvokevirtual (under CP.Mutex.Lock()) when
+	// multiple Java threads share this class's constant pool, so they must be
+	// lock-protected to avoid observing a torn/incorrect CpEntry.
+	CP.Mutex.RLock()
 	methodRef := CP.CpIndex[cpIndex].Slot
 	classIndex := CP.InterfaceRefs[methodRef].ClassIndex
-
 	classRefIdx := CP.CpIndex[classIndex].Slot
+	nameAndTypeCPindex := CP.InterfaceRefs[methodRef].NameAndType
+	nameAndTypeIndex := CP.CpIndex[nameAndTypeCPindex].Slot
+	CP.Mutex.RUnlock()
+
 	classIdx := CP.ClassRefs[classRefIdx]
 	classNamePtr := stringPool.GetStringPointer(uint32(classIdx))
 	className := *classNamePtr
 
 	// now get the method signature
-	nameAndTypeCPindex := CP.InterfaceRefs[methodRef].NameAndType
-	nameAndTypeIndex := CP.CpIndex[nameAndTypeCPindex].Slot
 	nameAndType := CP.NameAndTypes[nameAndTypeIndex]
 	methNameCPindex := nameAndType.NameIndex
+	CP.Mutex.RLock()
 	methNameUTF8index := CP.CpIndex[methNameCPindex].Slot
+	CP.Mutex.RUnlock()
 	methName := CP.Utf8Refs[methNameUTF8index]
 
 	// and get the method signature/description
 	methSigCPindex := nameAndType.DescIndex
+	CP.Mutex.RLock()
 	methSigUTF8index := CP.CpIndex[methSigCPindex].Slot
+	CP.Mutex.RUnlock()
 	methSig := CP.Utf8Refs[methSigUTF8index]
 
 	return className, methName, methSig
@@ -234,14 +249,20 @@ func GetClassNameFromCPclassref(CP *CPool, cpIndex uint16) string {
 // in the constant pool, and it returns the name and type of the target method. Note
 // there is no error checking here.
 func GetNATfieldsFromCPindex(CP *CPool, cpIndex int) (name, signature string) {
+	// Lock-protect all reads of CP.CpIndex: this slice is concurrently written
+	// (under CP.Mutex.Lock()) by doInvokestatic/doInvokevirtual when caching
+	// resolved methods, and multiple Java threads can call this function for
+	// the same constant-pool entries at the same time.
+	CP.Mutex.RLock()
 	nameAndTypeIndex := CP.CpIndex[cpIndex].Slot
 	nameAndType := CP.NameAndTypes[nameAndTypeIndex]
 	methNameCPindex := nameAndType.NameIndex
 	methNameUTF8index := CP.CpIndex[methNameCPindex].Slot
-	name = CP.Utf8Refs[methNameUTF8index]
-
 	methSigCPindex := nameAndType.DescIndex
 	methSigUTF8index := CP.CpIndex[methSigCPindex].Slot
+	CP.Mutex.RUnlock()
+
+	name = CP.Utf8Refs[methNameUTF8index]
 	signature = CP.Utf8Refs[methSigUTF8index]
 
 	return name, signature

--- a/src/jvm/interpreter.go
+++ b/src/jvm/interpreter.go
@@ -2183,7 +2183,9 @@ func doReturn(fr *frames.Frame, _ int64) int {
 func doGetStatic(fr *frames.Frame, _ int64) int {
 	CPslot := (int(fr.Meth[fr.PC+1]) * 256) + int(fr.Meth[fr.PC+2]) // next 2 bytes point to CP entry
 	CP := fr.CP.(*classloader.CPool)
+	CP.Mutex.RLock()
 	CPentry := CP.CpIndex[CPslot] // value is checked in codeCheck.go
+	CP.Mutex.RUnlock()
 
 	// get the field entry
 	field := CP.FieldRefs[CPentry.Slot]
@@ -2251,7 +2253,9 @@ func doGetStatic(fr *frames.Frame, _ int64) int {
 func doPutStatic(fr *frames.Frame, _ int64) int {
 	CPslot := (int(fr.Meth[fr.PC+1]) * 256) + int(fr.Meth[fr.PC+2])
 	CP := fr.CP.(*classloader.CPool)
+	CP.Mutex.RLock()
 	CPentry := CP.CpIndex[CPslot] // value is checked in codeCheck.go
+	CP.Mutex.RUnlock()
 
 	// get the field entry
 	field := CP.FieldRefs[CPentry.Slot]
@@ -2968,7 +2972,13 @@ func doInvokespecial(fr *frames.Frame, _ int64) int {
 	CPslot := (int(fr.Meth[fr.PC+1]) * 256) + int(fr.Meth[fr.PC+2]) // next 2 bytes point to CP entry
 	CP := fr.CP.(*classloader.CPool)
 
+	// This CP entry can be concurrently written (as a CachedMeth) by
+	// doInvokevirtual/doInvokestatic running in other threads that share
+	// this same class's constant pool, so the read must be lock-protected
+	// to avoid a data race that can yield a torn/incorrect CpEntry.
+	CP.Mutex.RLock()
 	entry := CP.CpIndex[CPslot]
+	CP.Mutex.RUnlock()
 	if entry.Type == classloader.Interface {
 		className, methodName, methodType =
 			classloader.GetMethInfoFromCPinterfaceRef(CP, CPslot)
@@ -3236,7 +3246,9 @@ func doInvokeinterface(fr *frames.Frame, _ int64) int {
 	zeroByte := fr.Meth[fr.PC+4]
 
 	CP := fr.CP.(*classloader.CPool)
+	CP.Mutex.RLock()
 	CPentry := CP.CpIndex[CPslot]
+	CP.Mutex.RUnlock()
 	if CPentry.Type != classloader.Interface || zeroByte != 0 { // remove the zeroByte test later
 		globals.GetGlobalRef().ErrorGoStack = string(debug.Stack())
 		errMsg := fmt.Sprintf("INVOKEINTERFACE: CP entry type (%d) did not point to an interface method type (%d)",
@@ -3252,13 +3264,17 @@ func doInvokeinterface(fr *frames.Frame, _ int64) int {
 
 	// get the class entry from this method
 	interfaceRef := method.ClassIndex
+	CP.Mutex.RLock()
 	interfaceNameIndex := CP.ClassRefs[CP.CpIndex[interfaceRef].Slot]
+	CP.Mutex.RUnlock()
 	interfaceNamePtr := stringPool.GetStringPointer(interfaceNameIndex)
 	interfaceName := *interfaceNamePtr
 
 	// get the method name for this method
 	nAndTindex := method.NameAndType
+	CP.Mutex.RLock()
 	nAndTentry := CP.CpIndex[nAndTindex]
+	CP.Mutex.RUnlock()
 	nAndTslot := nAndTentry.Slot
 	nAndT := CP.NameAndTypes[nAndTslot]
 	interfaceMethodNameIndex := nAndT.NameIndex


### PR DESCRIPTION
See JACOBIN-952.
modified:   jvm/interpreter.go
modified: classloader/cpUtils.go
