### PR TITLE
JACOBIN-953 fixed code for handling only the root handler (no user handlers)

### DIFF
--- a/src/gfunction/javaUtil/javaUtilLoggingCallback.go
+++ b/src/gfunction/javaUtil/javaUtilLoggingCallback.go
@@ -1,0 +1,90 @@
+/*
+ * Jacobin VM - A Java virtual machine
+ * Copyright (c) 2026 by the Jacobin authors. Consult jacobin.org.
+ * Licensed under Mozilla Public License 2.0 (MPL 2.0) All rights reserved.
+ */
+
+package javaUtil
+
+import (
+	"container/list"
+	"jacobin/src/classloader"
+	"jacobin/src/frames"
+	"jacobin/src/globals"
+	"jacobin/src/object"
+	"jacobin/src/stringPool"
+	"jacobin/src/types"
+)
+
+// This file provides support for dispatching to user-supplied (bytecode)
+// subclasses of java.util.logging.Formatter and java.util.logging.Filter,
+// so that e.g. a custom Formatter.format(LogRecord) or Filter.isLoggable(LogRecord)
+// actually gets executed, rather than always falling back to jacobin's
+// built-in default behavior. This mirrors the real JDK, where Handler.publish()
+// always calls through getFormatter().format(record) and, if a filter is set,
+// filter.isLoggable(record) -- both of which are ordinary (possibly overridden)
+// Java method calls.
+
+// loggingExtractFsAndArgs inspects the leading element of params: if it is a
+// frame stack (*list.List), it is treated as call context prepended by the
+// caller (see loggingLoggerPublishToHandler) and is stripped off; otherwise
+// there is no available frame stack (e.g. when called directly as a GFunction
+// from bytecode) and nil is returned for it.
+func loggingExtractFsAndArgs(params []interface{}) (*list.List, []interface{}) {
+	if len(params) > 0 {
+		if fs, ok := params[0].(*list.List); ok {
+			return fs, params[1:]
+		}
+	}
+	return nil, params
+}
+
+// loggingInvokeUserJavaMethod attempts to dynamically dispatch methodName/methodType
+// on obj's concrete class (and its ancestors), but only if the found implementation
+// is real Java bytecode (MType == 'J'); i.e., user-supplied code, as opposed to a
+// jacobin-native (GFunction) implementation, which callers already know how to
+// handle themselves. Returns (result, true) on success, or (nil, false) if no
+// frame stack is available, obj is null, or no Java bytecode implementation is found.
+func loggingInvokeUserJavaMethod(fs *list.List, obj *object.Object, methodName, methodType string, args ...interface{}) (interface{}, bool) {
+	if fs == nil || obj == nil || object.IsNull(obj) {
+		return nil, false
+	}
+
+	currClass := object.GoStringFromStringPoolIndex(obj.KlassName)
+	for currClass != "" {
+		specificFQN := currClass + "." + methodName + methodType
+
+		mtEntry := classloader.GetMtableEntry(specificFQN)
+		if mtEntry.Meth == nil {
+			mtEntry, _ = classloader.FetchMethodAndCP(currClass, methodName, methodType)
+		}
+
+		if mtEntry.Meth != nil {
+			if mtEntry.MType != 'J' {
+				// A jacobin-native (GFunction) implementation was found -- this is
+				// not user-supplied code, so let the caller apply its own fallback.
+				return nil, false
+			}
+
+			callArgs := make([]interface{}, 0, len(args)+1)
+			callArgs = append(callArgs, obj)
+			callArgs = append(callArgs, args...)
+			globals.GetGlobalRef().FuncRunJavaFromG(fs, currClass, methodName, methodType, callArgs...)
+
+			fr, ok := fs.Front().Value.(*frames.Frame)
+			if !ok || fr.TOS < 0 {
+				return nil, true
+			}
+			res := fr.OpStack[fr.TOS]
+			fr.TOS--
+			return res, true
+		}
+
+		klass := classloader.MethAreaFetch(currClass)
+		if klass == nil || klass.Data.SuperclassIndex == types.InvalidStringIndex {
+			break
+		}
+		currClass = *stringPool.GetStringPointer(uint32(klass.Data.SuperclassIndex))
+	}
+	return nil, false
+}

--- a/src/gfunction/javaUtil/javaUtilLoggingConsoleHandler.go
+++ b/src/gfunction/javaUtil/javaUtilLoggingConsoleHandler.go
@@ -85,13 +85,14 @@ func loggingConsoleHandlerClose([]interface{}) interface{} {
 // "java/util/logging/ConsoleHandler.publish(Ljava/util/logging/LogRecord;)V"
 // Writes the LogRecord's message to System.err if it is loggable by this Handler.
 func loggingConsoleHandlerPublish(params []interface{}) interface{} {
-	obj, ok := params[0].(*object.Object)
+	fs, args := loggingExtractFsAndArgs(params)
+	obj, ok := args[0].(*object.Object)
 	if !ok || obj == nil {
 		errMsg := "loggingConsoleHandlerPublish: The first parameter is not an object"
 		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
-	if len(params) < 2 {
+	if len(args) < 2 {
 		errMsg := "loggingConsoleHandlerPublish: Requires a LogRecord parameter"
 		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
@@ -101,12 +102,12 @@ func loggingConsoleHandlerPublish(params []interface{}) interface{} {
 		return nil
 	}
 
-	record, ok := params[1].(*object.Object)
+	record, ok := args[1].(*object.Object)
 	if !ok || record == nil || object.IsNull(record) {
 		return nil
 	}
 
-	msg := formatLogRecordWithHandlerFormatter(obj, record)
+	msg := formatLogRecordWithHandlerFormatter(obj, record, fs)
 	if msg == "" {
 		return nil
 	}

--- a/src/gfunction/javaUtil/javaUtilLoggingFileHandler.go
+++ b/src/gfunction/javaUtil/javaUtilLoggingFileHandler.go
@@ -275,13 +275,14 @@ func loggingFileHandlerClose(params []interface{}) interface{} {
 // "java/util/logging/FileHandler.publish(Ljava/util/logging/LogRecord;)V"
 // Writes the LogRecord's message to the underlying file if it is loggable by this Handler.
 func loggingFileHandlerPublish(params []interface{}) interface{} {
-	obj, ok := params[0].(*object.Object)
+	fs, args := loggingExtractFsAndArgs(params)
+	obj, ok := args[0].(*object.Object)
 	if !ok || obj == nil {
 		errMsg := "loggingFileHandlerPublish: The first parameter is not an object"
 		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
-	if len(params) < 2 {
+	if len(args) < 2 {
 		errMsg := "loggingFileHandlerPublish: Requires a LogRecord parameter"
 		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
@@ -291,12 +292,12 @@ func loggingFileHandlerPublish(params []interface{}) interface{} {
 		return nil
 	}
 
-	record, ok := params[1].(*object.Object)
+	record, ok := args[1].(*object.Object)
 	if !ok || record == nil || object.IsNull(record) {
 		return nil
 	}
 
-	msg := formatLogRecordWithHandlerFormatter(obj, record)
+	msg := formatLogRecordWithHandlerFormatter(obj, record, fs)
 	if msg == "" {
 		return nil
 	}

--- a/src/gfunction/javaUtil/javaUtilLoggingFormatter.go
+++ b/src/gfunction/javaUtil/javaUtilLoggingFormatter.go
@@ -7,6 +7,8 @@
 package javaUtil
 
 import (
+	"container/list"
+
 	"jacobin/src/excNames"
 	"jacobin/src/gfunction/ghelpers"
 	"jacobin/src/object"
@@ -160,7 +162,7 @@ func loggingFormatterGetTail(params []interface{}) interface{} {
 // formatter is set (should not normally happen, since every Handler is
 // initialized with a default SimpleFormatter), it falls back to the raw
 // message text so nothing is silently dropped.
-func formatLogRecordWithHandlerFormatter(handlerObj *object.Object, record *object.Object) string {
+func formatLogRecordWithHandlerFormatter(handlerObj *object.Object, record *object.Object, fs *list.List) string {
 	handlerObj.ThMutex.RLock()
 	formatter, hasFormatter := handlerObj.FieldTable[fieldNameHandlerFormatter].Fvalue.(*object.Object)
 	handlerObj.ThMutex.RUnlock()
@@ -171,8 +173,18 @@ func formatLogRecordWithHandlerFormatter(handlerObj *object.Object, record *obje
 		switch className {
 		case simpleFormatterClassName:
 			ret = loggingSimpleFormatterFormat([]interface{}{record})
-		default:
+		case formatterClassName:
 			ret = loggingFormatterFormat([]interface{}{record})
+		default:
+			// Possibly a user-supplied Formatter subclass with its own
+			// format(LogRecord) override; dispatch to the actual bytecode
+			// implementation, mirroring real Handler.publish() behavior.
+			if custom, ok := loggingInvokeUserJavaMethod(fs, formatter, "format",
+				"(Ljava/util/logging/LogRecord;)Ljava/lang/String;", record); ok {
+				ret = custom
+			} else {
+				ret = loggingFormatterFormat([]interface{}{record})
+			}
 		}
 		if strObj, ok := ret.(*object.Object); ok && strObj != nil {
 			return object.GoStringFromStringObject(strObj)

--- a/src/gfunction/javaUtil/javaUtilLoggingHandler.go
+++ b/src/gfunction/javaUtil/javaUtilLoggingHandler.go
@@ -340,6 +340,7 @@ func loggingHandlerSetLevel(params []interface{}) interface{} {
 // A LogRecord is loggable if this Handler's filter (if any) accepts it, and
 // the LogRecord's level is >= this Handler's level.
 func loggingHandlerIsLoggable(params []interface{}) interface{} {
+	fs, params := loggingExtractFsAndArgs(params)
 	obj, ok := params[0].(*object.Object)
 	if !ok || obj == nil {
 		errMsg := "loggingHandlerIsLoggable: The first parameter is not an object"
@@ -352,9 +353,20 @@ func loggingHandlerIsLoggable(params []interface{}) interface{} {
 	obj.ThMutex.RUnlock()
 
 	if hasFilter && filter != nil && !object.IsNull(filter) {
-		result := loggingFilterIsLoggable(params[1:])
-		if result != types.JavaBoolTrue {
-			return types.JavaBoolFalse
+		record, _ := params[1].(*object.Object)
+		// The filter may be a user-supplied class with its own isLoggable()
+		// override; dispatch to the actual bytecode implementation, mirroring
+		// what a real Handler.publish() does (filter.isLoggable(record)).
+		if custom, ok := loggingInvokeUserJavaMethod(fs, filter, "isLoggable",
+			"(Ljava/util/logging/LogRecord;)Z", record); ok {
+			if b, ok := custom.(int64); ok && b != types.JavaBoolTrue {
+				return types.JavaBoolFalse
+			}
+		} else {
+			result := loggingFilterIsLoggable(params[1:])
+			if result != types.JavaBoolTrue {
+				return types.JavaBoolFalse
+			}
 		}
 	}
 
@@ -378,13 +390,14 @@ func loggingHandlerIsLoggable(params []interface{}) interface{} {
 // "java/util/logging/Handler.publish(Ljava/util/logging/LogRecord;)V"
 // Writes the LogRecord's message to System.err if it is loggable by this Handler.
 func loggingHandlerPublish(params []interface{}) interface{} {
-	obj, ok := params[0].(*object.Object)
+	fs, args := loggingExtractFsAndArgs(params)
+	obj, ok := args[0].(*object.Object)
 	if !ok || obj == nil {
 		errMsg := "loggingHandlerPublish: The first parameter is not an object"
 		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
-	if len(params) < 2 {
+	if len(args) < 2 {
 		errMsg := "loggingHandlerPublish: Requires a LogRecord parameter"
 		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
@@ -394,12 +407,12 @@ func loggingHandlerPublish(params []interface{}) interface{} {
 		return nil
 	}
 
-	record, ok := params[1].(*object.Object)
+	record, ok := args[1].(*object.Object)
 	if !ok || record == nil || object.IsNull(record) {
 		return nil
 	}
 
-	msg := formatLogRecordWithHandlerFormatter(obj, record)
+	msg := formatLogRecordWithHandlerFormatter(obj, record, fs)
 	if msg == "" {
 		return nil
 	}

--- a/src/gfunction/javaUtil/javaUtilLoggingLogRecord.go
+++ b/src/gfunction/javaUtil/javaUtilLoggingLogRecord.go
@@ -11,6 +11,7 @@ import (
 	"jacobin/src/gfunction/ghelpers"
 	"jacobin/src/object"
 	"jacobin/src/types"
+	"sync/atomic"
 	"time"
 )
 
@@ -46,6 +47,16 @@ var fieldNameLogRecordThrown = "thrown"
 var fieldNameLogRecordResourceBundleName = "resourceBundleName"
 var fieldNameLogRecordResourceBundle = "resourceBundle"
 
+// logRecordSequenceCounter mirrors the real JDK's global, monotonically
+// increasing LogRecord sequence number, assigned when a LogRecord is created.
+var logRecordSequenceCounter atomic.Int64
+
+// loggingLogRecordNextSequenceNumber returns the next global sequence number
+// to assign to a newly created LogRecord.
+func loggingLogRecordNextSequenceNumber() int64 {
+	return logRecordSequenceCounter.Add(1) - 1
+}
+
 func Load_Util_Logging_LogRecord() {
 
 	ghelpers.MethodSignatures["java/util/logging/LogRecord.<init>(Ljava/util/logging/Level;Ljava/lang/String;)V"] =
@@ -75,7 +86,7 @@ func Load_Util_Logging_LogRecord() {
 	ghelpers.MethodSignatures["java/util/logging/LogRecord.getMillis()J"] =
 		ghelpers.GMeth{
 			ParamSlots: 0,
-			GFunction:  ghelpers.TrapDeprecated,
+			GFunction:  loggingLogRecordGetMillis,
 		}
 
 	ghelpers.MethodSignatures["java/util/logging/LogRecord.getParameters()[Ljava/lang/Object;"] =
@@ -147,7 +158,7 @@ func Load_Util_Logging_LogRecord() {
 	ghelpers.MethodSignatures["java/util/logging/LogRecord.setMillis(J)V"] =
 		ghelpers.GMeth{
 			ParamSlots: 1,
-			GFunction:  ghelpers.TrapDeprecated,
+			GFunction:  loggingLogRecordSetMillis,
 		}
 
 	ghelpers.MethodSignatures["java/util/logging/LogRecord.setParameters([Ljava/lang/Object;)V"] =
@@ -219,7 +230,7 @@ func loggingLogRecordInit(params []interface{}) interface{} {
 	obj.FieldTable[fieldNameHandlerLevel] = object.Field{Ftype: types.Ref, Fvalue: level}
 	obj.FieldTable[fieldNameLogRecordMessage] = object.Field{Ftype: types.Ref, Fvalue: message}
 	obj.FieldTable[fieldNameLogRecordLoggerName] = object.Field{Ftype: types.Ref, Fvalue: object.Null}
-	obj.FieldTable[fieldNameLogRecordSequenceNumber] = object.Field{Ftype: types.Long, Fvalue: int64(0)}
+	obj.FieldTable[fieldNameLogRecordSequenceNumber] = object.Field{Ftype: types.Long, Fvalue: loggingLogRecordNextSequenceNumber()}
 	obj.FieldTable[fieldNameLogRecordSourceClassName] = object.Field{Ftype: types.Ref, Fvalue: object.Null}
 	obj.FieldTable[fieldNameLogRecordSourceMethodName] = object.Field{Ftype: types.Ref, Fvalue: object.Null}
 	obj.FieldTable[fieldNameLogRecordParameters] = object.Field{Ftype: types.Ref, Fvalue: object.Null}
@@ -315,6 +326,35 @@ func loggingLogRecordSetLoggerName(params []interface{}) interface{} {
 	obj.ThMutex.Lock()
 	defer obj.ThMutex.Unlock()
 	obj.FieldTable[fieldNameLogRecordLoggerName] = object.Field{Ftype: types.Ref, Fvalue: params[1]}
+	return nil
+}
+
+// "java/util/logging/LogRecord.getMillis()J"
+// Deprecated as of Java 9 (in favor of getInstant()) but still functional.
+func loggingLogRecordGetMillis(params []interface{}) interface{} {
+	obj, ok := params[0].(*object.Object)
+	if !ok || obj == nil {
+		errMsg := "loggingLogRecordGetMillis: The first parameter is not an object"
+		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	obj.ThMutex.RLock()
+	defer obj.ThMutex.RUnlock()
+	millis, _ := obj.FieldTable[fieldNameLogRecordMillis].Fvalue.(int64)
+	return millis
+}
+
+// "java/util/logging/LogRecord.setMillis(J)V"
+// Deprecated as of Java 9 (in favor of setInstant()) but still functional.
+func loggingLogRecordSetMillis(params []interface{}) interface{} {
+	obj, ok := params[0].(*object.Object)
+	if !ok || obj == nil {
+		errMsg := "loggingLogRecordSetMillis: The first parameter is not an object"
+		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, errMsg)
+	}
+	millis, _ := params[1].(int64)
+	obj.ThMutex.Lock()
+	defer obj.ThMutex.Unlock()
+	obj.FieldTable[fieldNameLogRecordMillis] = object.Field{Ftype: types.Long, Fvalue: millis}
 	return nil
 }
 

--- a/src/gfunction/javaUtil/javaUtilLoggingLogRecord_test.go
+++ b/src/gfunction/javaUtil/javaUtilLoggingLogRecord_test.go
@@ -226,14 +226,17 @@ func TestLoggingLogRecordMethodSignaturesRegistered(t *testing.T) {
 		}
 	}
 
-	deprecated := []string{
-		"java/util/logging/LogRecord.getMillis()J",
-		"java/util/logging/LogRecord.setMillis(J)V",
+	// getMillis/setMillis are deprecated as of Java 9 (in favor of
+	// getInstant()/setInstant()), but real JDK still runs them (they are not
+	// unsupported), so they must remain functional rather than trapped.
+	functional := map[string]interface{}{
+		"java/util/logging/LogRecord.getMillis()J":  loggingLogRecordGetMillis,
+		"java/util/logging/LogRecord.setMillis(J)V": loggingLogRecordSetMillis,
 	}
-	for _, key := range deprecated {
+	for key, want := range functional {
 		gm := ghelpers.MethodSignatures[key]
-		if reflect.ValueOf(gm.GFunction).Pointer() != reflect.ValueOf(ghelpers.TrapDeprecated).Pointer() {
-			t.Errorf("%s: expected GFunction to be ghelpers.TrapDeprecated", key)
+		if reflect.ValueOf(gm.GFunction).Pointer() != reflect.ValueOf(want).Pointer() {
+			t.Errorf("%s: expected GFunction to be functional (not trapped)", key)
 		}
 	}
 }

--- a/src/gfunction/javaUtil/javaUtilLoggingLogger.go
+++ b/src/gfunction/javaUtil/javaUtilLoggingLogger.go
@@ -50,6 +50,8 @@ var loggerRegistry = map[string]*object.Object{}
 var loggerRegistryMutex sync.Mutex
 var globalLoggerObj *object.Object
 var globalLoggerMutex sync.Mutex
+var rootLoggerObj *object.Object
+var rootLoggerMutex sync.Mutex
 
 func Load_Util_Logging_Logger() {
 
@@ -243,7 +245,7 @@ func loggingLoggerGetOrCreate(name, resourceBundleName string) *object.Object {
 	}
 
 	logger := makeLoggerObject(name, resourceBundleName)
-	logger.FieldTable[fieldNameLoggerParent] = object.Field{Ftype: types.Ref, Fvalue: loggingLoggerGlobal()}
+	logger.FieldTable[fieldNameLoggerParent] = object.Field{Ftype: types.Ref, Fvalue: loggingLoggerRoot()}
 	loggerRegistry[name] = logger
 	return logger
 }
@@ -255,8 +257,30 @@ func loggingLoggerGlobal() *object.Object {
 	if globalLoggerObj == nil {
 		globalLoggerObj = makeLoggerObject("global", "")
 		globalLoggerObj.FieldTable[fieldNameHandlerLevel] = object.Field{Ftype: types.Ref, Fvalue: makeLevelObject("INFO", standardLevels["INFO"], "")}
+		globalLoggerObj.FieldTable[fieldNameLoggerParent] = object.Field{Ftype: types.Ref, Fvalue: loggingLoggerRoot()}
 	}
 	return globalLoggerObj
+}
+
+// loggingLoggerRoot lazily creates and returns the shared root Logger instance
+// (name ""), matching real JDK semantics where LogManager installs a default
+// ConsoleHandler (with a default SimpleFormatter and no filter) on the root
+// logger. Because every named Logger's parent chain ultimately reaches this
+// root logger, and useParentHandlers defaults to true, adding a ConsoleHandler
+// directly to a named logger causes HotSpot-style doubled console output --
+// once via the named logger's own handler, and once via the root logger's
+// default ConsoleHandler -- unless the caller calls setUseParentHandlers(false).
+func loggingLoggerRoot() *object.Object {
+	rootLoggerMutex.Lock()
+	defer rootLoggerMutex.Unlock()
+	if rootLoggerObj == nil {
+		rootLoggerObj = makeLoggerObject("", "")
+		rootLoggerObj.FieldTable[fieldNameHandlerLevel] = object.Field{Ftype: types.Ref, Fvalue: makeLevelObject("INFO", standardLevels["INFO"], "")}
+		defaultConsoleHandler := object.MakeEmptyObjectWithClassName(&consoleHandlerClassName)
+		_ = loggingConsoleHandlerInit([]interface{}{defaultConsoleHandler})
+		rootLoggerObj.FieldTable[fieldNameLoggerHandlers] = object.Field{Ftype: types.Ref, Fvalue: []*object.Object{defaultConsoleHandler}}
+	}
+	return rootLoggerObj
 }
 
 // "java/util/logging/Logger.getGlobal()Ljava/util/logging/Logger;"
@@ -267,14 +291,14 @@ func loggingLoggerGetGlobal([]interface{}) interface{} {
 // "java/util/logging/Logger.getAnonymousLogger()Ljava/util/logging/Logger;"
 func loggingLoggerGetAnonymousLogger([]interface{}) interface{} {
 	logger := makeLoggerObject("", "")
-	logger.FieldTable[fieldNameLoggerParent] = object.Field{Ftype: types.Ref, Fvalue: loggingLoggerGlobal()}
+	logger.FieldTable[fieldNameLoggerParent] = object.Field{Ftype: types.Ref, Fvalue: loggingLoggerRoot()}
 	return logger
 }
 
 // "java/util/logging/Logger.getAnonymousLogger(Ljava/lang/String;)Ljava/util/logging/Logger;"
 func loggingLoggerGetAnonymousLoggerWithBundle(params []interface{}) interface{} {
 	logger := makeLoggerObject("", loggingLoggerStringArg(params[0]))
-	logger.FieldTable[fieldNameLoggerParent] = object.Field{Ftype: types.Ref, Fvalue: loggingLoggerGlobal()}
+	logger.FieldTable[fieldNameLoggerParent] = object.Field{Ftype: types.Ref, Fvalue: loggingLoggerRoot()}
 	return logger
 }
 
@@ -558,15 +582,26 @@ func loggingLoggerStringArg(param interface{}) string {
 
 // loggingLoggerWrite formats a level-tagged message and writes it to System.err.
 // This is the fallback used when a Logger has no registered handlers (nor any
-// ancestor with handlers), matching the console-only behavior previously used
-// unconditionally by this file.
+// ancestor with handlers). It mirrors the real JDK's root Logger, which has a
+// default ConsoleHandler with a SimpleFormatter attached, producing the
+// familiar two-line output (date/class/method, then LEVEL: message).
 func loggingLoggerWrite(levelPrefix, msg string) interface{} {
+	return loggingLoggerWriteRecord(loggingLoggerMakeRecord(levelPrefix, msg, nil, nil))
+}
+
+// loggingLoggerWriteRecord formats the given LogRecord using the default
+// SimpleFormatter and writes the result to System.err.
+func loggingLoggerWriteRecord(record *object.Object) interface{} {
 	stderr, ok := statics.GetStaticValue("java/lang/System", "err").(*os.File)
 	if !ok || stderr == nil {
 		errMsg := "loggingLoggerWrite: could not obtain System.err"
 		return ghelpers.GetGErrBlk(excNames.IOException, errMsg)
 	}
-	_, _ = fmt.Fprintf(stderr, "%s: %s\n", levelPrefix, msg)
+	formatted := ""
+	if msgObj, ok := loggingSimpleFormatterFormat([]interface{}{record}).(*object.Object); ok && msgObj != nil {
+		formatted = object.GoStringFromStringObject(msgObj)
+	}
+	_, _ = fmt.Fprint(stderr, formatted)
 	return nil
 }
 
@@ -605,7 +640,7 @@ func loggingLoggerMakeRecord(levelName, msg string, loggerObj *object.Object, ca
 		}
 	}
 	record.FieldTable[fieldNameLogRecordLoggerName] = object.Field{Ftype: types.Ref, Fvalue: loggerName}
-	record.FieldTable[fieldNameLogRecordSequenceNumber] = object.Field{Ftype: types.Long, Fvalue: int64(0)}
+	record.FieldTable[fieldNameLogRecordSequenceNumber] = object.Field{Ftype: types.Long, Fvalue: loggingLogRecordNextSequenceNumber()}
 
 	sourceClassName := interface{}(object.Null)
 	sourceMethodName := interface{}(object.Null)
@@ -626,11 +661,11 @@ func loggingLoggerMakeRecord(levelName, msg string, loggerObj *object.Object, ca
 // loggingLoggerPublishToHandler dispatches a LogRecord to a single Handler,
 // invoking the correct native publish implementation for the Handler's
 // concrete class (FileHandler/ConsoleHandler/StreamHandler/plain Handler).
-func loggingLoggerPublishToHandler(handler *object.Object, record *object.Object) {
+func loggingLoggerPublishToHandler(handler *object.Object, record *object.Object, frameStack *list.List) {
 	if handler == nil || object.IsNull(handler) {
 		return
 	}
-	params := []interface{}{handler, record}
+	params := []interface{}{frameStack, handler, record}
 	switch object.GoStringFromStringPoolIndex(handler.KlassName) {
 	case fileHandlerClassName:
 		_ = loggingFileHandlerPublish(params)
@@ -646,7 +681,7 @@ func loggingLoggerPublishToHandler(handler *object.Object, record *object.Object
 // loggingLoggerDispatchToHandlers walks the given Logger's handlers, then
 // (while useParentHandlers is true) its ancestors' handlers, publishing the
 // record to each. It returns true if at least one handler received the record.
-func loggingLoggerDispatchToHandlers(loggerObj *object.Object, record *object.Object) bool {
+func loggingLoggerDispatchToHandlers(loggerObj *object.Object, record *object.Object, frameStack *list.List) bool {
 	dispatched := false
 	current := loggerObj
 	for current != nil && !object.IsNull(current) {
@@ -657,7 +692,7 @@ func loggingLoggerDispatchToHandlers(loggerObj *object.Object, record *object.Ob
 		current.ThMutex.RUnlock()
 
 		for _, handler := range handlers {
-			loggingLoggerPublishToHandler(handler, record)
+			loggingLoggerPublishToHandler(handler, record, frameStack)
 			dispatched = true
 		}
 
@@ -695,8 +730,8 @@ func loggingLoggerEmit(receiver interface{}, levelName, msg string, frameStack *
 
 	callerFrame := loggingLoggerCallerFrame(frameStack)
 	record := loggingLoggerMakeRecord(levelName, msg, loggerObj, callerFrame)
-	if !loggingLoggerDispatchToHandlers(loggerObj, record) {
-		return loggingLoggerWrite(levelName, msg)
+	if !loggingLoggerDispatchToHandlers(loggerObj, record, frameStack) {
+		return loggingLoggerWriteRecord(record)
 	}
 	return nil
 }

--- a/src/gfunction/javaUtil/javaUtilLoggingLogger_test.go
+++ b/src/gfunction/javaUtil/javaUtilLoggingLogger_test.go
@@ -43,7 +43,7 @@ func TestLoggingLoggerConfig(t *testing.T) {
 			t.Fatalf("loggingLoggerConfig returned error: %v", ret)
 		}
 	})
-	if out != "CONFIG: hello config\n" {
+	if !strings.HasSuffix(out, "CONFIG: hello config\n") {
 		t.Fatalf("unexpected output: %q", out)
 	}
 }
@@ -57,7 +57,7 @@ func TestLoggingLoggerEntering(t *testing.T) {
 			t.Fatalf("loggingLoggerEntering returned error: %v", ret)
 		}
 	})
-	if out != "FINER: ENTRY com.foo.Bar doIt\n" {
+	if !strings.HasSuffix(out, "FINER: ENTRY com.foo.Bar doIt\n") {
 		t.Fatalf("unexpected output: %q", out)
 	}
 }
@@ -72,7 +72,7 @@ func TestLoggingLoggerEnteringWithParam(t *testing.T) {
 			t.Fatalf("loggingLoggerEnteringWithParam returned error: %v", ret)
 		}
 	})
-	if !strings.HasPrefix(out, "FINER: ENTRY com.foo.Bar doIt") {
+	if !strings.Contains(out, "FINER: ENTRY com.foo.Bar doIt") {
 		t.Fatalf("unexpected output: %q", out)
 	}
 }
@@ -86,7 +86,7 @@ func TestLoggingLoggerExiting(t *testing.T) {
 			t.Fatalf("loggingLoggerExiting returned error: %v", ret)
 		}
 	})
-	if out != "FINER: RETURN com.foo.Bar doIt\n" {
+	if !strings.HasSuffix(out, "FINER: RETURN com.foo.Bar doIt\n") {
 		t.Fatalf("unexpected output: %q", out)
 	}
 }
@@ -101,7 +101,7 @@ func TestLoggingLoggerExitingWithParam(t *testing.T) {
 			t.Fatalf("loggingLoggerExitingWithParam returned error: %v", ret)
 		}
 	})
-	if out != "FINER: RETURN com.foo.Bar doIt result1\n" {
+	if !strings.HasSuffix(out, "FINER: RETURN com.foo.Bar doIt result1\n") {
 		t.Fatalf("unexpected output: %q", out)
 	}
 }
@@ -125,7 +125,7 @@ func TestLoggingLoggerFinestFinerInfoSevereWarning(t *testing.T) {
 				t.Fatalf("%s returned error: %v", c.prefix, ret)
 			}
 		})
-		if out != c.expected {
+		if !strings.HasSuffix(out, c.expected) {
 			t.Fatalf("%s: unexpected output: %q", c.prefix, out)
 		}
 	}
@@ -144,7 +144,7 @@ func TestLoggingLoggerWarningWithParams(t *testing.T) {
 			t.Fatalf("loggingLoggerWarningWithParams returned error: %v", ret)
 		}
 	})
-	if out != "WARNING: msg2 [a, b]\n" {
+	if !strings.HasSuffix(out, "WARNING: msg2 [a, b]\n") {
 		t.Fatalf("unexpected output: %q", out)
 	}
 }
@@ -159,7 +159,7 @@ func TestLoggingLoggerLog(t *testing.T) {
 			t.Fatalf("loggingLoggerLog returned error: %v", ret)
 		}
 	})
-	if out != "SEVERE: bad thing\n" {
+	if !strings.HasSuffix(out, "SEVERE: bad thing\n") {
 		t.Fatalf("unexpected output: %q", out)
 	}
 }
@@ -178,7 +178,7 @@ func TestLoggingLoggerLogWithParams(t *testing.T) {
 			t.Fatalf("loggingLoggerLogWithParams returned error: %v", ret)
 		}
 	})
-	if out != "INFO: msg [x]\n" {
+	if !strings.HasSuffix(out, "INFO: msg [x]\n") {
 		t.Fatalf("unexpected output: %q", out)
 	}
 }
@@ -196,7 +196,7 @@ func TestLoggingLoggerLogp(t *testing.T) {
 			t.Fatalf("loggingLoggerLogp returned error: %v", ret)
 		}
 	})
-	if out != "WARNING: com.foo.Bar doIt: careful\n" {
+	if !strings.HasSuffix(out, "WARNING: com.foo.Bar doIt: careful\n") {
 		t.Fatalf("unexpected output: %q", out)
 	}
 }
@@ -218,7 +218,7 @@ func TestLoggingLoggerLogpWithParams(t *testing.T) {
 			t.Fatalf("loggingLoggerLogpWithParams returned error: %v", ret)
 		}
 	})
-	if out != "CONFIG: com.foo.Bar doIt: msg [y]\n" {
+	if !strings.HasSuffix(out, "CONFIG: com.foo.Bar doIt: msg [y]\n") {
 		t.Fatalf("unexpected output: %q", out)
 	}
 }
@@ -237,7 +237,7 @@ func TestLoggingLoggerLogrb(t *testing.T) {
 			t.Fatalf("loggingLoggerLogrb returned error: %v", ret)
 		}
 	})
-	if out != "SEVERE: com.foo.Bar doIt: boom\n" {
+	if !strings.HasSuffix(out, "SEVERE: com.foo.Bar doIt: boom\n") {
 		t.Fatalf("unexpected output: %q", out)
 	}
 }
@@ -260,7 +260,7 @@ func TestLoggingLoggerLogrbWithParams(t *testing.T) {
 			t.Fatalf("loggingLoggerLogrbWithParams returned error: %v", ret)
 		}
 	})
-	if out != "INFO: com.foo.Bar doIt: msg [z]\n" {
+	if !strings.HasSuffix(out, "INFO: com.foo.Bar doIt: msg [z]\n") {
 		t.Fatalf("unexpected output: %q", out)
 	}
 }
@@ -275,7 +275,7 @@ func TestLoggingLoggerThrowing(t *testing.T) {
 			t.Fatalf("loggingLoggerThrowing returned error: %v", ret)
 		}
 	})
-	if out != "FINER: THROW com.foo.Bar doIt\n" {
+	if !strings.HasSuffix(out, "FINER: THROW com.foo.Bar doIt\n") {
 		t.Fatalf("unexpected output: %q", out)
 	}
 }
@@ -289,7 +289,7 @@ func TestLoggingLoggerLog_NilLevelDefaultsToInfo(t *testing.T) {
 			t.Fatalf("loggingLoggerLog returned error: %v", ret)
 		}
 	})
-	if out != "INFO: msg\n" {
+	if !strings.HasSuffix(out, "INFO: msg\n") {
 		t.Fatalf("unexpected output: %q", out)
 	}
 }
@@ -301,7 +301,7 @@ func TestLoggingLoggerFine(t *testing.T) {
 			t.Fatalf("loggingLoggerFine returned error: %v", ret)
 		}
 	})
-	if out != "FINE: fine msg\n" {
+	if !strings.HasSuffix(out, "FINE: fine msg\n") {
 		t.Fatalf("unexpected output: %q", out)
 	}
 }

--- a/src/gfunction/javaUtil/javaUtilLoggingStreamHandler.go
+++ b/src/gfunction/javaUtil/javaUtilLoggingStreamHandler.go
@@ -167,13 +167,14 @@ func loggingStreamHandlerFlush(params []interface{}) interface{} {
 // Writes the LogRecord's message to the underlying output stream if it is
 // loggable by this Handler and a stream has been set.
 func loggingStreamHandlerPublish(params []interface{}) interface{} {
-	obj, ok := params[0].(*object.Object)
+	fs, args := loggingExtractFsAndArgs(params)
+	obj, ok := args[0].(*object.Object)
 	if !ok || obj == nil {
 		errMsg := "loggingStreamHandlerPublish: The first parameter is not an object"
 		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
 
-	if len(params) < 2 {
+	if len(args) < 2 {
 		errMsg := "loggingStreamHandlerPublish: Requires a LogRecord parameter"
 		return ghelpers.GetGErrBlk(excNames.IllegalArgumentException, errMsg)
 	}
@@ -183,12 +184,12 @@ func loggingStreamHandlerPublish(params []interface{}) interface{} {
 		return nil
 	}
 
-	record, ok := params[1].(*object.Object)
+	record, ok := args[1].(*object.Object)
 	if !ok || record == nil || object.IsNull(record) {
 		return nil
 	}
 
-	msg := formatLogRecordWithHandlerFormatter(obj, record)
+	msg := formatLogRecordWithHandlerFormatter(obj, record, fs)
 	if msg == "" {
 		return nil
 	}

--- a/src/gfunction/misc/stringFormatter.go
+++ b/src/gfunction/misc/stringFormatter.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 	"unsafe"
 )
@@ -89,6 +90,14 @@ func StringFormatter(params []interface{}) interface{} {
 		obj := valuesIn[ii]
 		if obj == nil || object.IsNull(obj) {
 			rawArgs = append(rawArgs, nil)
+			continue
+		}
+		// Special-case java.util.Date: it has a "value" field of Ftype=Long
+		// (millis since epoch), but must not be unwrapped as a raw long --
+		// it needs to keep its object identity so %s can render it via its
+		// real toString() (see coerceJavaString), not as a numeric value.
+		if object.GoStringFromStringPoolIndex(obj.KlassName) == "java/util/Date" {
+			rawArgs = append(rawArgs, obj)
 			continue
 		}
 		// Prefer handling by presence of a "value" field; fall back to BigInteger/BigDecimal detection.
@@ -495,6 +504,16 @@ func coerceJavaString(args []interface{}, idx int) string {
 							return javaMath.FormatDecimalString(unscaled, scale)
 						}
 					}
+				}
+			}
+		}
+		// Special-case java.util.Date to mimic its real toString() output
+		// (e.g. "Sat Sep 12 16:52:33 CDT 2026"), rather than the generic
+		// ClassName@hex fallback below.
+		if object.GoStringFromStringPoolIndex(vv.KlassName) == "java/util/Date" {
+			if valFld, ok := vv.FieldTable["value"]; ok && valFld.Ftype == types.Long {
+				if millis, ok2 := valFld.Fvalue.(int64); ok2 {
+					return time.UnixMilli(millis).Local().Format("Mon Jan 2 15:04:05 MST 2006")
 				}
 			}
 		}


### PR DESCRIPTION
When code for covering Jacotest case `java-logging-basic` (new today, no custom handlers, root handler only) was fixed, we saw a regression in `java-logging` (uses a custom console handler and a custom file handler).

All's well that ends well.

	new file:   gfunction/javaUtil/javaUtilLoggingCallback.go
	modified:   gfunction/javaUtil/javaUtilLoggingConsoleHandler.go
	modified:   gfunction/javaUtil/javaUtilLoggingFileHandler.go
	modified:   gfunction/javaUtil/javaUtilLoggingFormatter.go
	modified:   gfunction/javaUtil/javaUtilLoggingHandler.go
	modified:   gfunction/javaUtil/javaUtilLoggingLogRecord.go
	modified:   gfunction/javaUtil/javaUtilLoggingLogRecord_test.go
	modified:   gfunction/javaUtil/javaUtilLoggingLogger.go
	modified:   gfunction/javaUtil/javaUtilLoggingLogger_test.go
	modified:   gfunction/javaUtil/javaUtilLoggingStreamHandler.go

	modified:   gfunction/misc/stringFormatter.go - Process `java.util.Date` to create realistic `toString()` output


 See Jacotest case `java-logging-basic` for a scenario example.